### PR TITLE
🪵 [CHORE/#67] 뉴스 수집 메트릭 로그, publishedAt 검증, rate limit 적용

### DIFF
--- a/src/main/java/com/example/globalTimes_be/domain/trend/scheduler/TrendScheduler.java
+++ b/src/main/java/com/example/globalTimes_be/domain/trend/scheduler/TrendScheduler.java
@@ -148,14 +148,13 @@ public class TrendScheduler {
                     .urlToImage(urlToImage)
                     .build();
 
-            //실검 dto 생성 확인
-            log.info("실검 키워드 생성 확인: {}", trendDTO.getKeyword());
-
             //리스트에 추가
             trendDTOS.add(trendDTO);
             
             count++;
         }
+
+        log.info("[트렌드 수집] {} | 키워드 {}개 저장", countryCode, trendDTOS.size());
         return trendDTOS;
     }
 }

--- a/src/main/java/com/example/globalTimes_be/externalApi/config/NewsFetchConfig.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/config/NewsFetchConfig.java
@@ -61,4 +61,20 @@ public class NewsFetchConfig {
     public int getPageSize() {
         return 100;
     }
+
+    /**
+     * 수집 실행 1회당 최대 API 요청 수 제한
+     * 무료 플랜: 100 req/24h → 초기 적재(1회) + 스케줄링(2~3회) 고려해 여유 있게 설정
+     */
+    public int getMaxRequestsPerRun() {
+        return 30;
+    }
+
+    /**
+     * API 요청 간 딜레이 (ms)
+     * rate limit 방지를 위해 요청 사이에 짧은 대기 시간 추가
+     */
+    public long getRequestDelayMs() {
+        return 200;
+    }
 }

--- a/src/main/java/com/example/globalTimes_be/externalApi/service/NewsApiService.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/service/NewsApiService.java
@@ -19,6 +19,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -42,6 +43,7 @@ public class NewsApiService {
     private boolean fetchEnabled;
 
     private int totalNewArticles = 0;
+    private int requestCount = 0;
 
     @Autowired
     public NewsApiService(RestTemplate restTemplate, ArticleRepository articleRepository, SourceRepository sourceRepository, ArticleService articleService, SourceService sourceService, NewsFetchConfig newsFetchConfig) {
@@ -60,6 +62,7 @@ public class NewsApiService {
         }
         try {
             totalNewArticles = 0;
+            requestCount = 0;
             fetchTopHeadlines(true);
             fetchDomainArticles(true);
         } catch (Exception e) {
@@ -73,6 +76,7 @@ public class NewsApiService {
         if (!fetchEnabled) return;
         try {
             totalNewArticles = 0;
+            requestCount = 0;
             fetchTopHeadlines(false);
             log.info("[스케줄링] 헤드라인 저장된 신규 기사: {}개", totalNewArticles);
         } catch (Exception e) {
@@ -85,6 +89,7 @@ public class NewsApiService {
         if (!fetchEnabled) return;
         try {
             totalNewArticles = 0;
+            requestCount = 0;
             fetchDomainArticles(false);
             log.info("[스케줄링] Everything 저장된 신규 기사: {}개", totalNewArticles);
         } catch (Exception e) {
@@ -104,8 +109,13 @@ public class NewsApiService {
 
     // Country + Category 조합으로 헤드라인 수집 (국가/카테고리는 NewsFetchConfig에서 관리)
     private void fetchTopHeadlines(boolean isInit) {
+        outer:
         for (String country : newsFetchConfig.getCountries()) {
             for (String category : newsFetchConfig.getCategories()) {
+                if (requestCount >= newsFetchConfig.getMaxRequestsPerRun()) {
+                    log.warn("[요청 제한] 최대 요청 수({})에 도달해 헤드라인 수집을 중단합니다.", newsFetchConfig.getMaxRequestsPerRun());
+                    break outer;
+                }
                 try {
                     String apiUrl = "https://newsapi.org/v2/top-headlines?"
                             + "country=" + country
@@ -113,53 +123,71 @@ public class NewsApiService {
                             + "&pageSize=" + newsFetchConfig.getPageSize()
                             + "&apiKey=" + apiKey;
 
+                    requestCount++;
                     processApiRequest(apiUrl, country, category);
+                    Thread.sleep(newsFetchConfig.getRequestDelayMs());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    log.warn("[헤드라인] 딜레이 중 인터럽트 발생");
+                    break outer;
                 } catch (Exception e) {
                     log.error("[헤드라인] {} / {} 처리 중 오류 발생", country, category, e);
                 }
             }
         }
         if (isInit) {
-            log.info("[초기 적재] 헤드라인 저장된 신규 기사: {}개", totalNewArticles);
+            log.info("[초기 적재] 헤드라인 저장된 신규 기사: {}개 (총 요청: {}회)", totalNewArticles, requestCount);
         }
     }
 
     private void fetchDomainArticles(boolean isInit) {
         for (String domain : newsFetchConfig.getDomains()) {
+            if (requestCount >= newsFetchConfig.getMaxRequestsPerRun()) {
+                log.warn("[요청 제한] 최대 요청 수({})에 도달해 도메인 수집을 중단합니다.", newsFetchConfig.getMaxRequestsPerRun());
+                break;
+            }
             try {
                 String apiUrl = "https://newsapi.org/v2/everything?"
                         + "domains=" + domain
                         + "&pageSize=" + newsFetchConfig.getPageSize()
                         + "&apiKey=" + apiKey;
 
+                requestCount++;
                 // 도메인 기사는 특정 국가에 종속되지 않으므로 "global"로 처리
                 processApiRequest(apiUrl, "global", "general");
+                Thread.sleep(newsFetchConfig.getRequestDelayMs());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.warn("[Everything] 딜레이 중 인터럽트 발생");
+                break;
             } catch (Exception e) {
                 log.error("[Everything] {} 도메인 처리 중 오류 발생", domain, e);
             }
         }
         if (isInit) {
-            log.info("[초기 적재] Everything 저장된 신규 기사: {}개", totalNewArticles);
+            log.info("[초기 적재] Everything 저장된 신규 기사: {}개 (총 요청: {}회)", totalNewArticles, requestCount);
         }
     }
 
     // 공통 API 호출 + 저장 처리
     private void processApiRequest(String apiUrl, String country, String category) {
+        String label = country + "/" + category;
         try {
             ResponseEntity<NewsApiResponseDto> responseEntity = restTemplate.getForEntity(apiUrl, NewsApiResponseDto.class);
             NewsApiResponseDto response = responseEntity.getBody();
 
             if (response == null || response.getArticles() == null || response.getArticles().isEmpty()) {
-                log.info("가져올 뉴스 없음: {} / {}", (country != null ? country : "도메인"), category);
+                log.info("[수집 통계] {} | 응답 없음", label);
                 return;
             }
 
             List<NewsApiArticleDto> articles = response.getArticles();
+            int total = articles.size();
+
+            // 기존 URL 조회
             List<String> urls = articles.stream()
                     .map(NewsApiArticleDto::getUrl)
                     .collect(Collectors.toList());
-
-            // 기존 URL 조회
             Set<String> existingUrls = articleRepository.findExistingUrls(urls);
 
             // Source 캐시
@@ -170,36 +198,54 @@ public class NewsApiService {
                     .filter(Objects::nonNull)
                     .distinct()
                     .collect(Collectors.toList());
-
             Map<String, Source> sourceCache = sourceService.preloadSources(sourceNames);
 
-            // 유효성 검증 + 저장
+            // 단계별 카운트 집계
+            long invalidCount = articles.stream().filter(this::isInvalid).count();
+            long duplicateCount = articles.stream()
+                    .filter(dto -> !isInvalid(dto) && existingUrls.contains(dto.getUrl()))
+                    .count();
+
+            // 유효성 검증 + 중복 제거 + 저장
             List<Article> articleList = articles.stream()
-                    .filter(articleDto -> !isInvalid(articleDto) && !existingUrls.contains(articleDto.getUrl()))
-                    .map(articleDto -> mapDtoToEntity(articleDto, country, category, sourceCache))
+                    .filter(dto -> !isInvalid(dto) && !existingUrls.contains(dto.getUrl()))
+                    .map(dto -> mapDtoToEntity(dto, country, category, sourceCache))
                     .collect(Collectors.toList());
 
             if (!articleList.isEmpty()) {
                 articleRepository.saveAll(articleList);
-                log.info("{} / {} - {}개 저장 완료", (country != null ? country : "도메인"), category, articleList.size());
                 totalNewArticles += articleList.size();
             }
+
+            log.info("[수집 통계] {} | 응답:{}, invalid:{}, 중복:{}, 저장:{}",
+                    label, total, invalidCount, duplicateCount, articleList.size());
+
         } catch (Exception e) {
-            log.error("[API 호출] {} / {} 처리 중 오류 발생", (country != null ? country : "도메인"), category, e);
+            log.error("[수집 오류] {} 처리 중 오류 발생", label, e);
         }
     }
 
-    private boolean isInvalid(NewsApiArticleDto dto){
-        // 하나라도 null 인 케이스들을 방지
-        return dto.getAuthor() == null ||
+    private boolean isInvalid(NewsApiArticleDto dto) {
+        if (dto.getAuthor() == null ||
                 dto.getTitle() == null ||
                 dto.getDescription() == null ||
                 dto.getContent() == null ||
                 dto.getUrl() == null ||
                 dto.getUrlToImage() == null ||
+                dto.getPublishedAt() == null ||
                 dto.getSource() == null ||
                 dto.getSource().getName() == null ||
-                dto.getSource().getName().isEmpty();
+                dto.getSource().getName().isEmpty()) {
+            return true;
+        }
+        try {
+            OffsetDateTime.parse(dto.getPublishedAt());
+        } catch (Exception e) {
+            log.warn("[유효성 검사] publishedAt 형식 오류 - url: {}, publishedAt: {}",
+                    dto.getUrl(), dto.getPublishedAt());
+            return true;
+        }
+        return false;
     }
 
     private Article mapDtoToEntity(NewsApiArticleDto articleDto, String countryCode,


### PR DESCRIPTION
## 🚀 관련 이슈
closed #67 

## 🧭 변경 타입
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- processApiRequest에 응답/invalid/중복/저장 단계별 카운트 집계 및 [수집 통계] 포맷 로그 출력
- isInvalid()에 publishedAt null 및 ISO 8601 형식 검증 추가 (파싱 오류 방지)
- fetchTopHeadlines/fetchDomainArticles에 requestCount 제한 + 요청 간 200ms 딜레이 적용
- TrendScheduler 로그를 키워드 단위 → 국가 단위 요약으로 변경

## 🧪 테스트/검증 (필수)
- [x] news-fetch.enabled: true 후 실행 시 [수집 통계] 로그 포맷 확인
- [x] publishedAt 오류 기사 [유효성 검사] 경고 로그 확인
- [x] 수집 완료까지 429 미발생 확인

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (develop 대상)
- [x] 로컬에서 실행 시 에러 없음
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?