### PR TITLE
✨ [FEAT/#90] 국가별 RSS 피드 카테고리 다양화 (연합뉴스/DW/BBC Arabic/BBC Mundo)

### DIFF
--- a/src/main/java/com/example/globalTimes_be/externalApi/config/RssFeedConfig.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/config/RssFeedConfig.java
@@ -33,9 +33,13 @@ public class RssFeedConfig {
 
                 // ── 한국 / 연합뉴스 ───────────────────────────────────────────
                 new FeedSource("https://www.yna.co.kr/rss/news.xml",          "kr", "ko", "연합뉴스", "general"),
+                new FeedSource("https://www.yna.co.kr/rss/politics.xml",      "kr", "ko", "연합뉴스", "politics"),
                 new FeedSource("https://www.yna.co.kr/rss/economy.xml",       "kr", "ko", "연합뉴스", "business"),
-                new FeedSource("https://www.yna.co.kr/rss/sports.xml",        "kr", "ko", "연합뉴스", "sports"),
+                new FeedSource("https://www.yna.co.kr/rss/industry.xml",      "kr", "ko", "연합뉴스", "technology"),
+                new FeedSource("https://www.yna.co.kr/rss/health.xml",        "kr", "ko", "연합뉴스", "health"),
                 new FeedSource("https://www.yna.co.kr/rss/culture.xml",       "kr", "ko", "연합뉴스", "entertainment"),
+                new FeedSource("https://www.yna.co.kr/rss/entertainment.xml", "kr", "ko", "연합뉴스", "entertainment"),
+                new FeedSource("https://www.yna.co.kr/rss/sports.xml",        "kr", "ko", "연합뉴스", "sports"),
 
                 // ── 일본 / NHK ────────────────────────────────────────────────
                 new FeedSource("https://www3.nhk.or.jp/rss/news/cat0.xml", "jp", "ja", "NHK", "general"),
@@ -49,11 +53,17 @@ public class RssFeedConfig {
                 new FeedSource("https://www.france24.com/fr/sports/rss",   "fr", "fr", "France24", "sports"),
 
                 // ── 독일 / Deutsche Welle ─────────────────────────────────────
-                new FeedSource("https://rss.dw.com/rdf/rss-de-all", "de", "de", "Deutsche Welle", "general"),
+                new FeedSource("https://rss.dw.com/rdf/rss-de-all",         "de", "de", "Deutsche Welle", "general"),
+                new FeedSource("https://rss.dw.com/rdf/rss-en-bus",         "de", "en", "Deutsche Welle", "business"),
+                new FeedSource("https://rss.dw.com/xml/rss_en_science",     "de", "en", "Deutsche Welle", "science"),
+                new FeedSource("https://rss.dw.com/rdf/rss-en-sports",      "de", "en", "Deutsche Welle", "sports"),
+                new FeedSource("https://rss.dw.com/rdf/rss-en-cul",         "de", "en", "Deutsche Welle", "entertainment"),
 
                 // ── 아랍어 / BBC Arabic ───────────────────────────────────────
-                new FeedSource("https://feeds.bbci.co.uk/arabic/rss.xml",              "sa", "ar", "BBC Arabic", "general"),
-                new FeedSource("https://feeds.bbci.co.uk/arabic/middleeast/rss.xml",   "sa", "ar", "BBC Arabic", "business"),
+                new FeedSource("https://feeds.bbci.co.uk/arabic/rss.xml",                   "sa", "ar", "BBC Arabic", "general"),
+                new FeedSource("https://feeds.bbci.co.uk/arabic/middleeast/rss.xml",         "sa", "ar", "BBC Arabic", "business"),
+                new FeedSource("https://feeds.bbci.co.uk/arabic/sport/rss.xml",              "sa", "ar", "BBC Arabic", "sports"),
+                new FeedSource("https://feeds.bbci.co.uk/arabic/scienceandtech/rss.xml",     "sa", "ar", "BBC Arabic", "technology"),
 
                 // ── 중국 / South China Morning Post ───────────────────────────
                 new FeedSource("https://www.scmp.com/rss/91/feed",  "cn", "zh", "South China Morning Post", "general"),
@@ -62,7 +72,10 @@ public class RssFeedConfig {
                 new FeedSource("https://www.scmp.com/rss/95/feed",  "cn", "zh", "South China Morning Post", "sports"),
 
                 // ── 스페인어 / BBC Mundo ──────────────────────────────────────
-                new FeedSource("https://feeds.bbci.co.uk/mundo/rss.xml", "es", "es", "BBC Mundo", "general")
+                new FeedSource("https://feeds.bbci.co.uk/mundo/rss.xml",           "es", "es", "BBC Mundo", "general"),
+                new FeedSource("https://feeds.bbci.co.uk/mundo/economia/rss.xml",  "es", "es", "BBC Mundo", "business"),
+                new FeedSource("https://feeds.bbci.co.uk/mundo/deportes/rss.xml",  "es", "es", "BBC Mundo", "sports"),
+                new FeedSource("https://feeds.bbci.co.uk/mundo/ciencia/rss.xml",   "es", "es", "BBC Mundo", "science")
         );
     }
 }


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #90

## 🧭 변경 타입
- [x] ✨ 기능 추가 (FEAT)

## 📝 작업 내용
- `RssFeedConfig.java`에 국가별 카테고리 RSS 피드 추가
- 추가 전/후 카테고리 현황:

| 국가 | 기존 | 추가 후 |
|------|------|---------|
| `kr` (연합뉴스) | general, business, sports, entertainment | + politics, technology, health |
| `de` (Deutsche Welle) | general | + business, science, sports, entertainment |
| `sa` (BBC Arabic) | general, business | + sports, technology |
| `es` (BBC Mundo) | general | + business, sports, science |

## 🔍 기술적 배경
- 기존 일부 국가(de, es 등)는 `general` 카테고리 피드만 등록되어 카테고리별 탐색이 제한적이었음
- 각 언론사 공식 RSS 피드 목록을 기반으로 카테고리별 URL을 추가, 수집 로직 변경 없이 피드 등록만으로 카테고리 다양화 가능
- Deutsche Welle 카테고리 피드는 영어(en) 기사로 제공됨

## 🧪 테스트/검증 (필수)
- [x] `news-fetch.enabled=true` 후 서버 기동 시 수집 로그 확인
- [x] 추가된 피드 전부 에러 없이 수집 완료 확인 (빌드 로그 기준)

**수집 결과 요약 (초기 적재 기준):**
- 연합뉴스: 8개 피드 전부 정상, 총 756개 기사 저장
- Deutsche Welle: 5개 피드 전부 정상, 총 84개 기사 저장
- BBC Arabic: 4개 피드 전부 정상 (신규 피드는 general과 중복 기사로 저장 0, URL 유효 확인)
- BBC Mundo: 4개 피드 전부 정상 (동일하게 중복으로 저장 0, URL 유효 확인)

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?

## 💬 리뷰 요구사항 (선택)
- BBC Arabic / BBC Mundo 신규 카테고리 피드는 general 피드와 동일한 기사 묶음을 반환하고 있어 현재는 `저장:0`으로 집계됨. 해당 언론사가 카테고리별로 별도 기사를 제공하는지 추후 확인 필요

## ➕ 추후 계획 (선택)
- BBC Mundo, BBC Arabic 카테고리별 독립 피드 URL이 있는지 추가 조사
- France24 기술/건강 카테고리 피드 추가 검토
- JP(NHK) 추가 카테고리 피드 검토

## 언론사 수집 기사 관련 혼동 방지 ) 

BC Arabic → BBC가 아랍어로 작성해서 제공하는 피드. 영어가 아니라 아랍어 원문 기사가 저장.
BBC Mundo → BBC가 스페인어로 작성해서 제공하는 피드. 스페인어 원문 기사 저장.

BBC 입장에서는 "국제 서비스" 개념으로 각 언어권 독자를 위해 별도 편집팀이 해당 언어로 직접 작성. 
번역이 아니라 원어민 기자가 해당 언어로 쓴 기사에 가까움.