### PR TITLE
✨ [Feat/#69] RSS 기반 다국어 뉴스 수집 파이프라인 추가 (#69)

### DIFF
--- a/src/main/java/com/example/globalTimes_be/domain/article/entity/Article.java
+++ b/src/main/java/com/example/globalTimes_be/domain/article/entity/Article.java
@@ -58,7 +58,11 @@ public class Article {
     @Column(name = "category", nullable = true)
     private String category;
 
-    // 정적 팩토리 메소드
+    // 원문 언어 코드 (ex. en, ko, fr, de, ja, ar, zh) - RSS 수집 기사에 사용
+    @Column(name = "language", nullable = true)
+    private String language;
+
+    // News API용 정적 팩토리 메소드 (publishedAt: ISO 8601 String)
     public static Article createArticle(Source source, String author, String title,
                                         String description, String content,
                                         String url, String urlToImage, String publishedAt,
@@ -73,14 +77,39 @@ public class Article {
         article.summary = null;
         article.url = url;
         article.urlToImage = urlToImage;
-        // article.viewCount = (viewCount != null) ? viewCount : 0L;
         article.viewCount = 0L;
         article.country = country;
         article.category = category;
+        article.language = "en";
 
         // ISO 8601 형식 변환
         OffsetDateTime offsetDateTime = OffsetDateTime.parse(publishedAt);
-        article.publishedAt = offsetDateTime.toLocalDateTime();  // UTC → LocalDateTime 변환
+        article.publishedAt = offsetDateTime.toLocalDateTime();
+
+        return article;
+    }
+
+    // RSS 수집용 정적 팩토리 메소드 (publishedAt: 이미 파싱된 LocalDateTime)
+    public static Article createRssArticle(Source source, String author, String title,
+                                           String description, String content,
+                                           String url, String urlToImage,
+                                           LocalDateTime publishedAt,
+                                           String country, String category, String language) {
+        Article article = new Article();
+        article.source = source;
+        article.author = (author != null && !author.isBlank()) ? author : "Unknown";
+        article.title = title;
+        article.description = (description != null) ? description : "";
+        article.content = (content != null && !content.isBlank()) ? content : article.description;
+        article.crawledContent = null;
+        article.summary = null;
+        article.url = url;
+        article.urlToImage = (urlToImage != null) ? urlToImage : "";
+        article.viewCount = 0L;
+        article.country = country;
+        article.category = category;
+        article.language = language;
+        article.publishedAt = publishedAt;
 
         return article;
     }

--- a/src/main/java/com/example/globalTimes_be/domain/trend/scheduler/TrendScheduler.java
+++ b/src/main/java/com/example/globalTimes_be/domain/trend/scheduler/TrendScheduler.java
@@ -39,22 +39,24 @@ public class TrendScheduler {
                 (Arrays.asList("KR", "AU", "AT", "BR", "CA", "CO", "DK", "EG", "FR", "DE", "GR", "HK", "IN",
                         "ID", "IT", "JP", "MY", "MX", "NL", "RU", "SG", "TW", "TR", "GB", "US", "ES"));
 
-        //나라 코드에 따른 실검 리스트 생성 후 저장
+        int totalKeywords = 0;
+        int successCount = 0;
+
         for (String countryCode : countries){
-            //나라 코드에 따른 실검 리스트 생성
             List<TrendDTO> trendDTOS = createTrendDTOS(countryCode);
 
-            //실검 리스트가 비어있으면 패스
             if(trendDTOS == null || trendDTOS.isEmpty()){
                 continue;
             }
 
-            //나라 코드를 키로 redis에 저장된 값 파기
             trendService.deleteTrendKeywords(countryCode);
-
-            //나라 코드를 키로 redis에 저장
             trendService.saveTrendKeywords(countryCode, trendDTOS);
+
+            totalKeywords += trendDTOS.size();
+            successCount++;
         }
+
+        log.info("[트렌드 수집] 완료 | {}개국, 총 {}개 키워드 저장", successCount, totalKeywords);
     }
 
     // 나라별 실검 리스트 생성
@@ -154,7 +156,6 @@ public class TrendScheduler {
             count++;
         }
 
-        log.info("[트렌드 수집] {} | 키워드 {}개 저장", countryCode, trendDTOS.size());
         return trendDTOS;
     }
 }

--- a/src/main/java/com/example/globalTimes_be/externalApi/config/NewsFetchConfig.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/config/NewsFetchConfig.java
@@ -16,13 +16,9 @@ public class NewsFetchConfig {
      * 지원 코드: https://newsapi.org/docs/endpoints/top-headlines
      */
     public List<String> getCountries() {
-        return List.of(
-                "us",   // 미국
-                "gb",   // 영국
-                "fr",   // 프랑스
-                "de",   // 독일
-                "kr"    // 한국
-        );
+        // 무료 플랜에서는 us만 실질적인 데이터를 반환함
+        // 다국어 수집은 RssNewsService(RSS 파이프라인)에서 담당
+        return List.of("us");
     }
 
     /**

--- a/src/main/java/com/example/globalTimes_be/externalApi/config/RssFeedConfig.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/config/RssFeedConfig.java
@@ -1,0 +1,40 @@
+package com.example.globalTimes_be.externalApi.config;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * 각국 언론사 RSS 피드 수집 대상 설정.
+ * 수집 대상 추가/제거 시 이 파일만 수정하면 된다.
+ */
+@Component
+public class RssFeedConfig {
+
+    public record FeedSource(
+            String url,
+            String country,
+            String language,
+            String sourceName,
+            String category
+    ) {}
+
+    public List<FeedSource> getFeeds() {
+        return List.of(
+                // 한국 - 연합뉴스 (실제 경로 수정)
+                new FeedSource("https://www.yna.co.kr/rss/news.xml", "kr", "ko", "연합뉴스", "general"),
+                // 프랑스
+                new FeedSource("https://www.france24.com/fr/rss", "fr", "fr", "France24", "general"),
+                // 독일
+                new FeedSource("https://rss.dw.com/rdf/rss-de-all", "de", "de", "Deutsche Welle", "general"),
+                // 일본
+                new FeedSource("https://www3.nhk.or.jp/rss/news/cat0.xml", "jp", "ja", "NHK", "general"),
+                // 아랍어 - BBC Arabic (Al Jazeera/Al Arabiya 모두 봇 차단, BBC는 RSS 안정 제공)
+                new FeedSource("https://feeds.bbci.co.uk/arabic/rss.xml", "sa", "ar", "BBC Arabic", "general"),
+                // 중국 - South China Morning Post
+                new FeedSource("https://www.scmp.com/rss/91/feed", "cn", "zh", "South China Morning Post", "general"),
+                // 스페인어 - BBC Mundo (RT 대체, 접근 안정적)
+                new FeedSource("https://feeds.bbci.co.uk/mundo/rss.xml", "es", "es", "BBC Mundo", "general")
+        );
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/externalApi/service/RssNewsService.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/service/RssNewsService.java
@@ -1,0 +1,199 @@
+package com.example.globalTimes_be.externalApi.service;
+
+import com.example.globalTimes_be.domain.article.entity.Article;
+import com.example.globalTimes_be.domain.article.repository.ArticleRepository;
+import com.example.globalTimes_be.domain.source.entity.Source;
+import com.example.globalTimes_be.domain.source.service.SourceService;
+import com.example.globalTimes_be.externalApi.config.RssFeedConfig;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RssNewsService {
+
+    private final ArticleRepository articleRepository;
+    private final SourceService sourceService;
+    private final RssFeedConfig rssFeedConfig;
+
+    @Value("${news-fetch.enabled:false}")
+    private boolean fetchEnabled;
+
+    // RSS pubDate 파싱 포맷 목록 (언론사마다 포맷이 다름)
+    // zzz = GMT/UTC 같은 이름형 타임존, Z = +0900/+0000 같은 숫자형 오프셋
+    // ISO_OFFSET_DATE_TIME = DW 등 RDF 피드의 dc:date 형식 (2026-03-19T08:00:00+00:00)
+    private static final List<DateTimeFormatter> DATE_FORMATTERS = List.of(
+            DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH),
+            DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.ENGLISH),
+            DateTimeFormatter.ofPattern("dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH),
+            DateTimeFormatter.ofPattern("dd MMM yyyy HH:mm:ss Z", Locale.ENGLISH),
+            DateTimeFormatter.ISO_OFFSET_DATE_TIME
+    );
+
+    @PostConstruct
+    public void init() {
+        if (!fetchEnabled) {
+            log.info("[RSS 초기화] news-fetch.enabled=false → RSS 수집 건너뜀");
+            return;
+        }
+        fetchAllFeeds("[RSS 초기 적재]");
+    }
+
+    // 6시간마다 RSS 수집
+    @Scheduled(cron = "0 0 0/6 * * *")
+    public void scheduledFetch() {
+        if (!fetchEnabled) return;
+        fetchAllFeeds("[RSS 스케줄링]");
+    }
+
+    private void fetchAllFeeds(String logPrefix) {
+        int totalSaved = 0;
+        for (RssFeedConfig.FeedSource feed : rssFeedConfig.getFeeds()) {
+            totalSaved += fetchFeed(feed);
+        }
+        log.info("{} 전체 저장된 신규 기사: {}개", logPrefix, totalSaved);
+    }
+
+    private int fetchFeed(RssFeedConfig.FeedSource feed) {
+        try {
+            // Jsoup으로 직접 fetch: Content-Type 비표준/User-Agent 문제를 RestTemplate보다 유연하게 처리
+            String xml = Jsoup.connect(feed.url())
+                    .userAgent("Mozilla/5.0 (compatible; GlobalTimesBot/1.0)")
+                    .timeout(10_000)
+                    .ignoreContentType(true)
+                    .execute()
+                    .body();
+
+            if (xml == null || xml.isBlank()) {
+                log.info("[수집 통계] {} | 응답 없음", feed.sourceName());
+                return 0;
+            }
+
+            Document doc = Jsoup.parse(xml, "", org.jsoup.parser.Parser.xmlParser());
+            Elements items = doc.select("item");
+
+            if (items.isEmpty()) {
+                log.info("[수집 통계] {} | 응답 없음", feed.sourceName());
+                return 0;
+            }
+
+            // 중복 URL 사전 조회
+            List<String> urls = items.stream()
+                    .map(item -> item.select("link").text().trim())
+                    .filter(url -> !url.isBlank())
+                    .collect(Collectors.toList());
+            Set<String> existingUrls = articleRepository.findExistingUrls(urls);
+
+            Source source = sourceService.getOrCreateSource(feed.sourceName(), null);
+
+            List<Article> toSave = new ArrayList<>();
+            int invalidCount = 0;
+            int duplicateCount = 0;
+
+            for (Element item : items) {
+                String url = item.select("link").text().trim();
+                String title = item.select("title").text().trim();
+                String pubDateStr = item.select("pubDate").text().trim();
+                // RDF 피드(Deutsche Welle 등)는 <pubDate> 대신 <dc:date> 사용
+                if (pubDateStr.isBlank()) {
+                    pubDateStr = item.select("dc|date").text().trim();
+                }
+
+                // 필수 필드 유효성 검사
+                if (url.isBlank() || title.isBlank() || pubDateStr.isBlank()) {
+                    invalidCount++;
+                    continue;
+                }
+
+                // 날짜 파싱
+                LocalDateTime publishedAt = parseRssDate(pubDateStr);
+                if (publishedAt == null) {
+                    invalidCount++;
+                    continue;
+                }
+
+                // 중복 체크
+                if (existingUrls.contains(url)) {
+                    duplicateCount++;
+                    continue;
+                }
+
+                String description = item.select("description").text().trim();
+                String author = extractAuthor(item);
+                String urlToImage = extractImage(item);
+
+                Article article = Article.createRssArticle(
+                        source, author, title, description, null,
+                        url, urlToImage, publishedAt,
+                        feed.country(), feed.category(), feed.language()
+                );
+                toSave.add(article);
+            }
+
+            if (!toSave.isEmpty()) {
+                articleRepository.saveAll(toSave);
+            }
+
+            log.info("[수집 통계] {} | 응답:{}, invalid:{}, 중복:{}, 저장:{}",
+                    feed.sourceName(), items.size(), invalidCount, duplicateCount, toSave.size());
+
+            return toSave.size();
+
+        } catch (Exception e) {
+            log.error("[RSS 수집 오류] {} 처리 중 오류 발생", feed.sourceName(), e);
+            return 0;
+        }
+    }
+
+    private LocalDateTime parseRssDate(String pubDateStr) {
+        for (DateTimeFormatter formatter : DATE_FORMATTERS) {
+            try {
+                return ZonedDateTime.parse(pubDateStr, formatter).toLocalDateTime();
+            } catch (DateTimeParseException ignored) {
+            }
+        }
+        log.warn("[RSS 날짜 파싱 실패] pubDate: {}", pubDateStr);
+        return null;
+    }
+
+    private String extractAuthor(Element item) {
+        String author = item.select("dc|creator").text().trim();
+        if (author.isBlank()) author = item.select("author").text().trim();
+        return author;
+    }
+
+    private String extractImage(Element item) {
+        // <media:thumbnail url="..."> 또는 <media:content url="...">
+        Element mediaThumbnail = item.selectFirst("media|thumbnail");
+        if (mediaThumbnail != null) return mediaThumbnail.attr("url");
+
+        Element mediaContent = item.selectFirst("media|content");
+        if (mediaContent != null) return mediaContent.attr("url");
+
+        // <enclosure url="..." type="image/...">
+        Element enclosure = item.selectFirst("enclosure");
+        if (enclosure != null && enclosure.attr("type").startsWith("image")) {
+            return enclosure.attr("url");
+        }
+        return "";
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,4 +35,4 @@ spring:
 # false(기본): 로컬 개발 중 API 할당량 절약 목적으로 @PostConstruct/스케줄러 비활성화
 # true: 수집 테스트 시에만 변경 (주의: 무료 플랜 100 req/24h 제한)
 news-fetch:
-  enabled: false
+  enabled: true


### PR DESCRIPTION
## 📌 작업 내용

### 새로 추가
- `RssFeedConfig`: 7개국 RSS 피드 소스 설정 (ko/fr/de/ja/ar/zh/es)
-> 국가 코드까지 잘 설정되서 데이터 베이스에 저장 된 것 확인 
 
- `RssNewsService`: Jsoup 기반 RSS XML 파싱 + 저장 파이프라인
  - 중복 URL 사전 조회로 중복 저장 방지
  - RFC 822 / 숫자형 오프셋(+0900) / ISO 8601(dc:date) 날짜 포맷 폴백 지원
  - `news-fetch.enabled` 플래그로 `@PostConstruct` / `@Scheduled` 전역 제어 ( 데이터 수집 파이프 라인 )  
  - 수집 통계 로그: `[수집 통계] 소스명 | 응답:N, invalid:N, 중복:N, 저장:N`

### 변경
- `Article` 엔티티에 `language` 필드 추가 + `createRssArticle` 팩토리 메서드 추가
- `NewsFetchConfig`: 수집 국가를 `us` 단일로 축소 
(News API free Plan 은 미국 -us 의 뉴스만 리턴해주기 때문에, 일단 영미권은 유지)  
- 기존 실시간 트렌드 수집 시 출력하던 로그도 [국가 코드 : 데이터 수] 로 국가별 전부 출력에서 -> 한줄로 요약해서 출력 

## 🧭 변경 타입
- [x] feat (새 기능)
- [x] refactor (기존 기능 변경)

## 🧪 테스트/검증
- `news-fetch.enabled: true` 설정 후 로컬 실행으로 수집 통계 로그 확인
- France24(fr), Deutsche Welle(de), NHK(ja), SCMP(zh), BBC Arabic(ar), BBC Mundo(es) 정상 수집 확인
- News API는 us 단일 수집으로 할당량 절약 확인

## ✅ 체크리스트
- [x] 빌드 성공 확인
- [x] 외부 동작/응답이 기존과 동일함을 확인