### PR TITLE
✨ [FEAT/#89] 국가/카테고리/날짜 기반 기사 탐색 API 구현 (GET /api/articles/explore)

### DIFF
--- a/src/main/java/com/example/globalTimes_be/domain/article/controller/ExploreController.java
+++ b/src/main/java/com/example/globalTimes_be/domain/article/controller/ExploreController.java
@@ -1,0 +1,30 @@
+package com.example.globalTimes_be.domain.article.controller;
+
+import com.example.globalTimes_be.domain.article.dto.CursorArticleResponseDto;
+import com.example.globalTimes_be.domain.article.service.ExploreService;
+import com.example.globalTimes_be.global.apiPayload.code.ApiResponse;
+import com.example.globalTimes_be.global.apiPayload.code.status.GlobalSuccessStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/articles")
+public class ExploreController implements ExploreControllerDocs {
+
+    private final ExploreService exploreService;
+
+    @Override
+    @GetMapping("/explore")
+    public ResponseEntity<ApiResponse> explore(
+            @RequestParam(required = false) String country,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String date,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        CursorArticleResponseDto response = exploreService.explore(country, category, date, cursor, size);
+        return ApiResponse.success(GlobalSuccessStatus._OK.getResponse(), response);
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/domain/article/controller/ExploreControllerDocs.java
+++ b/src/main/java/com/example/globalTimes_be/domain/article/controller/ExploreControllerDocs.java
@@ -1,0 +1,80 @@
+package com.example.globalTimes_be.domain.article.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "기사 탐색", description = "국가·카테고리·날짜 조건 기반 기사 탐색 API (검색과 별개)")
+public interface ExploreControllerDocs {
+
+    @Operation(
+            summary = "기사 탐색 (필터 + 커서 페이징)",
+            description = "country / category / date 조건을 조합해 기사를 탐색합니다. " +
+                    "파라미터는 전부 선택값이며, 아무것도 없으면 전체 기사를 최신순으로 반환합니다. " +
+                    "date는 yyyy-MM-dd 형식 (해당 날짜 하루치 기사), cursor는 이전 응답의 nextCursor 값을 사용합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "응답 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = com.example.globalTimes_be.global.apiPayload.code.ApiResponse.class),
+                            examples = @ExampleObject(value = """
+                                {
+                                    "timestamp": "2026-03-27T10:00:00",
+                                    "isSuccess": true,
+                                    "message": "응답에 성공했습니다.",
+                                    "data": {
+                                        "articles": [
+                                            {
+                                                "id": 100,
+                                                "sourceName": "연합뉴스",
+                                                "publishedAt": "2 hours ago",
+                                                "title": "한국 경제 동향",
+                                                "description": "...",
+                                                "urlToImage": "https://example.com/img.jpg",
+                                                "viewCount": 42
+                                            }
+                                        ],
+                                        "nextCursor": "2026-03-27T08:00:00",
+                                        "hasNext": true
+                                    }
+                                }
+                            """)
+                    )
+            ),
+            @ApiResponse(responseCode = "500", description = "서버 에러",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                {
+                                    "timestamp": "2026-03-27T10:00:00",
+                                    "isSuccess": false,
+                                    "message": "서버 에러가 발생하였습니다.",
+                                    "data": null
+                                }
+                            """)
+                    )
+            )
+    })
+    ResponseEntity<?> explore(
+            @Parameter(description = "국가 코드 (예: kr, us, jp, de)", example = "kr")
+            @RequestParam(required = false) String country,
+
+            @Parameter(description = "카테고리 (예: general, business, sports, technology, health, entertainment, science, politics)", example = "sports")
+            @RequestParam(required = false) String category,
+
+            @Parameter(description = "날짜 필터 (yyyy-MM-dd), 해당 날짜 하루치 기사만 반환", example = "2026-03-27")
+            @RequestParam(required = false) String date,
+
+            @Parameter(description = "커서 (이전 응답의 nextCursor 값, 첫 요청 시 생략)", example = "2026-03-27T08:00:00")
+            @RequestParam(required = false) String cursor,
+
+            @Parameter(description = "페이지 크기 (기본값 20)", example = "20")
+            @RequestParam(defaultValue = "20") int size
+    );
+}

--- a/src/main/java/com/example/globalTimes_be/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/com/example/globalTimes_be/domain/article/repository/ArticleRepository.java
@@ -61,6 +61,24 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     @Query("SELECT a FROM Article a ORDER BY a.publishedAt DESC")
     List<Article> findFirstPage(Pageable pageable);
 
+    // 탐색 필터(country/category/date) + 커서 기반 페이징 (최신순)
+    // cursor가 null이면 첫 페이지, 있으면 해당 시간 이전 기사 탐색
+    @Query("SELECT a FROM Article a WHERE " +
+            "(:country IS NULL OR a.country = :country) " +
+            "AND (:category IS NULL OR a.category = :category) " +
+            "AND (:dateFrom IS NULL OR a.publishedAt >= :dateFrom) " +
+            "AND (:dateTo IS NULL OR a.publishedAt <= :dateTo) " +
+            "AND (:cursor IS NULL OR a.publishedAt < :cursor) " +
+            "ORDER BY a.publishedAt DESC")
+    List<Article> findByExploreFilters(
+            @Param("country") String country,
+            @Param("category") String category,
+            @Param("dateFrom") LocalDateTime dateFrom,
+            @Param("dateTo") LocalDateTime dateTo,
+            @Param("cursor") LocalDateTime cursor,
+            Pageable pageable
+    );
+
     // 현재 시간 기준 이틀 이내인지 확인 ( 기준의 Hot News 요청을 위한 쿼리 메소드 )
     // publishedAt 으로 찾고 After -> 이후에 내림차순으로.
     Page<Article> findByPublishedAtAfterOrderByViewCountDesc(LocalDateTime from, Pageable pageable);

--- a/src/main/java/com/example/globalTimes_be/domain/article/service/ExploreService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/article/service/ExploreService.java
@@ -1,0 +1,73 @@
+package com.example.globalTimes_be.domain.article.service;
+
+import com.example.globalTimes_be.domain.article.dto.ArticleResponseDto;
+import com.example.globalTimes_be.domain.article.dto.CursorArticleResponseDto;
+import com.example.globalTimes_be.domain.article.entity.Article;
+import com.example.globalTimes_be.domain.article.repository.ArticleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class ExploreService {
+
+    private final ArticleRepository articleRepository;
+
+    @Transactional(readOnly = true)
+    public CursorArticleResponseDto explore(
+            String country,
+            String category,
+            String date,
+            String cursorStr,
+            int size
+    ) {
+        LocalDateTime dateFrom = null;
+        LocalDateTime dateTo = null;
+        if (date != null && !date.isBlank()) {
+            try {
+                LocalDate localDate = LocalDate.parse(date);
+                dateFrom = localDate.atStartOfDay();
+                dateTo = localDate.atTime(LocalTime.MAX);
+            } catch (DateTimeParseException ignored) {
+            }
+        }
+
+        LocalDateTime cursor = null;
+        if (cursorStr != null && !cursorStr.isBlank()) {
+            try {
+                cursor = LocalDateTime.parse(cursorStr);
+            } catch (DateTimeParseException ignored) {
+            }
+        }
+
+        String countryParam = (country != null && !country.isBlank()) ? country : null;
+        String categoryParam = (category != null && !category.isBlank()) ? category : null;
+
+        List<Article> fetched = articleRepository.findByExploreFilters(
+                countryParam, categoryParam, dateFrom, dateTo, cursor,
+                PageRequest.of(0, size + 1)
+        );
+
+        boolean hasNext = fetched.size() > size;
+        List<Article> articles = hasNext ? fetched.subList(0, size) : fetched;
+
+        String nextCursor = null;
+        if (hasNext && !articles.isEmpty()) {
+            nextCursor = articles.get(articles.size() - 1).getPublishedAt().toString();
+        }
+
+        List<ArticleResponseDto> dtos = articles.stream()
+                .map(ArticleResponseDto::fromEntity)
+                .toList();
+
+        return new CursorArticleResponseDto(dtos, nextCursor, hasNext);
+    }
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #89

## 🧭 변경 타입
- [x] ✨ 기능 추가 (FEAT)

## 📝 작업 내용
- 검색(FULLTEXT)과 별개로 국가·카테고리·날짜 조건을 조합해 기사를 탐색하는 `GET /api/articles/explore` API 구현
- 신규 파일: `ExploreController`, `ExploreControllerDocs`, `ExploreService`
- `ArticleRepository`에 `findByExploreFilters` 커서 기반 동적 필터 쿼리 추가
- 기존 `ArticleResponseDto`, `CursorArticleResponseDto` 재활용

**지원 파라미터 (전부 선택값):**

| 파라미터 | 설명 | 예시 |
|----------|------|------|
| `country` | 국가 코드 | `kr`, `us`, `jp` |
| `category` | 카테고리 | `sports`, `business`, `technology` |
| `date` | 날짜 (yyyy-MM-dd) | `2026-03-27` |
| `cursor` | 커서 (이전 응답 nextCursor) | `2026-03-27T08:00:00` |
| `size` | 페이지 크기 (기본 20) | `20` |

## 🔍 기술적 배경
- `ArticleRepository.findByFilters`(관리자용 오프셋)와 별개로, 탐색 전용 커서 기반 쿼리 `findByExploreFilters` 추가
- 모든 파라미터를 nullable로 처리해 조건 없을 시 전체 기사 탐색 가능
- `date` 파라미터는 서비스 레이어에서 해당 날짜 00:00 ~ 23:59:59 범위로 변환
- 현재 국가당 언론사가 1개씩이라 언론사 필터는 포함하지 않음 → 국가당 다수 언론사가 수집되는 시점에 `source` 파라미터 추가 확장 예정

## 🧪 테스트/검증 (필수)
- [x] `GET /api/articles/explore` 파라미터 없이 호출 → 전체 기사 최신순 반환 확인
- [x] `country=kr&category=sports` 조합 필터 응답 확인
- [x] `date=2026-03-27` 단독 호출 → 해당 날짜 기사만 반환 확인
- [x] `cursor` 값으로 다음 페이지 탐색 확인
- [x] Swagger UI(`/swagger-ui.html`)에서 엔드포인트 노출 확인

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?

## ➕ 추후 계획 (선택)
- 국가당 수집 언론사가 다양해지는 시점에 `source` 파라미터 추가 (언론사 필터링)
지금은 RSS 기반 수집하는 언론사가 나라별 1개로 제한해 놓음. 

- `language` 파라미터 추가 검토 (현재는 country로 언어 구분 가능)
같은 국가(de)에 다국어 기사가 섞여 있음. 
그래서 language 필터가 의미 있는 경우가 있긴 한데, FE 입장에서 사용자가 굳이 언어까지 선택할 일이 있을지는 의문.

E.G ) de 독일의 경우 독일어와 영어 피드로 가져오는 것 같이 이런 케이스가 존재하기 때문임. 