### PR TITLE
🧪 [CHORE/#61] News API 수집 파이프라인 단계별 메트릭 로그 추가

### DIFF
--- a/src/main/java/com/example/globalTimes_be/domain/trend/scheduler/TrendScheduler.java
+++ b/src/main/java/com/example/globalTimes_be/domain/trend/scheduler/TrendScheduler.java
@@ -148,14 +148,13 @@ public class TrendScheduler {
                     .urlToImage(urlToImage)
                     .build();
 
-            //실검 dto 생성 확인
-            log.info("실검 키워드 생성 확인: {}", trendDTO.getKeyword());
-
             //리스트에 추가
             trendDTOS.add(trendDTO);
             
             count++;
         }
+
+        log.info("[트렌드 수집] {} | 키워드 {}개 저장", countryCode, trendDTOS.size());
         return trendDTOS;
     }
 }

--- a/src/main/java/com/example/globalTimes_be/externalApi/config/NewsFetchConfig.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/config/NewsFetchConfig.java
@@ -61,4 +61,20 @@ public class NewsFetchConfig {
     public int getPageSize() {
         return 100;
     }
+
+    /**
+     * 수집 실행 1회당 최대 API 요청 수 제한
+     * 무료 플랜: 100 req/24h → 초기 적재(1회) + 스케줄링(2~3회) 고려해 여유 있게 설정
+     */
+    public int getMaxRequestsPerRun() {
+        return 30;
+    }
+
+    /**
+     * API 요청 간 딜레이 (ms)
+     * rate limit 방지를 위해 요청 사이에 짧은 대기 시간 추가
+     */
+    public long getRequestDelayMs() {
+        return 200;
+    }
 }

--- a/src/main/java/com/example/globalTimes_be/externalApi/service/NewsApiService.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/service/NewsApiService.java
@@ -133,21 +133,23 @@ public class NewsApiService {
 
     // 공통 API 호출 + 저장 처리
     private void processApiRequest(String apiUrl, String country, String category) {
+        String label = country + "/" + category;
         try {
             ResponseEntity<NewsApiResponseDto> responseEntity = restTemplate.getForEntity(apiUrl, NewsApiResponseDto.class);
             NewsApiResponseDto response = responseEntity.getBody();
 
             if (response == null || response.getArticles() == null || response.getArticles().isEmpty()) {
-                log.info("가져올 뉴스 없음: {} / {}", (country != null ? country : "도메인"), category);
+                log.info("[수집 통계] {} | 응답 없음(0건)", label);
                 return;
             }
 
             List<NewsApiArticleDto> articles = response.getArticles();
+            int total = articles.size();
+
+            // 기존 URL 조회
             List<String> urls = articles.stream()
                     .map(NewsApiArticleDto::getUrl)
                     .collect(Collectors.toList());
-
-            // 기존 URL 조회
             Set<String> existingUrls = articleRepository.findExistingUrls(urls);
 
             // Source 캐시
@@ -158,22 +160,32 @@ public class NewsApiService {
                     .filter(Objects::nonNull)
                     .distinct()
                     .collect(Collectors.toList());
-
             Map<String, Source> sourceCache = sourceService.preloadSources(sourceNames);
+
+            // 단계별 카운트 계산
+            long invalidCount = articles.stream()
+                    .filter(this::isInvalid)
+                    .count();
+            long duplicateCount = articles.stream()
+                    .filter(dto -> !isInvalid(dto) && existingUrls.contains(dto.getUrl()))
+                    .count();
 
             // 유효성 검증 + 저장
             List<Article> articleList = articles.stream()
-                    .filter(articleDto -> !isInvalid(articleDto) && !existingUrls.contains(articleDto.getUrl()))
-                    .map(articleDto -> mapDtoToEntity(articleDto, country, category, sourceCache))
+                    .filter(dto -> !isInvalid(dto) && !existingUrls.contains(dto.getUrl()))
+                    .map(dto -> mapDtoToEntity(dto, country, category, sourceCache))
                     .collect(Collectors.toList());
 
             if (!articleList.isEmpty()) {
                 articleRepository.saveAll(articleList);
-                log.info("{} / {} - {}개 저장 완료", (country != null ? country : "도메인"), category, articleList.size());
                 totalNewArticles += articleList.size();
             }
+
+            log.info("[수집 통계] {} | 응답:{}, invalid:{}, 중복:{}, 저장:{}",
+                    label, total, invalidCount, duplicateCount, articleList.size());
+
         } catch (Exception e) {
-            log.error("[API 호출] {} / {} 처리 중 오류 발생", (country != null ? country : "도메인"), category, e);
+            log.error("[수집 오류] {} 처리 중 오류 발생", label, e);
         }
     }
 

--- a/src/main/java/com/example/globalTimes_be/externalApi/service/NewsApiService.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/service/NewsApiService.java
@@ -37,6 +37,7 @@ public class NewsApiService {
     @Value("${spring.newsapi.api-key}")
     private String apiKey;
     private int totalNewArticles = 0;
+    private int requestCount = 0;
 
     @Autowired
     public NewsApiService(RestTemplate restTemplate, ArticleRepository articleRepository, SourceRepository sourceRepository, ArticleService articleService, SourceService sourceService, NewsFetchConfig newsFetchConfig) {
@@ -49,19 +50,19 @@ public class NewsApiService {
     @PostConstruct
     public void init() {
         try {
-            fetchTopHeadlines(true);    // 뉴스 초기 적재
+            resetCounters();
+            fetchTopHeadlines(true);
             fetchDomainArticles(true);
         } catch (Exception e) {
             log.error("[초기화] 데이터 초기 적재 중 오류 발생", e);
         }
-
     }
 
     // 4시간마다 헤드라인 뉴스 Scheduling
     @Scheduled(cron = "0 0 0/4 * * *")
     public void scheduledTopHeadlines() {
         try {
-            totalNewArticles = 0;
+            resetCounters();
             fetchTopHeadlines(false);
             log.info("[스케줄링] 헤드라인 저장된 신규 기사: {}개", totalNewArticles);
         } catch (Exception e) {
@@ -69,16 +70,20 @@ public class NewsApiService {
         }
     }
 
-
     @Scheduled(cron = "0 0 0 * * *")
     public void scheduledFetchFixed() {
         try {
-            totalNewArticles = 0;
+            resetCounters();
             fetchDomainArticles(false);
             log.info("[스케줄링] Everything 저장된 신규 기사: {}개", totalNewArticles);
         } catch (Exception e) {
             log.error("[스케줄링] Everything 뉴스 수집 중 오류 발생", e);
         }
+    }
+
+    private void resetCounters() {
+        totalNewArticles = 0;
+        requestCount = 0;
     }
 
     // 최상위 실행 메소드 ( 두 방식 동시에 테스트용 -> Scheduling 제외 )
@@ -93,8 +98,14 @@ public class NewsApiService {
 
     // Country + Category 조합으로 헤드라인 수집 (국가/카테고리는 NewsFetchConfig에서 관리)
     private void fetchTopHeadlines(boolean isInit) {
+        outer:
         for (String country : newsFetchConfig.getCountries()) {
             for (String category : newsFetchConfig.getCategories()) {
+                if (requestCount >= newsFetchConfig.getMaxRequestsPerRun()) {
+                    log.warn("[요청 제한] 최대 요청 수({})에 도달해 헤드라인 수집을 중단합니다.",
+                            newsFetchConfig.getMaxRequestsPerRun());
+                    break outer;
+                }
                 try {
                     String apiUrl = "https://newsapi.org/v2/top-headlines?"
                             + "country=" + country
@@ -102,33 +113,50 @@ public class NewsApiService {
                             + "&pageSize=" + newsFetchConfig.getPageSize()
                             + "&apiKey=" + apiKey;
 
+                    requestCount++;
                     processApiRequest(apiUrl, country, category);
+                    Thread.sleep(newsFetchConfig.getRequestDelayMs());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    log.warn("[헤드라인] 딜레이 중 인터럽트 발생");
+                    break outer;
                 } catch (Exception e) {
                     log.error("[헤드라인] {} / {} 처리 중 오류 발생", country, category, e);
                 }
             }
         }
         if (isInit) {
-            log.info("[초기 적재] 헤드라인 저장된 신규 기사: {}개", totalNewArticles);
+            log.info("[초기 적재] 헤드라인 저장된 신규 기사: {}개 (총 요청: {}회)", totalNewArticles, requestCount);
         }
     }
 
     private void fetchDomainArticles(boolean isInit) {
         for (String domain : newsFetchConfig.getDomains()) {
+            if (requestCount >= newsFetchConfig.getMaxRequestsPerRun()) {
+                log.warn("[요청 제한] 최대 요청 수({})에 도달해 도메인 수집을 중단합니다.",
+                        newsFetchConfig.getMaxRequestsPerRun());
+                break;
+            }
             try {
                 String apiUrl = "https://newsapi.org/v2/everything?"
                         + "domains=" + domain
                         + "&pageSize=" + newsFetchConfig.getPageSize()
                         + "&apiKey=" + apiKey;
 
+                requestCount++;
                 // 도메인 기사는 특정 국가에 종속되지 않으므로 "global"로 처리
                 processApiRequest(apiUrl, "global", "general");
+                Thread.sleep(newsFetchConfig.getRequestDelayMs());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.warn("[Everything] 딜레이 중 인터럽트 발생");
+                break;
             } catch (Exception e) {
                 log.error("[Everything] {} 도메인 처리 중 오류 발생", domain, e);
             }
         }
         if (isInit) {
-            log.info("[초기 적재] Everything 저장된 신규 기사: {}개", totalNewArticles);
+            log.info("[초기 적재] Everything 저장된 신규 기사: {}개 (총 요청: {}회)", totalNewArticles, requestCount);
         }
     }
 

--- a/src/main/java/com/example/globalTimes_be/externalApi/service/NewsApiService.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/service/NewsApiService.java
@@ -47,7 +47,8 @@ public class NewsApiService {
         this.newsFetchConfig = newsFetchConfig;
     }
 
-    @PostConstruct
+    // @PostConstruct 비활성화 (개발 중 API 할당량 절약 목적, 수집 테스트 시 활성화)
+    // @PostConstruct
     public void init() {
         try {
             resetCounters();

--- a/src/main/java/com/example/globalTimes_be/externalApi/service/NewsApiService.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/service/NewsApiService.java
@@ -19,6 +19,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -191,15 +192,27 @@ public class NewsApiService {
 
     private boolean isInvalid(NewsApiArticleDto dto){
         // 하나라도 null 인 케이스들을 방지
-        return dto.getAuthor() == null ||
+        if (dto.getAuthor() == null ||
                 dto.getTitle() == null ||
                 dto.getDescription() == null ||
                 dto.getContent() == null ||
                 dto.getUrl() == null ||
                 dto.getUrlToImage() == null ||
+                dto.getPublishedAt() == null ||
                 dto.getSource() == null ||
                 dto.getSource().getName() == null ||
-                dto.getSource().getName().isEmpty();
+                dto.getSource().getName().isEmpty()) {
+            return true;
+        }
+        // publishedAt ISO 8601 형식 검증 (파싱 실패 시 invalid 처리)
+        try {
+            OffsetDateTime.parse(dto.getPublishedAt());
+        } catch (Exception e) {
+            log.warn("[유효성 검사] publishedAt 형식 오류 - url: {}, publishedAt: {}",
+                    dto.getUrl(), dto.getPublishedAt());
+            return true;
+        }
+        return false;
     }
 
     private Article mapDtoToEntity(NewsApiArticleDto articleDto, String countryCode,


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) ✨ [FEAT/#1] 로그인 페이지 UI 구현 -->

## 🚀 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->
- closed #61 

## 🧭 변경 타입
<!-- 해당하는 항목에 x 표시 -->
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [X] 🧪 테스트/품질 (TEST/CHORE)


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
-  `processApiRequest`에 단계별 카운트 추가
total(API 응답) / invalidCount(null 필드 제거) / duplicateCount(중복 URL 제거) / savedCount(최종 저장)
 
- 수집 로그 포맷 통일
- `[수집 통계] us/general | 응답:100, invalid:20, 중복:50, 저장:30`
 
-  트렌드 수집 로그를 키워드 단위(156줄) → 국가 단위 요약(26줄)으로 변경. 로그가 너무 길게 나오는 문제가 문재.
`[트렌드 수집] KR | 키워드 6개 저장` 포맷으로 통일

- `isInvalid()`에 `publishedAt` null 및 ISO 8601 형식 검증 추가 (기존 파싱 오류 방지)
- News API rate limit(429) 대응: ( 무료 플랜이라서 문제가 생긴듯함 ) 
  - 실행 1회당 최대 요청 수 제한(기본 30회) 추가
  - 요청 간 200ms 딜레이 추가
  - `NewsFetchConfig`에서 설정값으로 관리하도록 분리

## 🧪 테스트/검증 (필수)
<!-- 최소 2줄 권장: “무엇을 / 어떤 케이스로 / 무엇을 확인” -->
- [ ] bootRun 후 `[수집 통계]` 포맷 로그 확인
- [ ] invalidCount + duplicateCount + savedCount = total 검증
- [ ] 기존 수집 기능 동작 이상 없음 확인


## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?

      
## 📝 트러블 슈팅 관련 

[1] 수집량이 예상보다 적은 문제

문제: 국가/카테고리 확장했는데 us만 저장됨
원인: News API 무료 플랜의 비영어권 커버리지 제한
해결: 도메인 기반 everything 방식 병행, 수집 메트릭 로그로 원인 가시화
[2] API rate limit(429) 문제

문제: 국가×카테고리 조합 확장 후 429 에러 발생
원인: 무료 플랜 100 req/24h 한도, @PostConstruct 반복 실행으로 빠르게 소진
해결: 최대 요청 수 제한 + 딜레이 추가, NewsFetchConfig로 설정값 분리
