### PR TITLE
♻️ [REFACTOR/#73] RestTemplate/WebClient timeout 및 에러 정책 표준화

### DIFF
--- a/src/main/java/com/example/globalTimes_be/domain/news/service/AiService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/news/service/AiService.java
@@ -5,7 +5,9 @@ import com.example.globalTimes_be.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
@@ -17,10 +19,19 @@ public class AiService {
     public String summarizeArticle(String crawledContent, String language){
         String summary = openAiWebClient.post()
                 .uri("/chat/completions")
-                .bodyValue(createRequestBody(crawledContent, language))  // 요청 본문
+                .bodyValue(createRequestBody(crawledContent, language))
                 .retrieve()
-                .bodyToMono(Map.class)  // 전체 응답을 한 번에 받음
-                .map(response -> extractContent(response))  // 응답 본문에서 요약 내용 추출
+                .onStatus(
+                        status -> !status.is2xxSuccessful(),
+                        response -> Mono.error(new BaseException(NewsErrorStatus._GPT_ERROR.getResponse()))
+                )
+                .bodyToMono(Map.class)
+                .timeout(Duration.ofSeconds(10))  // 10초 내 응답 없으면 타임아웃
+                .onErrorMap(
+                        ex -> !(ex instanceof BaseException),
+                        ex -> new BaseException(NewsErrorStatus._GPT_ERROR.getResponse())
+                )
+                .map(response -> extractContent(response))
                 .block();
 
         return summary;

--- a/src/main/java/com/example/globalTimes_be/domain/trend/scheduler/TrendScheduler.java
+++ b/src/main/java/com/example/globalTimes_be/domain/trend/scheduler/TrendScheduler.java
@@ -9,6 +9,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
@@ -22,18 +23,24 @@ import java.util.List;
 @RequiredArgsConstructor
 @Component
 public class TrendScheduler {
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;  // timeout 설정된 빈 주입
     private final TrendService trendService;
 
-    //서버 시작 시 한 번 실행되도록 함
+    @Value("${news-fetch.enabled:false}")
+    private boolean fetchEnabled;
+
     @PostConstruct
     public void init() {
+        if (!fetchEnabled) {
+            log.info("[트렌드 초기화] news-fetch.enabled=false → 트렌드 수집 건너뜀");
+            return;
+        }
         saveTrendApi();
     }
 
-    //1시간 마다 갱신
     @Scheduled(cron = "0 0 */1 * * *")
     public void saveTrendApi(){
+        if (!fetchEnabled) return;
         //나라 코드 리스트 생성
         List<String> countries = new ArrayList<>
                 (Arrays.asList("KR", "AU", "AT", "BR", "CA", "CO", "DK", "EG", "FR", "DE", "GR", "HK", "IN",

--- a/src/main/java/com/example/globalTimes_be/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/globalTimes_be/global/config/RestTemplateConfig.java
@@ -2,13 +2,17 @@ package com.example.globalTimes_be.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class RestTemplateConfig {
 
     @Bean
-    public RestTemplate restTemplate(){
-        return new RestTemplate();
+    public RestTemplate restTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(3_000);  // 외부 서버 연결 최대 3초 대기
+        factory.setReadTimeout(5_000);     // 응답 수신 최대 5초 대기
+        return new RestTemplate(factory);
     }
 }

--- a/src/main/java/com/example/globalTimes_be/global/translate/TranslateUtil.java
+++ b/src/main/java/com/example/globalTimes_be/global/translate/TranslateUtil.java
@@ -24,7 +24,7 @@ public class TranslateUtil {
 
     //자동으로 언어 감지 후 영어로 번역
     public String translateToEnglish(String text){
-        System.out.println("번역기에 들어온 텍스트: " + text);
+        log.debug("[번역 요청] text: {}", text);
         try {
             Translation translation = translate.translate(
                     text,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,7 @@ spring:
       port: 6379
 
   jpa:
+    open-in-view: false
     hibernate:
       ddl-auto: update
 


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #73

## 🧭 변경 타입
- [x] ♻️ 리팩토링 (REFACTOR)

## 📝 작업 내용

### RestTemplateConfig
- `new RestTemplate()` → `SimpleClientHttpRequestFactory` 적용
  - connectTimeout 3초 / readTimeout 5초 설정
  - 외부 API 무응답 시 스레드 무한 점유 방지

### AiService
- WebClient에 `.timeout(Duration.ofSeconds(10))` 추가
- `.onStatus()` 로 HTTP 4xx/5xx 에러 명시적 처리
- `.onErrorMap()` 으로 타임아웃 포함 기타 에러를 `_GPT_ERROR`로 통일

### TrendScheduler
- `new RestTemplate()` 직접 생성 → timeout 설정된 RestTemplate 빈 주입으로 변경
- `news-fetch.enabled` 플래그 적용 → NewsAPI/RSS와 함께 전체 수집 파이프라인 일괄 on/off 가능

### TranslateUtil
- `System.out.println` → `log.debug` 로 교체 (로그 표준화)

### application.yml
- `spring.jpa.open-in-view: false` 추가
  - 기본값 `true` 는 DB 커넥션을 뷰 렌더링까지 열어두는 설정
  - Service 계층에서 DTO 변환을 완결하므로 `false` 로 변경

## 📝 추가로 공부한 내용

### Open-in-view?

MVC에서의 요청 처리 흐름:
```
HTTP 요청 → Controller → Service (@Transactional)
    → Repository (DB 조회) → 트랜잭션 종료
    → View 렌더링 → 응답 반환
```

`open-in-view: true` (기본값)이면 DB 커넥션을 View 렌더링까지 잡아둠.
DTO 변환을 Service 내에서 완결하므로 `false`로 설정.

### Lazy Loading?

```java
@Entity
public class Article {
    @ManyToOne(fetch = FetchType.LAZY)  // 지연 로딩
    private Source source;
}
```

기사에 언론사가 연결되어 있는데, 지연 로딩은 실제 접근할 때 DB를 조회함:

```
articleRepository.findById(1L)
    └── DB: SELECT * FROM article WHERE id = 1
        └── Source는 아직 안 가져옴 (프록시 객체만 있음)

article.getSource().getSourceName()
    └── 그때서야 DB: SELECT * FROM source WHERE id = ?
```

Eager 로딩은 Article + Source를 한꺼번에 JOIN해서 가져옴.
Article 조회 시 Source가 필요 없는 경우도 많아서 Lazy가 기본값.

### open-in-view와 Lazy Loading의 관계

```java
// Service에서 트랜잭션 안에 있을 때
Article article = articleRepository.findById(id);
article.getSource().getSourceName();  // ✅ 트랜잭션 있으니까 DB 조회 가능

// 트랜잭션 끝난 후 Controller/View에서
article.getSource().getSourceName();
// ❌ LazyInitializationException
// (트랜잭션 없으면 DB 연결이 없어서 Lazy 로딩 불가)
```

## 🧪 테스트/검증
- [x] 빌드 성공 확인
- [x] `news-fetch.enabled: false` 시 NewsAPI / RSS / 트렌드 전부 건너뜀 확인
- [x] 기존 API 외부 동작 동일

## ✅ 체크리스트
- [x] 빌드 성공 확인
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?