### PR TITLE
✨ [FEAT/#87] Perspectives API Swagger 문서 추가 및 Source null 방어 처리

### DIFF
--- a/src/main/java/com/example/globalTimes_be/domain/detail/controller/DetailController.java
+++ b/src/main/java/com/example/globalTimes_be/domain/detail/controller/DetailController.java
@@ -24,7 +24,7 @@ public class DetailController implements DetailControllerDocs {
         return ApiResponse.success(GlobalSuccessStatus._OK.getResponse(), detailResDTO);
     }
 
-    // 기사 상세에서 타 국가 관련 기사 비교 (국가별 시각 비교)
+    @Override
     @GetMapping("/{id}/perspectives")
     public ResponseEntity<ApiResponse> getPerspectives(@PathVariable Long id) {
         PerspectivesResDTO response = perspectivesService.getPerspectives(id);

--- a/src/main/java/com/example/globalTimes_be/domain/detail/controller/DetailControllerDocs.java
+++ b/src/main/java/com/example/globalTimes_be/domain/detail/controller/DetailControllerDocs.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "뉴스 상세 페이지", description = "뉴스 상세페이지 관련 API입니다.")
@@ -87,4 +88,79 @@ public interface DetailControllerDocs {
             @Parameter(description = "뉴스기사 ID", example = "1")
             @NotNull(message = "뉴스기사id는 비어있을 수 없습니다.")
             @RequestParam("id") Long id);
+
+    @Operation(summary = "국가별 시각 비교 기사 응답",
+            description = "해당 기사의 키워드를 기반으로 다른 국가의 관련 기사 목록을 반환합니다. (키워드 매칭 방식)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "응답 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = com.example.globalTimes_be.global.apiPayload.code.ApiResponse.class),
+                            examples = @ExampleObject(value = """
+                                {
+                                    "timestamp": "2025-03-28T10:24:28.6081968",
+                                    "isSuccess": true,
+                                    "message": "응답에 성공했습니다.",
+                                    "data": {
+                                        "keyword": "Trump",
+                                        "perspectives": {
+                                            "US": [
+                                                {
+                                                    "id": 10,
+                                                    "country": "US",
+                                                    "language": "en",
+                                                    "source": "CNN",
+                                                    "title": "Trump signs executive order on trade",
+                                                    "description": "President Trump signed...",
+                                                    "urlToImage": "https://example.com/img.jpg",
+                                                    "publishedAt": "2025-03-27T08:00:00"
+                                                }
+                                            ],
+                                            "KR": [
+                                                {
+                                                    "id": 42,
+                                                    "country": "KR",
+                                                    "language": "ko",
+                                                    "source": "연합뉴스",
+                                                    "title": "트럼프 행정명령 서명",
+                                                    "description": "트럼프 대통령이...",
+                                                    "urlToImage": "https://example.com/img2.jpg",
+                                                    "publishedAt": "2025-03-27T09:00:00"
+                                                }
+                                            ]
+                                        },
+                                        "countriesFound": 2,
+                                        "totalArticles": 2
+                                    }
+                                }
+                            """)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "비즈니스 에러",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(name = "기사 정보 없음", value = """
+                                {
+                                    "timestamp": "2025-03-28T10:24:28.6081968",
+                                    "isSuccess": false,
+                                    "message": "해당 기사의 정보가 없습니다.",
+                                    "data": null
+                                }
+                                """)
+                    )
+            ),
+            @ApiResponse(responseCode = "500", description = "서버 에러가 발생하였습니다.",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                {
+                                    "timestamp": "2025-03-28T10:24:28.6081968",
+                                    "isSuccess": false,
+                                    "message": "서버 에러가 발생하였습니다.",
+                                    "data": null
+                                }
+                                """)
+                    )
+            )
+    })
+    public ResponseEntity<?> getPerspectives(
+            @Parameter(description = "뉴스기사 ID", example = "1")
+            @PathVariable Long id);
 }

--- a/src/main/java/com/example/globalTimes_be/externalApi/service/RssNewsService.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/service/RssNewsService.java
@@ -103,7 +103,9 @@ public class RssNewsService {
                     .collect(Collectors.toList());
             Set<String> existingUrls = articleRepository.findExistingUrls(urls);
 
+            // feed.sourceName()은 하드코딩된 RSS 피드 설정값이므로 null/empty 가능성 없음
             Source source = sourceService.getOrCreateSource(feed.sourceName(), null);
+            if (source == null) continue;
 
             List<Article> toSave = new ArrayList<>();
             int invalidCount = 0;

--- a/src/main/java/com/example/globalTimes_be/externalApi/service/RssNewsService.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/service/RssNewsService.java
@@ -105,7 +105,7 @@ public class RssNewsService {
 
             // feed.sourceName()은 하드코딩된 RSS 피드 설정값이므로 null/empty 가능성 없음
             Source source = sourceService.getOrCreateSource(feed.sourceName(), null);
-            if (source == null) continue;
+            if (source == null) return 0;
 
             List<Article> toSave = new ArrayList<>();
             int invalidCount = 0;


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #87

## 🧭 변경 타입
- [x] ✨ 기능 추가 (FEAT)
- [x] 🐛 버그 수정 (FIX)

## 📝 작업 내용
- `DetailControllerDocs`에 `GET /api/news/{id}/perspectives` Swagger 어노테이션 추가 (200/400/500 응답 예시 포함)
- `DetailController.getPerspectives`에 `@Override` 누락 수정
- `RssNewsService`에서 `getOrCreateSource` 반환값이 null일 경우 해당 피드를 스킵하는 형태로 코드 수정 

## 🔍 기술적 배경
- Perspectives 엔드포인트가 `DetailControllerDocs` 인터페이스에 선언되지 않아 Swagger API 문서에 보이지 않음. 
- `Source.createSource`는 sourceName이 없을 때 의도적으로 null을 반환하는 설계이나, `RssNewsService`에서 반환값 null 체크 없이 기사 저장 로직으로 흘러 잠재적 NPE 가능성이 존재 ( Null Pointer Exception ) 

## 🧪 테스트/검증 (필수)
- [x] 서버 기동 후 Swagger UI(`/swagger-ui.html`)에서 `GET /api/news/{id}/perspectives` 항목 정상 노출 확인
- [x] `/api/news/{id}/perspectives` 호출 시 정상 응답 확인

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?

## 💬 리뷰 요구사항(선택)
- `Source.createSource` null 반환 정책이 `NewsApiService` / `RssNewsService` 양쪽에서 일관되게 처리되고 있는지 
추후 확인할 필요가 있음. 

- 한국어 기사 기준으로 키워드 추출 시 조사(`에`, `의`, `을` 등)가 제거되지 않아 동일 언어 내 
FULLTEXT 매칭 정확도가 낮을 수 있음.
- 다국어 매칭은 번역 단계에서 구글 번역이 명사형으로 처리해 주므로 실질적 영향은 없으나,
- 원문 키워드 추가 탐색(한국어 → 한국어) 품질 향상이 필요하다면 검토가 필요.


## 기타 (마이크로서비스?)

- 🌱 `KeywordExtractor` 한국어 조사 제거 로직 추가 검토
  - 대상: `은/는/이/가/을/를/에/의/로/으로/와/과` 등 빈출 조사
  - 다국어 매칭에는 영향 없으나 동일 언어(한국어) 기사 간 FULLTEXT 매칭 정확도 개선 목적
  - 형태소 분석기(Komoran 등) 도입 vs 룰 기반 suffix 제거 중 방향 검토 필요

Java 기반 형태소 분석기(Arirang, HanNanum) 또는 간단한 룰 기반 suffix 제거로 충분.
-> 마이크로서비스의 형태로 가능은 하나, 추후 고려사항 정도로만 두자.
(기능마다 서버를 따로 띄우는 형태)

대형 서비스들이 쓰는 형태 

