### PR TITLE
✨ [FEAT/#93] 트렌드 기사 요약 결과 Redis 캐싱 적용 [ 추후 Cache Hit / Miss 관련 테스트 필요, 빌드는 문제 없음 ]

### DIFF
--- a/src/main/java/com/example/globalTimes_be/domain/trend/controller/TrendAiController.java
+++ b/src/main/java/com/example/globalTimes_be/domain/trend/controller/TrendAiController.java
@@ -27,7 +27,7 @@ public class TrendAiController implements TrendAiControllerDocs{
         //본문 크롤링
         String content = trendCrawledService.getArticleCrawledContent(url);
         //크롤링한 본문 요약
-        String summary = trendAiService.summarizeTrendArticle(content, language);
+        String summary = trendAiService.summarizeTrendArticle(content, language, url);
         return ApiResponse.success(GlobalSuccessStatus._OK.getResponse(), summary);
     }
 }

--- a/src/main/java/com/example/globalTimes_be/domain/trend/service/TrendAiService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/trend/service/TrendAiService.java
@@ -2,27 +2,77 @@ package com.example.globalTimes_be.domain.trend.service;
 
 import com.example.globalTimes_be.domain.trend.exception.TrendErrorStatus;
 import com.example.globalTimes_be.global.exception.BaseException;
+import com.example.globalTimes_be.global.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class TrendAiService {
-    private final WebClient openAiWebClient;
 
-    public String summarizeTrendArticle (String content, String language) {
+    private static final String CACHE_KEY_PREFIX = "trend:summary:";
+
+    private final WebClient openAiWebClient;
+    private final RedisUtil redisUtil;
+
+    @Value("${trend.summary-cache-ttl-seconds:21600}")
+    private long cacheTtlSeconds;
+
+    public String summarizeTrendArticle(String content, String language, String url) {
+        if (cacheTtlSeconds > 0 && url != null) {
+            String cacheKey = CACHE_KEY_PREFIX + hashUrl(url) + ":" + language;
+            try {
+                String cached = redisUtil.getData(cacheKey);
+                if (cached != null) {
+                    log.debug("[트렌드 요약] 캐시 히트 url={}", url);
+                    return cached;
+                }
+            } catch (Exception e) {
+                log.warn("[트렌드 요약] 캐시 조회 실패, GPT 호출: {}", e.getMessage());
+            }
+
+            String summary = callGpt(content, language);
+
+            try {
+                redisUtil.setData(cacheKey, summary, cacheTtlSeconds);
+            } catch (Exception e) {
+                log.warn("[트렌드 요약] 캐시 저장 실패 (무시): {}", e.getMessage());
+            }
+            return summary;
+        }
+
+        return callGpt(content, language);
+    }
+
+    private String callGpt(String content, String language) {
         String summary = openAiWebClient.post()
                 .uri("/chat/completions")
-                .bodyValue(createRequestBody(content, language))  // 요청 본문
+                .bodyValue(createRequestBody(content, language))
                 .retrieve()
-                .bodyToMono(Map.class)  // 전체 응답을 한 번에 받음
-                .map(response -> extractContent(response))  // 응답 본문에서 요약 내용 추출
+                .bodyToMono(Map.class)
+                .map(response -> extractContent(response))
                 .block();
         return summary;
+    }
+
+    private String hashUrl(String url) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(url.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash).substring(0, 16);
+        } catch (Exception e) {
+            return String.valueOf(url.hashCode());
+        }
     }
 
     // OpenAI 요청 본문 생성 (기사 요약)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,3 +41,7 @@ news-fetch:
 # 국가별 시각 비교 API: Redis 캐시 (0이면 미사용, 동일 articleId 반복 요청 시 FULLTEXT 부하 감소)
 perspectives:
   cache-ttl-seconds: 3600
+
+# 트렌드 기사 요약 캐시 (0이면 미사용, 동일 URL 반복 요청 시 GPT 호출 절감)
+trend:
+  summary-cache-ttl-seconds: 21600


### PR DESCRIPTION
## 🚀 관련 이슈
- Related #93

## 🧭 변경 타입
- [x] ✨ 기능 추가 (FEAT)

## 📝 작업 내용
- `TrendAiService.summarizeTrendArticle`에 URL 기준 Redis read-through 캐시 적용

Redis의 Read-Through 패턴 ?
DB 를 직접적으로 탐색하는 것이 아닌, 캐시 ( Redis ) 에게 모든 데이터 조회를 맡기는 패턴
Cache Hit : 즉시 반환 
Cache Miss : DB 탐색 해서 해당 메소드 안에 명시된 SQL 조회 로직 동작

-> Read-Through 패턴 아님 ( 주의 )
Read Through 는 캐시 뒤에 DB가 있어 미스시 DB를 탐색한다. 

지금의 데이터 계층 : Google Rss Trends 는 아예 분리해서 Redis 에서만 관리하기에
 Cache-Aside(Lazy Loading) 패턴에 가까움. Miss 시 새로 가져와서 캐시에 저장하는 형태. 

- 동일 URL + 언어 조합 재요청 시 GPT 호출 없이 캐시에서 응답

- `application.yml`에 `trend.summary-cache-ttl-seconds` 설정 추가 (기본 6시간, 0이면 미사용)
서비스 로직에서 yml 설정값을 가져옴 (@Value 바인딩)

- Redis 장애 시 기존 GPT 호출 방식으로 degrade 

**Redis 키 구조:**
`trend:summary:{URL SHA-256 해시 앞 16자리}:{language}`

## 🔍 기술적 배경
- URL을 Redis 키로 직접 사용하면 길이 초과 및 `/`, `?`, `&` 등 특수문자로 인한 파싱 문제 발생 가능
  → URL을 SHA-256으로 해싱해 16자리 고정 길이 키로 변환하여 안전하게 저장
- `@Value("${trend.summary-cache-ttl-seconds:21600}")` 방식으로 yml 설정값을 서비스에 주입
  → 서비스마다 TTL을 독립적으로 yml에서 관리 가능 (perspectives, trend 등 각각 다른 TTL)
- Redis 장애(완전 다운) 시: 캐시 조회/저장 모두 불가하므로 key:value 저장 없이 GPT를 직접 호출해 응답 반환
  → 사용자 입장에서는 평소보다 느릴 수 있지만 서비스는 정상 동작

## 🧪 테스트/검증 (필수)
- [ ] **캐시 미스**: 새로운 URL로 첫 요청 → GPT 호출 후 응답, 로그에 캐시 저장 확인
- [ ] **캐시 히트**: 동일 URL로 재요청 → 로그에 `[트렌드 요약] 캐시 히트` 출력, GPT 미호출 확인
- [ ] **degrade 확인**: Redis 중단 후 요청 → `[트렌드 요약] 캐시 조회 실패` 로그 출력 후 GPT 정상 응답
- [ ] TTL 0 설정 시 캐시 미사용, 매 요청마다 GPT 호출 확인

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [ ] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?

## 💬 리뷰 요구사항 (선택)
- Redis 완전 장애 시 캐시 저장이 불가하므로 해당 요청은 GPT 직접 호출로 응답
  장애 복구 이후 동일 URL 재요청 시 다시 캐싱이 시작되는 구조.

## ➕ 추후 계획 (선택)
트렌드 요약 → Redis만으로 충분 (트렌드는 휘발성, DB 저장 불필요)

 대상 | 방식 | TTL | 상태 |
|------|------|-----|------|
| 실시간 트렌드 키워드 | Redis | 48h 10m | ✅ 완료 |
| 번역 결과 | Redis | 24h | ✅ 완료 |
| Perspectives(국가별 관점) | Redis | 1h | ✅ 완료 |
| 트렌드 기사 요약 | Redis Cache-Aside | 6h | ✅ 이번 PR |
| `crawledContent` (크롤링 원문) | MySQL 영속 | - | ✅ 완료 |
| `summary` (기사 상세 GPT 요약) | 미구현 | - | ❌ 추후 이슈 |