### PR TITLE
♻️ [REFACTOR#36] Hot News 관련 응답 기준 수정

### DIFF
--- a/src/main/java/com/example/globalTimes_be/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/com/example/globalTimes_be/domain/article/repository/ArticleRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -40,4 +41,8 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     List<Article> searchByDescriptionOrTitle(@Param("text1") String text,
                                              @Param("text2") String translatedText,
                                              Pageable pageable);
+
+    // 현재 시간 기준 이틀 이내인지 확인 ( 기준의 Hot News 요청을 위한 쿼리 메소드 )
+    // publishedAt 으로 찾고 After -> 이후에 내림차순으로.
+    Page<Article> findByPublishedAtAfterOrderByViewCountDesc(LocalDateTime from, Pageable pageable);
 }

--- a/src/main/java/com/example/globalTimes_be/domain/article/service/ArticleService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/article/service/ArticleService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import java.time.LocalDateTime;
 
 @Service
 public class ArticleService {
@@ -25,12 +26,16 @@ public class ArticleService {
        return articles.map(ArticleResponseDto::fromEntity);
     }
 
-    // 조회수 기준
+    // Hot News : 발행일 기준 이틀 내 기사만 출력되도록 수정 ( 랜딩 페이지네이션 토탈 : 42개 )
     public Page<ArticleResponseDto> getArticlesByViewCount(int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<Article> articles = articleRepository.findAllByOrderByViewCountDesc(pageable);
 
-        // Dto 변환
+        // 현재 시간에서 -2일 한 데이터들만 따로 출력 ( -1로 설정하면 출력되는 데이터 없음 )
+        // Free : 하루 이전 기사들까지가 최신. 당일 기사 제공 X
+        LocalDateTime twoDaysAgo = LocalDateTime.now().minusDays(2);
+
+        Page<Article> articles = articleRepository.findByPublishedAtAfterOrderByViewCountDesc(twoDaysAgo, pageable);
+
         return articles.map(ArticleResponseDto::fromEntity);
     }
 }


### PR DESCRIPTION
## 🚀 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->
- closed #36 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 기존 : 단순 viewCount Desc
- 수정 후 : Desc + 이틀 이내에 발행된 기사들만 출력하도록 수정

( 단, newsAPI 는 무료 요금제 기준 하루 전 기사부터 제공하기에 현실적으로 이틀 이내가 가장 최신 )
DB 적재 이후, 워크벤치에서 쿼리 날려보면 하루 전 데이터는 조회되지 않음.

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?


## 💬 리뷰 요구사항

/externalApi/Service/NewsApiService.java 를 참고해보면
- fetchTopHeadLines 
- fetchDomainArticles 로 각각 별도의 API 가 호출되는데 ( 언론사 고정 ) 

**Hot News** : 헤드라인 api 에서 불러온 API 응답을 주는건 어떤지? ( 헤드라인 - 실시간 데이터 및 + 조회수순으로 수정 )
아래의 사진에서 로그 및 해당 Service 로직을 참고해보면, 

헤드라인 : Request Parameter에 카테고리 설정이 가능 
( DTO를 엔티티로 매핑시킬 때 Category 를 넣어서 엔티티 영속화 ) 

Everything : Parameter에 카테고리가 없음 -> Null 로 설정해서 영속화

![KakaoTalk_20250407_005915904](https://github.com/user-attachments/assets/2d1a243b-a530-4bfb-98ed-c01fd6cdefd7)

즉 Hot News 를 말 그대로 헤드라인 응답 + 조회수 순으로 로직 수정 ? ( 해당 부분 의미 없음. 아래 참고 부탁 ) 

수정 )
Headline 엔드포인트는 실시간으로 주는줄 알았으나..
"2025-04-06T14:40:55Z" (UTC)
→ "2025-04-06 23:40:55" ( 호출 시간 기준 3시간 전 ) : 실시간 기준으로 응답을 주네? 라고 생각했는데

(https://newsapi.org/docs/endpoints/top-headlines) : 해당 응답값은 Live ( 즉 Pricing 이 적용된 응답값인듯 함 )

초기 PostConstruct 어노테이션에 의해 실행한 이후 쿼리 날려보면 하루 이내의 결과값은 오지 않음. 
결론 : Headline 요청도 말이 헤드라인이지 최신 데이터 안준다. 의미없다 ! 라는거.








