### PR TITLE
[REFACTOR#59] News API 수집 설정 분리 및 수집 대상 국가/도메인 확장

### DIFF
--- a/src/main/java/com/example/globalTimes_be/externalApi/config/NewsFetchConfig.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/config/NewsFetchConfig.java
@@ -1,0 +1,64 @@
+package com.example.globalTimes_be.externalApi.config;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * News API 수집 대상(국가/카테고리/도메인) 설정을 한 곳에서 관리한다.
+ * 수집 대상을 추가/제거할 때는 이 파일만 수정하면 된다.
+ */
+@Component
+public class NewsFetchConfig {
+
+    /**
+     * 헤드라인 수집 대상 국가 코드 목록 (News API top-headlines 기준)
+     * 지원 코드: https://newsapi.org/docs/endpoints/top-headlines
+     */
+    public List<String> getCountries() {
+        return List.of(
+                "us",   // 미국
+                "gb",   // 영국
+                "fr",   // 프랑스
+                "de",   // 독일
+                "kr"    // 한국
+        );
+    }
+
+    /**
+     * 수집 카테고리 목록 (null = general)
+     */
+    public List<String> getCategories() {
+        return List.of(
+                "general",
+                "business",
+                "entertainment",
+                "health",
+                "science",
+                "sports",
+                "technology"
+        );
+    }
+
+    /**
+     * Everything API 수집 대상 도메인 목록
+     * 국가별 대표 미디어 도메인을 포함한다.
+     */
+    public List<String> getDomains() {
+        return List.of(
+                "wsj.com",          // 미국 - Wall Street Journal
+                "bbc.co.uk",        // 영국 - BBC
+                "techcrunch.com",   // 미국 - TechCrunch
+                "theguardian.com",  // 영국 - The Guardian
+                "reuters.com",      // 글로벌 - Reuters
+                "aljazeera.com"     // 중동 - Al Jazeera
+        );
+    }
+
+    /**
+     * 한 번 요청 시 가져올 최대 기사 수 (News API 최대: 100)
+     */
+    public int getPageSize() {
+        return 100;
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/externalApi/service/NewsApiService.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/service/NewsApiService.java
@@ -2,6 +2,7 @@ package com.example.globalTimes_be.externalApi.service;
 
 import com.example.globalTimes_be.domain.article.entity.Article;
 import com.example.globalTimes_be.domain.article.service.ArticleService;
+import com.example.globalTimes_be.externalApi.config.NewsFetchConfig;
 import com.example.globalTimes_be.externalApi.dto.NewsApiArticleDto;
 import com.example.globalTimes_be.externalApi.dto.NewsApiResponseDto;
 import com.example.globalTimes_be.externalApi.dto.NewsApiSourceDto;
@@ -21,6 +22,7 @@ import org.springframework.web.client.RestTemplate;
 import java.util.*;
 import java.util.stream.Collectors;
 
+
 // 전적인 API 호출 ( 외부 ) 처리 및 관리하는 서비스 레이어
 @Slf4j
 @Service
@@ -29,28 +31,18 @@ public class NewsApiService {
     private final RestTemplate restTemplate;
     private final ArticleRepository articleRepository;
     private final SourceService sourceService;
-
-    private static final List<String> COUNTRIES = List.of("us");
-    private static final List<String> CATEGORY_LIST = Arrays.asList(
-            null, // general
-            "business",
-            "entertainment",
-            "health",
-            "science",
-            "sports",
-            "technology"
-    );
-    private static final List<String> DOMAINS = Arrays.asList("wsj.com", "bbc.co.uk", "techcrunch.com");
+    private final NewsFetchConfig newsFetchConfig;
 
     @Value("${spring.newsapi.api-key}")
     private String apiKey;
     private int totalNewArticles = 0;
 
     @Autowired
-    public NewsApiService(RestTemplate restTemplate, ArticleRepository articleRepository, SourceRepository sourceRepository, ArticleService articleService, SourceService sourceService) {
+    public NewsApiService(RestTemplate restTemplate, ArticleRepository articleRepository, SourceRepository sourceRepository, ArticleService articleService, SourceService sourceService, NewsFetchConfig newsFetchConfig) {
         this.restTemplate = restTemplate;
         this.articleRepository = articleRepository;
         this.sourceService = sourceService;
+        this.newsFetchConfig = newsFetchConfig;
     }
 
     @PostConstruct
@@ -98,19 +90,18 @@ public class NewsApiService {
     }
     */
 
-    // Country + Category ( 기존의 헤드라인 호출 ) : 헤드라인이기에 좀 더 자주 스케줄링하고
+    // Country + Category 조합으로 헤드라인 수집 (국가/카테고리는 NewsFetchConfig에서 관리)
     private void fetchTopHeadlines(boolean isInit) {
-        for (String country : COUNTRIES) {
-            for (String category : CATEGORY_LIST) {
+        for (String country : newsFetchConfig.getCountries()) {
+            for (String category : newsFetchConfig.getCategories()) {
                 try {
-                    String categoryParam = (category == null) ? "" : "&category=" + category;
                     String apiUrl = "https://newsapi.org/v2/top-headlines?"
                             + "country=" + country
-                            + categoryParam
-                            + "&pageSize=" + 100
+                            + "&category=" + category
+                            + "&pageSize=" + newsFetchConfig.getPageSize()
                             + "&apiKey=" + apiKey;
 
-                    processApiRequest(apiUrl, country, (category == null ? "general" : category));
+                    processApiRequest(apiUrl, country, category);
                 } catch (Exception e) {
                     log.error("[헤드라인] {} / {} 처리 중 오류 발생", country, category, e);
                 }
@@ -122,14 +113,14 @@ public class NewsApiService {
     }
 
     private void fetchDomainArticles(boolean isInit) {
-        for (String domain : DOMAINS) {
+        for (String domain : newsFetchConfig.getDomains()) {
             try {
                 String apiUrl = "https://newsapi.org/v2/everything?"
                         + "domains=" + domain
-                        + "&pageSize=" + 100
+                        + "&pageSize=" + newsFetchConfig.getPageSize()
                         + "&apiKey=" + apiKey;
 
-                processApiRequest(apiUrl, "us", null);
+                processApiRequest(apiUrl, null, null);
             } catch (Exception e) {
                 log.error("[Everything] {} 도메인 처리 중 오류 발생", domain, e);
             }

--- a/src/main/java/com/example/globalTimes_be/externalApi/service/NewsApiService.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/service/NewsApiService.java
@@ -120,7 +120,8 @@ public class NewsApiService {
                         + "&pageSize=" + newsFetchConfig.getPageSize()
                         + "&apiKey=" + apiKey;
 
-                processApiRequest(apiUrl, null, null);
+                // 도메인 기사는 특정 국가에 종속되지 않으므로 "global"로 처리
+                processApiRequest(apiUrl, "global", "general");
             } catch (Exception e) {
                 log.error("[Everything] {} 도메인 처리 중 오류 발생", domain, e);
             }


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) ✨ [FEAT/#1] 로그인 페이지 UI 구현 -->

## 🚀 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->
- closed #59 

## 🧭 변경 타입
<!-- 해당하는 항목에 x 표시 -->
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [x] ♻️ 리팩토링 (REFACTOR)
- [ ] 🧪 테스트/품질 (TEST/CHORE)


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- NewsFetchConfig 클래스 신규 생성
- us/gb/fr/de/kr 5개 국가로 확장

## 🧪 테스트/검증 (필수)
<!-- 최소 2줄 권장: “무엇을 / 어떤 케이스로 / 무엇을 확인” -->
- [x] bootRun 후 5개 국가 수집 로그 확인
- [x] DB country_code 분포 확인
  → us 집중 현상 확인, News API 무료 플랜 한계로 판단


## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?