### PR TITLE
♻️ [REFACTOR/#95] 기사 상세 GPT 요약 결과 Article.summary DB 영속 저장

### DIFF
--- a/src/main/java/com/example/globalTimes_be/domain/ai/controller/AiController.java
+++ b/src/main/java/com/example/globalTimes_be/domain/ai/controller/AiController.java
@@ -26,6 +26,12 @@ public class AiController implements AiControllerDocs {
     @GetMapping(value = "/{id}/summary")
     public ResponseEntity<ApiResponse> summarizeArticle(@PathVariable Long id,
                                                         @RequestParam(defaultValue = "영어") String language) {
+        // DB에 저장된 요약이 있으면 GPT 스킵
+        String saved = detailService.getArticleSummary(id, language);
+        if (saved != null && !saved.isBlank()) {
+            return ApiResponse.success(GlobalSuccessStatus._OK.getResponse(), saved);
+        }
+
         String crawledContent = detailService.getArticleCrawledContent(id);
 
         if (crawledContent == null) {
@@ -34,6 +40,10 @@ public class AiController implements AiControllerDocs {
         }
 
         String summary = aiService.summarizeArticle(crawledContent, language);
+
+        // 요약 결과 DB 저장 (이후 재요청 시 GPT 스킵)
+        detailService.saveArticleSummary(id, summary);
+
         return ApiResponse.success(GlobalSuccessStatus._OK.getResponse(), summary);
     }
 

--- a/src/main/java/com/example/globalTimes_be/domain/article/entity/Article.java
+++ b/src/main/java/com/example/globalTimes_be/domain/article/entity/Article.java
@@ -130,6 +130,11 @@ public class Article {
         this.crawledContent = crawledContent;
     }
 
+    // GPT 요약 결과 저장
+    public void updateSummary(String summary) {
+        this.summary = summary;
+    }
+
     // get/{id} 와 같이 특정 뉴스 조회시 viewCount 증가
     public void increaseViewCount() {
         this.viewCount++;

--- a/src/main/java/com/example/globalTimes_be/domain/detail/service/DetailService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/detail/service/DetailService.java
@@ -66,6 +66,24 @@ public class DetailService {
         return article.getContent();
     }
 
+    // DB에 저장된 요약 조회 (없으면 null 반환)
+    public String getArticleSummary(Long id, String language) {
+        Article article = articleRepository.findById(id)
+                .orElseThrow(() -> new BaseException(DetailErrorStatus._EMPTY_NEWS_DATA.getResponse()));
+
+        return article.getSummary();
+    }
+
+    // GPT 요약 결과를 DB에 저장
+    @org.springframework.transaction.annotation.Transactional
+    public void saveArticleSummary(Long id, String summary) {
+        Article article = articleRepository.findById(id)
+                .orElseThrow(() -> new BaseException(DetailErrorStatus._EMPTY_NEWS_DATA.getResponse()));
+
+        article.updateSummary(summary);
+        articleRepository.save(article);
+    }
+
     // @Transactional 제거: 크롤링(네트워크 I/O)을 트랜잭션 밖에서 실행해 DB 커넥션 점유 시간 최소화
     public String getArticleCrawledContent(Long id) {
         Article article = articleRepository.findById(id)


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #95

## 🧭 변경 타입
- [x] ♻️ 리팩토링 (REFACTOR)

## 📝 작업 내용
- `Article`에 `updateSummary` 메서드 추가
- `DetailService`에 `getArticleSummary`, `saveArticleSummary` 메서드 추가
- `AiController.summarizeArticle`에 DB summary 조회/저장 로직 추가
  - DB에 요약 있으면 GPT 스킵 후 바로 반환
  - 없으면 크롤링 → GPT 호출 → DB 저장 → 반환
- SSE 스트리밍(`/summary/sse`, `/ask`)은 실시간 전송 특성상 캐싱 제외 ( 완성 시점이 어려움 ) 

**프로젝트 전체 캐싱/영속성 진척 현황:**

| 대상 | 방식 | 상태 |
|------|------|------|
| 실시간 트렌드 키워드 | Redis (48h TTL) | ✅ 완료 |
| 번역 결과 | Redis (24h TTL) | ✅ 완료 |
| Perspectives 국가별 관점 | Redis (1h TTL) | ✅ 완료 |
| 트렌드 기사 요약 | Redis Cache-Aside (6h TTL) | ✅ 완료 |
| `crawledContent` 크롤링 원문 | MySQL 영속 | ✅ 완료 |
| `summary` 기사 상세 GPT 요약 | MySQL 영속 | ✅ 이번 PR |


## 📝 SSE 스트리밍 관련 ) 

기존의 HTTP 요청 : 요청에 대한 응답을 받을때까지 기다려야 하기에 대기 시간이 길어지면 체감 대기가 길게 됨
SSE ( Server-Sent-Event ) : 토큰을 생성하는 즉시, FE 로 전송해서 실시간 타이핑 하는 것처럼 보이게 됨 ( 실시간 랜더링 ) 

## 🔍 기술적 배경
- `crawledContent`와 동일한 패턴으로 최초 1회 GPT 호출 후 DB 저장, 이후 재요청 시 DB에서 반환
- SSE는 GPT 토큰 생성 즉시 FE로 청크를 흘려보내는 실시간 스트리밍 방식이라 완성 시점 파악이 복잡해 캐싱에서 제외
  - 동기 `/summary` API에서 저장된 결과는 SSE와 별개로 동작

## 🧪 테스트/검증 (필수)
- [ ] 동일 기사 id로 `/summary` 두 번 호출 시 두 번째 응답에서 GPT 미호출 확인
- [ ] DB `article` 테이블 `summary` 컬럼에 요약 결과 저장 확인

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?