### PR TITLE
✨ [FEAT/#97] Google OAuth2 + JWT 로그인 구현 ( 질의 프롬프트는 별개의 이슈로 분리 구현 예정 ) 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,4 +11,15 @@ NEWS_API_KEY=your_news_api_key
 OPENAI_API_KEY=your_openai_api_key
 GOOGLE_API_KEY=your_google_api_key
 
-# Example을 따라 직접 환경 변수 파일 만들어서 테스트 할 것. 
+# OAuth2 - Google (https://console.cloud.google.com 에서 발급)
+# 승인된 리다이렉트 URI: http://localhost:8080/login/oauth2/code/google
+GOOGLE_OAUTH_CLIENT_ID=your_google_oauth_client_id
+GOOGLE_OAUTH_CLIENT_SECRET=your_google_oauth_client_secret
+
+# JWT 서명 키 (32자 이상 랜덤 문자열 권장)
+JWT_SECRET=your_jwt_secret_key_must_be_at_least_32_characters
+
+# OAuth2 로그인 성공 후 FE 리다이렉트 URI
+OAUTH2_REDIRECT_URI=http://localhost:5173/oauth2/redirect
+
+# Example을 따라 직접 환경 변수 파일 만들어서 테스트 할 것.

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,15 @@ dependencies {
 	//google translate
 	implementation 'com.google.cloud:google-cloud-translate:2.32.0'
 
+	//security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	//jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
 	//test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/example/globalTimes_be/domain/user/controller/AuthController.java
+++ b/src/main/java/com/example/globalTimes_be/domain/user/controller/AuthController.java
@@ -1,0 +1,30 @@
+package com.example.globalTimes_be.domain.user.controller;
+
+import com.example.globalTimes_be.domain.user.dto.UserResDTO;
+import com.example.globalTimes_be.domain.user.entity.User;
+import com.example.globalTimes_be.domain.user.repository.UserRepository;
+import com.example.globalTimes_be.global.apiPayload.code.ApiResponse;
+import com.example.globalTimes_be.global.apiPayload.code.status.GlobalSuccessStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+public class AuthController implements AuthControllerDocs {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse> getMe(Authentication authentication) {
+        Long userId = (Long) authentication.getPrincipal();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalStateException("존재하지 않는 사용자입니다."));
+        return ApiResponse.success(GlobalSuccessStatus._OK.getResponse(), UserResDTO.from(user));
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/domain/user/controller/AuthControllerDocs.java
+++ b/src/main/java/com/example/globalTimes_be/domain/user/controller/AuthControllerDocs.java
@@ -1,0 +1,44 @@
+package com.example.globalTimes_be.domain.user.controller;
+
+import com.example.globalTimes_be.global.apiPayload.code.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+
+@Tag(name = "Auth", description = "OAuth2 로그인 및 사용자 정보 API")
+public interface AuthControllerDocs {
+
+    @Operation(
+            summary = "내 정보 조회",
+            description = "JWT 토큰으로 로그인한 사용자의 정보를 조회합니다. Authorization 헤더에 `Bearer {token}`을 포함해야 합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(examples = @ExampleObject(value = """
+                            {
+                              "isSuccess": true,
+                              "message": "성공",
+                              "data": {
+                                "userId": 1,
+                                "email": "user@example.com",
+                                "nickname": "홍길동",
+                                "provider": "kakao"
+                              }
+                            }
+                            """))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")
+    })
+    ResponseEntity<ApiResponse> getMe(
+            @Parameter(hidden = true) Authentication authentication
+    );
+}

--- a/src/main/java/com/example/globalTimes_be/domain/user/dto/UserResDTO.java
+++ b/src/main/java/com/example/globalTimes_be/domain/user/dto/UserResDTO.java
@@ -1,0 +1,24 @@
+package com.example.globalTimes_be.domain.user.dto;
+
+import com.example.globalTimes_be.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserResDTO {
+
+    private Long userId;
+    private String email;
+    private String nickname;
+    private String provider;
+
+    public static UserResDTO from(User user) {
+        return UserResDTO.builder()
+                .userId(user.getId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .provider(user.getProvider())
+                .build();
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/domain/user/entity/User.java
+++ b/src/main/java/com/example/globalTimes_be/domain/user/entity/User.java
@@ -1,0 +1,49 @@
+package com.example.globalTimes_be.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
+    private String provider; // "kakao", "google"
+
+    @Column(name = "provider_id", nullable = false)
+    private String providerId;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    public static User create(String email, String nickname, String provider, String providerId) {
+        return User.builder()
+                .email(email)
+                .nickname(nickname)
+                .provider(provider)
+                .providerId(providerId)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/globalTimes_be/domain/user/repository/UserRepository.java
@@ -1,0 +1,15 @@
+package com.example.globalTimes_be.domain.user.repository;
+
+import com.example.globalTimes_be.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByProviderAndProviderId(String provider, String providerId);
+
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/example/globalTimes_be/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/globalTimes_be/global/config/SecurityConfig.java
@@ -1,0 +1,81 @@
+package com.example.globalTimes_be.global.config;
+
+import com.example.globalTimes_be.global.security.JwtAuthenticationFilter;
+import com.example.globalTimes_be.global.security.JwtUtil;
+import com.example.globalTimes_be.global.security.oauth2.CustomOAuth2UserService;
+import com.example.globalTimes_be.global.security.oauth2.OAuth2SuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtUtil jwtUtil;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        // 인증 불필요 (기존 API 전체 허용)
+                        .requestMatchers(
+                                "/api/**",
+                                "/oauth2/**",
+                                "/login/**",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/error"
+                        ).permitAll()
+                        // 사용자 정보 조회/히스토리 관련은 인증 필요
+                        .requestMatchers("/api/user/**").authenticated()
+                        .anyRequest().permitAll()
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService))
+                        .successHandler(oAuth2SuccessHandler)
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of(
+                "https://global-times.netlify.app",
+                "https://globaltimes.store",
+                "https://www.globaltimes.store",
+                "http://localhost:5173",
+                "http://localhost:3000"
+        ));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/globalTimes_be/global/config/SwaggerConfig.java
@@ -2,15 +2,23 @@ package com.example.globalTimes_be.global.config;
 
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Contact;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.servers.Server;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT"
+)
 @OpenAPIDefinition(
         info = @Info(
                 title = "GlobalTimes API 명세서",

--- a/src/main/java/com/example/globalTimes_be/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/globalTimes_be/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,51 @@
+package com.example.globalTimes_be.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = extractToken(request);
+
+        if (StringUtils.hasText(token) && jwtUtil.validate(token)) {
+            Long userId = jwtUtil.getUserId(token);
+            String email = jwtUtil.getEmail(token);
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userId, null, Collections.emptyList());
+            authentication.setDetails(email);
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.debug("[JWT] 인증 성공 - userId: {}", userId);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearer) && bearer.startsWith("Bearer ")) {
+            return bearer.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/global/security/JwtUtil.java
+++ b/src/main/java/com/example/globalTimes_be/global/security/JwtUtil.java
@@ -1,0 +1,63 @@
+package com.example.globalTimes_be.global.security;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtUtil {
+
+    private final SecretKey secretKey;
+    private final long expirationMs;
+
+    public JwtUtil(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.expiration-ms:604800000}") long expirationMs
+    ) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expirationMs = expirationMs;
+    }
+
+    public String generateToken(Long userId, String email) {
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("email", email)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expirationMs))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public Long getUserId(String token) {
+        return Long.parseLong(getClaims(token).getSubject());
+    }
+
+    public String getEmail(String token) {
+        return getClaims(token).get("email", String.class);
+    }
+
+    public boolean validate(String token) {
+        try {
+            getClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn("[JWT] 유효하지 않은 토큰: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/global/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/globalTimes_be/global/security/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,66 @@
+package com.example.globalTimes_be.global.security.oauth2;
+
+import com.example.globalTimes_be.domain.user.entity.User;
+import com.example.globalTimes_be.domain.user.repository.UserRepository;
+import com.example.globalTimes_be.global.security.oauth2.userinfo.GoogleOAuth2UserInfo;
+import com.example.globalTimes_be.global.security.oauth2.userinfo.OAuth2UserInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        String provider = userRequest.getClientRegistration().getRegistrationId(); // "google"
+        OAuth2UserInfo userInfo = resolveUserInfo(provider, oAuth2User.getAttributes());
+
+        User user = saveOrUpdate(provider, userInfo);
+
+        Map<String, Object> attributes = new HashMap<>(oAuth2User.getAttributes());
+        attributes.put("userId", user.getId());
+        attributes.put("email", user.getEmail());
+
+        return new DefaultOAuth2User(
+                Collections.emptyList(),
+                attributes,
+                "sub"
+        );
+    }
+
+    private OAuth2UserInfo resolveUserInfo(String provider, Map<String, Object> attributes) {
+        return switch (provider) {
+            case "google" -> new GoogleOAuth2UserInfo(attributes);
+            default -> throw new OAuth2AuthenticationException("지원하지 않는 OAuth2 provider: " + provider);
+        };
+    }
+
+    private User saveOrUpdate(String provider, OAuth2UserInfo userInfo) {
+        return userRepository.findByProviderAndProviderId(provider, userInfo.getProviderId())
+                .map(existing -> {
+                    existing.updateNickname(userInfo.getNickname());
+                    return existing;
+                })
+                .orElseGet(() -> userRepository.save(
+                        User.create(userInfo.getEmail(), userInfo.getNickname(), provider, userInfo.getProviderId())
+                ));
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/global/security/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/example/globalTimes_be/global/security/oauth2/OAuth2SuccessHandler.java
@@ -1,0 +1,40 @@
+package com.example.globalTimes_be.global.security.oauth2;
+
+import com.example.globalTimes_be.global.security.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtUtil jwtUtil;
+
+    @Value("${oauth2.redirect-uri:http://localhost:3000/oauth2/redirect}")
+    private String redirectUri;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+
+        Long userId = (Long) oAuth2User.getAttributes().get("userId");
+        String email = (String) oAuth2User.getAttributes().get("email");
+
+        String token = jwtUtil.generateToken(userId, email);
+        log.info("[OAuth2] 로그인 성공 - userId: {}, email: {}", userId, email);
+
+        getRedirectStrategy().sendRedirect(request, response, redirectUri + "?token=" + token);
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/global/security/oauth2/userinfo/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/example/globalTimes_be/global/security/oauth2/userinfo/GoogleOAuth2UserInfo.java
@@ -1,0 +1,29 @@
+package com.example.globalTimes_be.global.security.oauth2.userinfo;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo implements OAuth2UserInfo {
+
+    private final Map<String, Object> attributes;
+
+    public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getProviderId() {
+        return String.valueOf(attributes.get("sub"));
+    }
+
+    @Override
+    public String getEmail() {
+        Object email = attributes.get("email");
+        return email != null ? String.valueOf(email) : "";
+    }
+
+    @Override
+    public String getNickname() {
+        Object name = attributes.get("name");
+        return name != null ? String.valueOf(name) : "사용자";
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/global/security/oauth2/userinfo/OAuth2UserInfo.java
+++ b/src/main/java/com/example/globalTimes_be/global/security/oauth2/userinfo/OAuth2UserInfo.java
@@ -1,0 +1,10 @@
+package com.example.globalTimes_be.global.security.oauth2.userinfo;
+
+public interface OAuth2UserInfo {
+
+    String getProviderId();
+
+    String getEmail();
+
+    String getNickname();
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,16 @@ spring:
     hibernate:
       ddl-auto: update
 
+  # OAuth2 소셜 로그인 (Google)
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_OAUTH_CLIENT_ID}
+            client-secret: ${GOOGLE_OAUTH_CLIENT_SECRET}
+            scope: profile, email
+
   #gpt
   openai:
     api-key: ${OPENAI_API_KEY}
@@ -31,6 +41,15 @@ spring:
   #google translate
   google:
     api-key: ${GOOGLE_API_KEY}
+
+# JWT 설정
+jwt:
+  secret: ${JWT_SECRET}
+  expiration-ms: 604800000  # 7일 (ms)
+
+# OAuth2 로그인 후 FE 리다이렉트 URI
+oauth2:
+  redirect-uri: ${OAUTH2_REDIRECT_URI:http://localhost:5173/oauth2/redirect}
 
 # 뉴스 수집 활성화 여부
 # false(기본): 로컬 개발 중 API 할당량 절약 목적으로 @PostConstruct/스케줄러 비활성화


### PR DESCRIPTION
## ✨ [FEAT/#97] Google OAuth2 + JWT 로그인 구현

### 📌 관련 이슈
Close #97
> 기존 #97 이슈에서 로그인 구현 부분만 먼저 반영.
> GPT 질의 히스토리 저장/조회는 별도 이슈로 분리 예정.

---

### 📖 작업 배경

기사별 GPT 질의 히스토리를 사용자별로 저장/조회하려면 **사용자를 식별할 수 있는 인증 체계**가 선행되어야 함.
프로젝트가 다국가 기사를 다루는 글로벌 서비스인 만큼, 전 세계 사용자가 계정을 보유한 **Google OAuth2** 를 채택. (카카오 / 네이버 제외)

---

### 🔄 FE ↔ BE 전체 플로우

```
① [FE]              로그인 버튼 클릭
                     → GET /oauth2/authorization/google

② [Spring Security] 구글 인증 서버로 리다이렉트
                     → https://accounts.google.com/o/oauth2/auth?...

③ [Google]          사용자 계정 선택 + 동의
                     → 콜백 URI로 Authorization Code 전달

④ [Spring Security] Authorization Code → Access Token 교환 (내부 자동 처리)
                     → CustomOAuth2UserService.loadUser() 호출

⑤ [BE]              Google 사용자 정보 수신 (email, name, sub)
                     → DB에 User upsert (신규 가입 or 닉네임 업데이트)

⑥ [BE]              OAuth2SuccessHandler → JWT 발급
                     → FE 리다이렉트: {OAUTH2_REDIRECT_URI}?token=eyJhbGci...

⑦ [FE]              토큰 수신 → localStorage 저장
                     → 이후 모든 API 요청 헤더: Authorization: Bearer {token}

⑧ [BE]              JwtAuthenticationFilter → 요청마다 토큰 검증
                     → SecurityContext에 userId 주입

⑨ [FE]              GET /api/user/me → 로그인 사용자 정보 확인
```

---

### 🗂 추가된 파일

| 파일 | 설명 |
|---|---|
| `domain/user/entity/User.java` | users 테이블 엔티티 (id, email, nickname, provider, providerId) |
| `domain/user/repository/UserRepository.java` | provider + providerId 기반 사용자 조회 |
| `domain/user/dto/UserResDTO.java` | 사용자 정보 응답 DTO |
| `domain/user/controller/AuthController.java` | `GET /api/user/me` 내 정보 조회 엔드포인트 |
| `global/security/JwtUtil.java` | JWT 발급 / 검증 유틸 (jjwt 0.12.x) |
| `global/security/JwtAuthenticationFilter.java` | Authorization 헤더 파싱 → SecurityContext 주입 |
| `global/security/oauth2/CustomOAuth2UserService.java` | OAuth2 사용자 로드 + DB upsert 처리 |
| `global/security/oauth2/OAuth2SuccessHandler.java` | 로그인 성공 시 JWT 발급 후 FE 리다이렉트 |
| `global/security/oauth2/userinfo/OAuth2UserInfo.java` | 공급자 추상화 인터페이스 (확장 대비) |
| `global/security/oauth2/userinfo/GoogleOAuth2UserInfo.java` | Google 사용자 정보 파싱 구현체 |
| `global/config/SecurityConfig.java` | Security 필터체인 / CORS / OAuth2 / JWT 필터 등록 |

### 🛠 수정된 파일

| 파일 | 변경 내용 |
|---|---|
| `build.gradle` | spring-boot-starter-security, oauth2-client, jjwt 의존성 추가 |
| `application.yml` | OAuth2 Google 설정, JWT expiration, 리다이렉트 URI 추가 / YAML 구조 오류 수정 |
| `global/config/SwaggerConfig.java` | `@SecurityScheme` 추가 → Swagger UI Authorize 버튼 활성화 |
| `.env.example` | GOOGLE_OAUTH_CLIENT_ID/SECRET, JWT_SECRET, OAUTH2_REDIRECT_URI 키 안내 추가 |

---

### 🧪 BE 단독 테스트 방법 (FE 없이)

> Google Cloud Console → 사용자 인증 정보 → OAuth 2.0 클라이언트 ID → 승인된 리다이렉트 URI에
> `http://localhost:8080/login/oauth2/code/google` 추가 필수

**Step 1. `.env` 키 세팅**
```properties
GOOGLE_OAUTH_CLIENT_ID=...      # Google Cloud Console에서 발급
GOOGLE_OAUTH_CLIENT_SECRET=...  # Google Cloud Console에서 발급
JWT_SECRET=minimum-32-characters-random-string
OAUTH2_REDIRECT_URI=http://localhost:8080/oauth2/redirect
```

**Step 2. 서버 실행 후 브라우저에서 직접 접속**
```
http://localhost:8080/oauth2/authorization/google
```
→ 구글 로그인 완료 후 주소창에서 `token` 값 복사

**Step 3. Swagger UI에서 토큰 인증 후 API 테스트**
```
http://localhost:8080/swagger-ui/index.html
```
→ 우상단 **[Authorize]** 버튼 클릭 → `Bearer {복사한 token}` 입력 → `GET /api/user/me` 실행

**Step 4. 응답 결과 확인**
```json
{
  "isSuccess": true,
  "message": "응답에 성공했습니다.",
  "data": {
    "userId": 1,
    "email": "user@gmail.com",
    "nickname": "홍길동",
    "provider": "google"
  }
}
```

---

### 💡 JWT 동작 원리 요약

| 단계 | 설명 |
|---|---|
| **발급** | `userId + email` → HMAC-SHA256(secret) 서명 → Base64 인코딩 → token 문자열 |
| **검증** | token → 서명 검증 → payload 추출 → userId → SecurityContext 주입 |
| **만료** | `expiration-ms: 604800000` (7일), 만료 시 재로그인 필요 |

> 세션이 서버에 저장되지 않는 **Stateless** 구조이므로, 서버 재시작 후에도 유효한 토큰이면 인증 유지됨.

---

### 🔜 다음 이슈 (분리 예정)
- `[FEAT] 기사별 GPT 질의 히스토리 저장/조회 API`

토큰은 정상 발급됐고 그 토큰을 받아서 저장해줄 FE 페이지가 없어서 에러 발생 ( 프론트 이슈 ) 
정상 작동함. 