### PR TITLE
✨ [FEAT/#99] 기사별 GPT 질의 히스토리 저장 및 조회 API 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,14 @@ LOCAL_MYSQL_PASSWORD=localpw
 
 # External APIs (개발용 키를 넣어 사용)
 NEWS_API_KEY=your_news_api_key
-OPENAI_API_KEY=your_openai_api_key
 GOOGLE_API_KEY=your_google_api_key
+
+# Gemini API (GPT 대체, 무료 티어: 일 1,500회 / 분 15회)
+# 발급: https://aistudio.google.com → Get API Key → Create API Key
+GEMINI_API_KEY=your_gemini_api_key
+
+# GPT (비활성 / 필요 시 복구)
+# OPENAI_API_KEY=your_openai_api_key
 
 # OAuth2 - Google (https://console.cloud.google.com 에서 발급)
 # 승인된 리다이렉트 URI: http://localhost:8080/login/oauth2/code/google

--- a/src/main/java/com/example/globalTimes_be/domain/ai/controller/AiController.java
+++ b/src/main/java/com/example/globalTimes_be/domain/ai/controller/AiController.java
@@ -11,6 +11,7 @@ import com.example.globalTimes_be.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -63,13 +64,17 @@ public class AiController implements AiControllerDocs {
     @Override
     @GetMapping(value = "/{id}/ask", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter askArticle(@PathVariable Long id,
-                                 @RequestParam String question) {
+                                 @RequestParam String question,
+                                 Authentication authentication) {
         String crawledContent = detailService.getArticleCrawledContent(id);
 
         if (crawledContent == null) {
             throw new BaseException(DetailErrorStatus._CRAWLER_ERROR.getResponse());
         }
 
-        return aiSseService.askGPT(crawledContent, question);
+        // 로그인 사용자면 userId 전달 → 스트리밍 완료 후 히스토리 저장
+        // 비로그인이면 null 전달 → 저장 생략 (기존 동작 유지)
+        Long userId = (authentication != null) ? (Long) authentication.getPrincipal() : null;
+        return aiSseService.askGPT(crawledContent, question, userId, id);
     }
 }

--- a/src/main/java/com/example/globalTimes_be/domain/ai/controller/AiControllerDocs.java
+++ b/src/main/java/com/example/globalTimes_be/domain/ai/controller/AiControllerDocs.java
@@ -13,6 +13,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -202,5 +203,7 @@ public interface AiControllerDocs {
             @Parameter(description = "사용자 질문", example = "기사에서 키워드를 뽑아줘.")
             @NotBlank(message = "질문은 비어있을 수 없습니다.")
             @Size(min = 1, message = "질문은 최소 1자 이상이어야 합니다.")
-            @RequestParam String question);
+            @RequestParam String question,
+
+            @Parameter(hidden = true) Authentication authentication);
 }

--- a/src/main/java/com/example/globalTimes_be/domain/ai/service/AiService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/ai/service/AiService.java
@@ -3,6 +3,7 @@ package com.example.globalTimes_be.domain.ai.service;
 import com.example.globalTimes_be.domain.detail.exception.DetailErrorStatus;
 import com.example.globalTimes_be.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -13,18 +14,19 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class AiService {
 
-    // ── Gemini (현재 활성) ──────────────────────────────────────────────────
+    // Gemini (?? ??)
     @Qualifier("geminiWebClient")
     private final WebClient geminiWebClient;
 
     @Value("${gemini.api-key}")
     private String geminiApiKey;
 
-    private static final String GEMINI_MODEL = "gemini-2.0-flash";
+    private static final String GEMINI_MODEL = "gemini-2.5-flash";
 
     public String summarizeArticle(String crawledContent, String language) {
         return geminiWebClient.post()
@@ -33,13 +35,18 @@ public class AiService {
                 .retrieve()
                 .onStatus(
                         status -> !status.is2xxSuccessful(),
-                        response -> Mono.error(new BaseException(DetailErrorStatus._GPT_ERROR.getResponse()))
+                        response -> response.bodyToMono(String.class)
+                                .doOnNext(body -> log.error("[Gemini] API ?? ??: {}", body))
+                                .then(Mono.error(new BaseException(DetailErrorStatus._GPT_ERROR.getResponse())))
                 )
                 .bodyToMono(Map.class)
                 .timeout(Duration.ofSeconds(30))
                 .onErrorMap(
                         ex -> !(ex instanceof BaseException),
-                        ex -> new BaseException(DetailErrorStatus._GPT_ERROR.getResponse())
+                        ex -> {
+                            log.error("[Gemini] ?? ??: {}", ex.getMessage());
+                            return new BaseException(DetailErrorStatus._GPT_ERROR.getResponse());
+                        }
                 )
                 .map(this::extractGeminiContent)
                 .block();
@@ -48,7 +55,7 @@ public class AiService {
     private Map<String, Object> createGeminiRequestBody(String crawledContent, String language) {
         return Map.of(
                 "system_instruction", Map.of(
-                        "parts", List.of(Map.of("text", "이 기사를 " + language + "로 요약해줘."))
+                        "parts", List.of(Map.of("text", "? ??? " + language + "? ????."))
                 ),
                 "contents", List.of(
                         Map.of("parts", List.of(Map.of("text", crawledContent)))
@@ -72,7 +79,7 @@ public class AiService {
     }
 
 
-    // ── GPT (비활성 / 주석 보존) ────────────────────────────────────────────
+    // GPT (??? / ?? ??)
     // private final WebClient openAiWebClient;
     //
     // public String summarizeArticle(String crawledContent, String language) {
@@ -98,7 +105,7 @@ public class AiService {
     //     return Map.of(
     //             "model", "gpt-4o-mini",
     //             "messages", List.of(
-    //                     Map.of("role", "system", "content", "이 기사를 " + language + "로 요약해줘."),
+    //                     Map.of("role", "system", "content", "? ??? " + language + "? ????."),
     //                     Map.of("role", "user", "content", crawledContent)
     //             ),
     //             "stream", false

--- a/src/main/java/com/example/globalTimes_be/domain/ai/service/AiService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/ai/service/AiService.java
@@ -3,6 +3,8 @@ package com.example.globalTimes_be.domain.ai.service;
 import com.example.globalTimes_be.domain.detail.exception.DetailErrorStatus;
 import com.example.globalTimes_be.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -14,46 +16,101 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Service
 public class AiService {
-    private final WebClient openAiWebClient;
+
+    // ── Gemini (현재 활성) ──────────────────────────────────────────────────
+    @Qualifier("geminiWebClient")
+    private final WebClient geminiWebClient;
+
+    @Value("${gemini.api-key}")
+    private String geminiApiKey;
+
+    private static final String GEMINI_MODEL = "gemini-2.0-flash";
 
     public String summarizeArticle(String crawledContent, String language) {
-        String summary = openAiWebClient.post()
-                .uri("/chat/completions")
-                .bodyValue(createRequestBody(crawledContent, language))
+        return geminiWebClient.post()
+                .uri("/v1beta/models/" + GEMINI_MODEL + ":generateContent?key=" + geminiApiKey)
+                .bodyValue(createGeminiRequestBody(crawledContent, language))
                 .retrieve()
                 .onStatus(
                         status -> !status.is2xxSuccessful(),
                         response -> Mono.error(new BaseException(DetailErrorStatus._GPT_ERROR.getResponse()))
                 )
                 .bodyToMono(Map.class)
-                .timeout(Duration.ofSeconds(10))
+                .timeout(Duration.ofSeconds(30))
                 .onErrorMap(
                         ex -> !(ex instanceof BaseException),
                         ex -> new BaseException(DetailErrorStatus._GPT_ERROR.getResponse())
                 )
-                .map(response -> extractContent(response))
+                .map(this::extractGeminiContent)
                 .block();
-
-        return summary;
     }
 
-    private Map<String, Object> createRequestBody(String crawledContent, String language) {
+    private Map<String, Object> createGeminiRequestBody(String crawledContent, String language) {
         return Map.of(
-                "model", "gpt-4o-mini",
-                "messages", List.of(
-                        Map.of("role", "system", "content", "이 기사를 " + language + "로 요약해줘."),
-                        Map.of("role", "user", "content", crawledContent)
+                "system_instruction", Map.of(
+                        "parts", List.of(Map.of("text", "이 기사를 " + language + "로 요약해줘."))
                 ),
-                "stream", false
+                "contents", List.of(
+                        Map.of("parts", List.of(Map.of("text", crawledContent)))
+                )
         );
     }
 
-    private String extractContent(Map<String, Object> response) {
-        List<Map<String, Object>> choices = (List<Map<String, Object>>) response.get("choices");
-        if (choices != null && !choices.isEmpty()) {
-            Map<String, Object> message = (Map<String, Object>) choices.get(0).get("message");
-            return (String) message.get("content");
+    @SuppressWarnings("unchecked")
+    private String extractGeminiContent(Map<String, Object> response) {
+        List<Map<String, Object>> candidates = (List<Map<String, Object>>) response.get("candidates");
+        if (candidates != null && !candidates.isEmpty()) {
+            Map<String, Object> content = (Map<String, Object>) candidates.get(0).get("content");
+            if (content != null) {
+                List<Map<String, Object>> parts = (List<Map<String, Object>>) content.get("parts");
+                if (parts != null && !parts.isEmpty()) {
+                    return (String) parts.get(0).get("text");
+                }
+            }
         }
         throw new BaseException(DetailErrorStatus._GPT_ERROR.getResponse());
     }
+
+
+    // ── GPT (비활성 / 주석 보존) ────────────────────────────────────────────
+    // private final WebClient openAiWebClient;
+    //
+    // public String summarizeArticle(String crawledContent, String language) {
+    //     return openAiWebClient.post()
+    //             .uri("/chat/completions")
+    //             .bodyValue(createGptRequestBody(crawledContent, language))
+    //             .retrieve()
+    //             .onStatus(
+    //                     status -> !status.is2xxSuccessful(),
+    //                     response -> Mono.error(new BaseException(DetailErrorStatus._GPT_ERROR.getResponse()))
+    //             )
+    //             .bodyToMono(Map.class)
+    //             .timeout(Duration.ofSeconds(10))
+    //             .onErrorMap(
+    //                     ex -> !(ex instanceof BaseException),
+    //                     ex -> new BaseException(DetailErrorStatus._GPT_ERROR.getResponse())
+    //             )
+    //             .map(response -> extractGptContent(response))
+    //             .block();
+    // }
+    //
+    // private Map<String, Object> createGptRequestBody(String crawledContent, String language) {
+    //     return Map.of(
+    //             "model", "gpt-4o-mini",
+    //             "messages", List.of(
+    //                     Map.of("role", "system", "content", "이 기사를 " + language + "로 요약해줘."),
+    //                     Map.of("role", "user", "content", crawledContent)
+    //             ),
+    //             "stream", false
+    //     );
+    // }
+    //
+    // private String extractGptContent(Map<String, Object> response) {
+    //     List<Map<String, Object>> choices = (List<Map<String, Object>>) response.get("choices");
+    //     if (choices != null && !choices.isEmpty()) {
+    //         Map<String, Object> message = (Map<String, Object>) choices.get(0).get("message");
+    //         return (String) message.get("content");
+    //     }
+    //     throw new BaseException(DetailErrorStatus._GPT_ERROR.getResponse());
+    // }
 }

--- a/src/main/java/com/example/globalTimes_be/domain/ai/service/AiSseService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/ai/service/AiSseService.java
@@ -1,5 +1,6 @@
 package com.example.globalTimes_be.domain.ai.service;
 
+import com.example.globalTimes_be.domain.chat.service.ChatHistoryService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,20 +18,24 @@ import java.util.Map;
 @Service
 public class AiSseService {
     private final WebClient openAiWebClient;
+    private final ChatHistoryService chatHistoryService;
 
     public SseEmitter summarizeContent(String crawledContent, String language) {
         SseEmitter emitter = new SseEmitter(10 * 60 * 1000L);
-        processStreamingRequest(emitter, createRequestBody(crawledContent, language));
+        processStreamingRequest(emitter, createRequestBody(crawledContent, language), null, null, null);
         return emitter;
     }
 
-    public SseEmitter askGPT(String crawledContent, String question) {
+    // 인증된 사용자: userId, articleId 전달 → 스트리밍 완료 후 히스토리 저장
+    // 비인증 사용자: userId = null → 저장 생략
+    public SseEmitter askGPT(String crawledContent, String question, Long userId, Long articleId) {
         SseEmitter emitter = new SseEmitter(10 * 60 * 1000L);
-        processStreamingRequest(emitter, createQuestionRequestBody(crawledContent, question));
+        processStreamingRequest(emitter, createQuestionRequestBody(crawledContent, question), question, userId, articleId);
         return emitter;
     }
 
-    private void processStreamingRequest(SseEmitter emitter, Map<String, Object> requestBody) {
+    private void processStreamingRequest(SseEmitter emitter, Map<String, Object> requestBody,
+                                         String question, Long userId, Long articleId) {
         StringBuilder resultBuilder = new StringBuilder();
 
         openAiWebClient.post()
@@ -43,6 +48,10 @@ public class AiSseService {
                     String jsonPart = data.trim();
 
                     if ("[DONE]".equals(jsonPart)) {
+                        // 스트리밍 완료 → 로그인 사용자면 히스토리 저장
+                        if (userId != null && articleId != null && question != null) {
+                            chatHistoryService.save(userId, articleId, question, resultBuilder.toString());
+                        }
                         emitter.complete();
                         return;
                     }

--- a/src/main/java/com/example/globalTimes_be/domain/ai/service/AiSseService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/ai/service/AiSseService.java
@@ -4,12 +4,13 @@ import com.example.globalTimes_be.domain.chat.service.ChatHistoryService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -17,91 +18,179 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Service
 public class AiSseService {
-    private final WebClient openAiWebClient;
+
+    // ── Gemini (현재 활성) ──────────────────────────────────────────────────
+    @Qualifier("geminiWebClient")
+    private final WebClient geminiWebClient;
+
+    @Value("${gemini.api-key}")
+    private String geminiApiKey;
+
+    private static final String GEMINI_MODEL = "gemini-2.0-flash";
+
     private final ChatHistoryService chatHistoryService;
 
     public SseEmitter summarizeContent(String crawledContent, String language) {
         SseEmitter emitter = new SseEmitter(10 * 60 * 1000L);
-        processStreamingRequest(emitter, createRequestBody(crawledContent, language), null, null, null);
+        Map<String, Object> body = createGeminiRequestBody(
+                "이 기사를 " + language + "로 요약해줘.",
+                crawledContent
+        );
+        processGeminiStreaming(emitter, body, null, null, null);
         return emitter;
     }
 
-    // 인증된 사용자: userId, articleId 전달 → 스트리밍 완료 후 히스토리 저장
-    // 비인증 사용자: userId = null → 저장 생략
     public SseEmitter askGPT(String crawledContent, String question, Long userId, Long articleId) {
         SseEmitter emitter = new SseEmitter(10 * 60 * 1000L);
-        processStreamingRequest(emitter, createQuestionRequestBody(crawledContent, question), question, userId, articleId);
+        Map<String, Object> body = createGeminiRequestBody(
+                "다음 기사 내용을 참고하여 사용자 질문에 자세하게 답변해줘.",
+                "기사 내용:\n" + crawledContent + "\n\n사용자 질문:\n" + question
+        );
+        processGeminiStreaming(emitter, body, question, userId, articleId);
         return emitter;
     }
 
-    private void processStreamingRequest(SseEmitter emitter, Map<String, Object> requestBody,
-                                         String question, Long userId, Long articleId) {
+    private Map<String, Object> createGeminiRequestBody(String systemPrompt, String userMessage) {
+        return Map.of(
+                "system_instruction", Map.of(
+                        "parts", List.of(Map.of("text", systemPrompt))
+                ),
+                "contents", List.of(
+                        Map.of("parts", List.of(Map.of("text", userMessage)))
+                )
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private void processGeminiStreaming(SseEmitter emitter, Map<String, Object> requestBody,
+                                        String question, Long userId, Long articleId) {
         StringBuilder resultBuilder = new StringBuilder();
 
-        openAiWebClient.post()
-                .uri("/chat/completions")
+        geminiWebClient.post()
+                .uri("/v1beta/models/" + GEMINI_MODEL + ":streamGenerateContent?alt=sse&key=" + geminiApiKey)
                 .accept(MediaType.TEXT_EVENT_STREAM)
                 .bodyValue(requestBody)
                 .retrieve()
                 .bodyToFlux(String.class)
                 .doOnNext(data -> {
                     String jsonPart = data.trim();
-
-                    if ("[DONE]".equals(jsonPart)) {
-                        // 스트리밍 완료 → 로그인 사용자면 히스토리 저장
-                        if (userId != null && articleId != null && question != null) {
-                            chatHistoryService.save(userId, articleId, question, resultBuilder.toString());
-                        }
-                        emitter.complete();
-                        return;
-                    }
+                    if (jsonPart.isEmpty()) return;
 
                     try {
-                        Map response = new ObjectMapper().readValue(jsonPart, Map.class);
+                        Map<String, Object> response = new ObjectMapper().readValue(jsonPart, Map.class);
+                        List<Map<String, Object>> candidates = (List<Map<String, Object>>) response.get("candidates");
+                        if (candidates == null || candidates.isEmpty()) return;
 
-                        List<Map<String, Object>> choices = (List<Map<String, Object>>) response.get("choices");
-                        if (choices != null && !choices.isEmpty()) {
-                            Map<String, Object> delta = (Map<String, Object>) choices.get(0).get("delta");
-                            if (delta != null && delta.containsKey("content")) {
-                                String contentText = (String) delta.get("content");
-                                resultBuilder.append(contentText);
+                        Map<String, Object> content = (Map<String, Object>) candidates.get(0).get("content");
+                        if (content == null) return;
 
-                                String currentText = resultBuilder.toString();
-                                emitter.send(currentText);
-                            }
+                        List<Map<String, Object>> parts = (List<Map<String, Object>>) content.get("parts");
+                        if (parts == null || parts.isEmpty()) return;
+
+                        String text = (String) parts.get(0).get("text");
+                        if (text != null) {
+                            resultBuilder.append(text);
+                            emitter.send(resultBuilder.toString());
                         }
-                    } catch (IOException e) {
-                        log.warn("JSON 파싱 오류 발생!", e);
-                        emitter.completeWithError(e);
+                    } catch (Exception e) {
+                        log.warn("[Gemini SSE] JSON 파싱 오류: {}", e.getMessage());
+                    }
+                })
+                .doOnComplete(() -> {
+                    // 스트리밍 완료 → 로그인 사용자면 히스토리 저장
+                    if (userId != null && articleId != null && question != null) {
+                        chatHistoryService.save(userId, articleId, question, resultBuilder.toString());
+                    }
+                    try {
+                        emitter.complete();
+                    } catch (Exception e) {
+                        log.warn("[Gemini SSE] emitter complete 오류: {}", e.getMessage());
                     }
                 })
                 .doOnError(error -> {
-                    log.error("OpenAI SSE 처리 중 오류 발생", error);
+                    log.error("[Gemini SSE] 처리 중 오류 발생", error);
                     emitter.completeWithError(error);
                 })
                 .subscribe();
     }
 
-    private Map<String, Object> createRequestBody(String crawledContent, String language) {
-        return Map.of(
-                "model", "gpt-4o-mini",
-                "messages", List.of(
-                        Map.of("role", "system", "content", "이 기사를 " + language + "로 요약해줘."),
-                        Map.of("role", "user", "content", crawledContent)
-                ),
-                "stream", true
-        );
-    }
 
-    private Map<String, Object> createQuestionRequestBody(String crawledContent, String question) {
-        return Map.of(
-                "model", "gpt-4o-mini",
-                "messages", List.of(
-                        Map.of("role", "system", "content", "다음 기사 내용을 참고하여 사용자 질문에 자세하게 답변해줘."),
-                        Map.of("role", "user", "content", "기사 내용:\n" + crawledContent),
-                        Map.of("role", "user", "content", "사용자 질문:\n" + question)
-                ),
-                "stream", true
-        );
-    }
+    // ── GPT (비활성 / 주석 보존) ────────────────────────────────────────────
+    // private final WebClient openAiWebClient;
+    //
+    // public SseEmitter summarizeContent(String crawledContent, String language) {
+    //     SseEmitter emitter = new SseEmitter(10 * 60 * 1000L);
+    //     processStreamingRequest(emitter, createRequestBody(crawledContent, language), null, null, null);
+    //     return emitter;
+    // }
+    //
+    // public SseEmitter askGPT(String crawledContent, String question, Long userId, Long articleId) {
+    //     SseEmitter emitter = new SseEmitter(10 * 60 * 1000L);
+    //     processStreamingRequest(emitter, createQuestionRequestBody(crawledContent, question), question, userId, articleId);
+    //     return emitter;
+    // }
+    //
+    // private void processStreamingRequest(SseEmitter emitter, Map<String, Object> requestBody,
+    //                                      String question, Long userId, Long articleId) {
+    //     StringBuilder resultBuilder = new StringBuilder();
+    //     openAiWebClient.post()
+    //             .uri("/chat/completions")
+    //             .accept(MediaType.TEXT_EVENT_STREAM)
+    //             .bodyValue(requestBody)
+    //             .retrieve()
+    //             .bodyToFlux(String.class)
+    //             .doOnNext(data -> {
+    //                 String jsonPart = data.trim();
+    //                 if ("[DONE]".equals(jsonPart)) {
+    //                     if (userId != null && articleId != null && question != null) {
+    //                         chatHistoryService.save(userId, articleId, question, resultBuilder.toString());
+    //                     }
+    //                     emitter.complete();
+    //                     return;
+    //                 }
+    //                 try {
+    //                     Map response = new ObjectMapper().readValue(jsonPart, Map.class);
+    //                     List<Map<String, Object>> choices = (List<Map<String, Object>>) response.get("choices");
+    //                     if (choices != null && !choices.isEmpty()) {
+    //                         Map<String, Object> delta = (Map<String, Object>) choices.get(0).get("delta");
+    //                         if (delta != null && delta.containsKey("content")) {
+    //                             String contentText = (String) delta.get("content");
+    //                             resultBuilder.append(contentText);
+    //                             emitter.send(resultBuilder.toString());
+    //                         }
+    //                     }
+    //                 } catch (IOException e) {
+    //                     log.warn("JSON 파싱 오류 발생!", e);
+    //                     emitter.completeWithError(e);
+    //                 }
+    //             })
+    //             .doOnError(error -> {
+    //                 log.error("OpenAI SSE 처리 중 오류 발생", error);
+    //                 emitter.completeWithError(error);
+    //             })
+    //             .subscribe();
+    // }
+    //
+    // private Map<String, Object> createRequestBody(String crawledContent, String language) {
+    //     return Map.of(
+    //             "model", "gpt-4o-mini",
+    //             "messages", List.of(
+    //                     Map.of("role", "system", "content", "이 기사를 " + language + "로 요약해줘."),
+    //                     Map.of("role", "user", "content", crawledContent)
+    //             ),
+    //             "stream", true
+    //     );
+    // }
+    //
+    // private Map<String, Object> createQuestionRequestBody(String crawledContent, String question) {
+    //     return Map.of(
+    //             "model", "gpt-4o-mini",
+    //             "messages", List.of(
+    //                     Map.of("role", "system", "content", "다음 기사 내용을 참고하여 사용자 질문에 자세하게 답변해줘."),
+    //                     Map.of("role", "user", "content", "기사 내용:\n" + crawledContent),
+    //                     Map.of("role", "user", "content", "사용자 질문:\n" + question)
+    //             ),
+    //             "stream", true
+    //     );
+    // }
 }

--- a/src/main/java/com/example/globalTimes_be/domain/ai/service/AiSseService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/ai/service/AiSseService.java
@@ -19,21 +19,21 @@ import java.util.Map;
 @Service
 public class AiSseService {
 
-    // ── Gemini (현재 활성) ──────────────────────────────────────────────────
+    // Gemini (?? ??)
     @Qualifier("geminiWebClient")
     private final WebClient geminiWebClient;
 
     @Value("${gemini.api-key}")
     private String geminiApiKey;
 
-    private static final String GEMINI_MODEL = "gemini-2.0-flash";
+    private static final String GEMINI_MODEL = "gemini-2.5-flash";
 
     private final ChatHistoryService chatHistoryService;
 
     public SseEmitter summarizeContent(String crawledContent, String language) {
         SseEmitter emitter = new SseEmitter(10 * 60 * 1000L);
         Map<String, Object> body = createGeminiRequestBody(
-                "이 기사를 " + language + "로 요약해줘.",
+                "? ??? " + language + "? ????.",
                 crawledContent
         );
         processGeminiStreaming(emitter, body, null, null, null);
@@ -43,8 +43,8 @@ public class AiSseService {
     public SseEmitter askGPT(String crawledContent, String question, Long userId, Long articleId) {
         SseEmitter emitter = new SseEmitter(10 * 60 * 1000L);
         Map<String, Object> body = createGeminiRequestBody(
-                "다음 기사 내용을 참고하여 사용자 질문에 자세하게 답변해줘.",
-                "기사 내용:\n" + crawledContent + "\n\n사용자 질문:\n" + question
+                "?? ?? ??? ???? ??? ??? ???? ????.",
+                "?? ??:\n" + crawledContent + "\n\n??? ??:\n" + question
         );
         processGeminiStreaming(emitter, body, question, userId, articleId);
         return emitter;
@@ -93,29 +93,29 @@ public class AiSseService {
                             emitter.send(resultBuilder.toString());
                         }
                     } catch (Exception e) {
-                        log.warn("[Gemini SSE] JSON 파싱 오류: {}", e.getMessage());
+                        log.warn("[Gemini SSE] JSON ?? ??: {}", e.getMessage());
                     }
                 })
                 .doOnComplete(() -> {
-                    // 스트리밍 완료 → 로그인 사용자면 히스토리 저장
+                    // ???? ?? ? ???? ??
                     if (userId != null && articleId != null && question != null) {
                         chatHistoryService.save(userId, articleId, question, resultBuilder.toString());
                     }
                     try {
                         emitter.complete();
                     } catch (Exception e) {
-                        log.warn("[Gemini SSE] emitter complete 오류: {}", e.getMessage());
+                        log.warn("[Gemini SSE] emitter complete ??: {}", e.getMessage());
                     }
                 })
                 .doOnError(error -> {
-                    log.error("[Gemini SSE] 처리 중 오류 발생", error);
+                    log.error("[Gemini SSE] ?? ? ?? ??", error);
                     emitter.completeWithError(error);
                 })
                 .subscribe();
     }
 
 
-    // ── GPT (비활성 / 주석 보존) ────────────────────────────────────────────
+    // GPT (??? / ?? ??)
     // private final WebClient openAiWebClient;
     //
     // public SseEmitter summarizeContent(String crawledContent, String language) {
@@ -159,13 +159,13 @@ public class AiSseService {
     //                             emitter.send(resultBuilder.toString());
     //                         }
     //                     }
-    //                 } catch (IOException e) {
-    //                     log.warn("JSON 파싱 오류 발생!", e);
+    //                 } catch (Exception e) {
+    //                     log.warn("JSON ?? ?? ??!", e);
     //                     emitter.completeWithError(e);
     //                 }
     //             })
     //             .doOnError(error -> {
-    //                 log.error("OpenAI SSE 처리 중 오류 발생", error);
+    //                 log.error("OpenAI SSE ?? ? ?? ??", error);
     //                 emitter.completeWithError(error);
     //             })
     //             .subscribe();
@@ -175,7 +175,7 @@ public class AiSseService {
     //     return Map.of(
     //             "model", "gpt-4o-mini",
     //             "messages", List.of(
-    //                     Map.of("role", "system", "content", "이 기사를 " + language + "로 요약해줘."),
+    //                     Map.of("role", "system", "content", "? ??? " + language + "? ????."),
     //                     Map.of("role", "user", "content", crawledContent)
     //             ),
     //             "stream", true
@@ -186,9 +186,9 @@ public class AiSseService {
     //     return Map.of(
     //             "model", "gpt-4o-mini",
     //             "messages", List.of(
-    //                     Map.of("role", "system", "content", "다음 기사 내용을 참고하여 사용자 질문에 자세하게 답변해줘."),
-    //                     Map.of("role", "user", "content", "기사 내용:\n" + crawledContent),
-    //                     Map.of("role", "user", "content", "사용자 질문:\n" + question)
+    //                     Map.of("role", "system", "content", "?? ?? ??? ???? ??? ??? ???? ????."),
+    //                     Map.of("role", "user", "content", "?? ??:\n" + crawledContent),
+    //                     Map.of("role", "user", "content", "??? ??:\n" + question)
     //             ),
     //             "stream", true
     //     );

--- a/src/main/java/com/example/globalTimes_be/domain/chat/controller/ChatHistoryController.java
+++ b/src/main/java/com/example/globalTimes_be/domain/chat/controller/ChatHistoryController.java
@@ -1,0 +1,42 @@
+package com.example.globalTimes_be.domain.chat.controller;
+
+import com.example.globalTimes_be.domain.chat.service.ChatHistoryService;
+import com.example.globalTimes_be.global.apiPayload.code.ApiResponse;
+import com.example.globalTimes_be.global.apiPayload.code.status.GlobalSuccessStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ChatHistoryController implements ChatHistoryControllerDocs {
+
+    private final ChatHistoryService chatHistoryService;
+
+    // GET /api/user/chat-history  →  팝업 목록 (기사별 마지막 대화 미리보기)
+    @Override
+    @GetMapping("/user/chat-history")
+    public ResponseEntity<ApiResponse> getChatList(Authentication authentication) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ApiResponse.success(
+                GlobalSuccessStatus._OK.getResponse(),
+                chatHistoryService.getChatList(userId)
+        );
+    }
+
+    // GET /api/articles/{id}/chat-history  →  기사 상세 페이지 전체 대화 내역
+    @Override
+    @GetMapping("/articles/{id}/chat-history")
+    public ResponseEntity<ApiResponse> getChatsByArticle(
+            @PathVariable("id") Long articleId,
+            Authentication authentication
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ApiResponse.success(
+                GlobalSuccessStatus._OK.getResponse(),
+                chatHistoryService.getChatsByArticle(userId, articleId)
+        );
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/domain/chat/controller/ChatHistoryControllerDocs.java
+++ b/src/main/java/com/example/globalTimes_be/domain/chat/controller/ChatHistoryControllerDocs.java
@@ -1,0 +1,79 @@
+package com.example.globalTimes_be.domain.chat.controller;
+
+import com.example.globalTimes_be.global.apiPayload.code.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+
+@Tag(name = "ChatHistory", description = "GPT 질의 히스토리 API")
+public interface ChatHistoryControllerDocs {
+
+    @Operation(
+            summary = "내 채팅 목록 조회 (팝업 리스트용)",
+            description = "로그인한 사용자가 질의한 기사별 마지막 대화 미리보기 목록을 반환합니다. 최신 대화 순으로 정렬됩니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(examples = @ExampleObject(value = """
+                            {
+                              "isSuccess": true,
+                              "message": "응답에 성공했습니다.",
+                              "data": [
+                                {
+                                  "articleId": 42,
+                                  "articleTitle": "BTS 공연 매진 기록...",
+                                  "thumbnailUrl": "https://...",
+                                  "lastQuestion": "이 기사의 핵심 내용은?",
+                                  "lastAnswerPreview": "BTS의 이번 공연은 역대 최단 시간 매진을...",
+                                  "lastChatAt": "2026-03-30T15:00:00"
+                                }
+                              ]
+                            }
+                            """))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")
+    })
+    ResponseEntity<ApiResponse> getChatList(
+            @Parameter(hidden = true) Authentication authentication
+    );
+
+    @Operation(
+            summary = "기사별 대화 전체 조회 (상세 페이지용)",
+            description = "특정 기사에 대해 로그인한 사용자가 나눈 GPT 대화 전체를 오래된 순으로 반환합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(examples = @ExampleObject(value = """
+                            {
+                              "isSuccess": true,
+                              "message": "응답에 성공했습니다.",
+                              "data": [
+                                {
+                                  "chatId": 1,
+                                  "question": "이 기사의 핵심 내용은?",
+                                  "answer": "이 기사는 BTS의 공연이 역대 최단...",
+                                  "createdAt": "2026-03-30T15:00:00"
+                                }
+                              ]
+                            }
+                            """))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")
+    })
+    ResponseEntity<ApiResponse> getChatsByArticle(
+            @Parameter(description = "기사 ID") Long articleId,
+            @Parameter(hidden = true) Authentication authentication
+    );
+}

--- a/src/main/java/com/example/globalTimes_be/domain/chat/dto/ChatHistoryListResDTO.java
+++ b/src/main/java/com/example/globalTimes_be/domain/chat/dto/ChatHistoryListResDTO.java
@@ -1,0 +1,38 @@
+package com.example.globalTimes_be.domain.chat.dto;
+
+import com.example.globalTimes_be.domain.chat.entity.ChatHistory;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+// 플로팅 팝업 목록 - 기사별 마지막 대화 미리보기 (1건)
+@Getter
+@Builder
+public class ChatHistoryListResDTO {
+
+    private Long articleId;
+    private String articleTitle;
+    private String thumbnailUrl;
+    private String lastQuestion;
+    private String lastAnswerPreview; // 최대 100자 미리보기
+    private LocalDateTime lastChatAt;
+
+    private static final int PREVIEW_MAX_LENGTH = 100;
+
+    public static ChatHistoryListResDTO from(ChatHistory latestChat) {
+        String answer = latestChat.getAnswer();
+        String preview = answer.length() > PREVIEW_MAX_LENGTH
+                ? answer.substring(0, PREVIEW_MAX_LENGTH) + "..."
+                : answer;
+
+        return ChatHistoryListResDTO.builder()
+                .articleId(latestChat.getArticle().getId())
+                .articleTitle(latestChat.getArticle().getTitle())
+                .thumbnailUrl(latestChat.getArticle().getUrlToImage())
+                .lastQuestion(latestChat.getQuestion())
+                .lastAnswerPreview(preview)
+                .lastChatAt(latestChat.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/domain/chat/dto/ChatHistoryResDTO.java
+++ b/src/main/java/com/example/globalTimes_be/domain/chat/dto/ChatHistoryResDTO.java
@@ -1,0 +1,27 @@
+package com.example.globalTimes_be.domain.chat.dto;
+
+import com.example.globalTimes_be.domain.chat.entity.ChatHistory;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+// 기사 상세 페이지 - 해당 기사의 대화 전체 목록 (1건)
+@Getter
+@Builder
+public class ChatHistoryResDTO {
+
+    private Long chatId;
+    private String question;
+    private String answer;
+    private LocalDateTime createdAt;
+
+    public static ChatHistoryResDTO from(ChatHistory chat) {
+        return ChatHistoryResDTO.builder()
+                .chatId(chat.getId())
+                .question(chat.getQuestion())
+                .answer(chat.getAnswer())
+                .createdAt(chat.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/domain/chat/entity/ChatHistory.java
+++ b/src/main/java/com/example/globalTimes_be/domain/chat/entity/ChatHistory.java
@@ -1,0 +1,52 @@
+package com.example.globalTimes_be.domain.chat.entity;
+
+import com.example.globalTimes_be.domain.article.entity.Article;
+import com.example.globalTimes_be.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chat_history", indexes = {
+        @Index(name = "idx_chat_user_id", columnList = "user_id"),
+        @Index(name = "idx_chat_user_article", columnList = "user_id, article_id")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class ChatHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chat_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id", nullable = false)
+    private Article article;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String question;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String answer;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    public static ChatHistory create(User user, Article article, String question, String answer) {
+        return ChatHistory.builder()
+                .user(user)
+                .article(article)
+                .question(question)
+                .answer(answer)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/domain/chat/repository/ChatHistoryRepository.java
+++ b/src/main/java/com/example/globalTimes_be/domain/chat/repository/ChatHistoryRepository.java
@@ -1,0 +1,17 @@
+package com.example.globalTimes_be.domain.chat.repository;
+
+import com.example.globalTimes_be.domain.chat.entity.ChatHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ChatHistoryRepository extends JpaRepository<ChatHistory, Long> {
+
+    // 사용자의 전체 히스토리 (최신순) - 팝업 목록용
+    List<ChatHistory> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    // 특정 기사의 사용자 히스토리 (오래된순) - 상세 페이지 대화 흐름용
+    List<ChatHistory> findByUserIdAndArticleIdOrderByCreatedAtAsc(Long userId, Long articleId);
+}

--- a/src/main/java/com/example/globalTimes_be/domain/chat/service/ChatHistoryService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/chat/service/ChatHistoryService.java
@@ -1,0 +1,71 @@
+package com.example.globalTimes_be.domain.chat.service;
+
+import com.example.globalTimes_be.domain.article.entity.Article;
+import com.example.globalTimes_be.domain.article.repository.ArticleRepository;
+import com.example.globalTimes_be.domain.chat.dto.ChatHistoryListResDTO;
+import com.example.globalTimes_be.domain.chat.dto.ChatHistoryResDTO;
+import com.example.globalTimes_be.domain.chat.entity.ChatHistory;
+import com.example.globalTimes_be.domain.chat.repository.ChatHistoryRepository;
+import com.example.globalTimes_be.domain.user.entity.User;
+import com.example.globalTimes_be.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatHistoryService {
+
+    private final ChatHistoryRepository chatHistoryRepository;
+    private final UserRepository userRepository;
+    private final ArticleRepository articleRepository;
+
+    // GPT 질의 완료 시 저장 (AiSseService에서 호출)
+    @Transactional
+    public void save(Long userId, Long articleId, String question, String answer) {
+        try {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자: " + userId));
+            Article article = articleRepository.findById(articleId)
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 기사: " + articleId));
+
+            chatHistoryRepository.save(ChatHistory.create(user, article, question, answer));
+            log.info("[ChatHistory] 저장 완료 - userId: {}, articleId: {}", userId, articleId);
+        } catch (Exception e) {
+            log.error("[ChatHistory] 저장 실패 - userId: {}, articleId: {}, error: {}", userId, articleId, e.getMessage());
+        }
+    }
+
+    // 팝업 목록용: 사용자의 기사별 마지막 대화 미리보기
+    @Transactional(readOnly = true)
+    public List<ChatHistoryListResDTO> getChatList(Long userId) {
+        List<ChatHistory> all = chatHistoryRepository.findByUserIdOrderByCreatedAtDesc(userId);
+
+        // 기사별로 가장 최신 채팅 1건만 추출 (이미 최신순 정렬이므로 첫 번째가 최신)
+        Map<Long, ChatHistory> latestPerArticle = new LinkedHashMap<>();
+        for (ChatHistory chat : all) {
+            latestPerArticle.putIfAbsent(chat.getArticle().getId(), chat);
+        }
+
+        return latestPerArticle.values().stream()
+                .map(ChatHistoryListResDTO::from)
+                .collect(Collectors.toList());
+    }
+
+    // 상세 페이지용: 특정 기사의 전체 대화 내역
+    @Transactional(readOnly = true)
+    public List<ChatHistoryResDTO> getChatsByArticle(Long userId, Long articleId) {
+        return chatHistoryRepository
+                .findByUserIdAndArticleIdOrderByCreatedAtAsc(userId, articleId)
+                .stream()
+                .map(ChatHistoryResDTO::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/domain/trend/service/TrendAiService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/trend/service/TrendAiService.java
@@ -3,8 +3,10 @@ package com.example.globalTimes_be.domain.trend.service;
 import com.example.globalTimes_be.domain.trend.exception.TrendErrorStatus;
 import com.example.globalTimes_be.global.exception.BaseException;
 import com.example.globalTimes_be.global.redis.RedisUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -21,8 +23,15 @@ import java.util.Map;
 public class TrendAiService {
 
     private static final String CACHE_KEY_PREFIX = "trend:summary:";
+    private static final String GEMINI_MODEL = "gemini-2.0-flash";
 
-    private final WebClient openAiWebClient;
+    // ── Gemini (현재 활성) ──────────────────────────────────────────────────
+    @Qualifier("geminiWebClient")
+    private final WebClient geminiWebClient;
+
+    @Value("${gemini.api-key}")
+    private String geminiApiKey;
+
     private final RedisUtil redisUtil;
 
     @Value("${trend.summary-cache-ttl-seconds:21600}")
@@ -38,10 +47,10 @@ public class TrendAiService {
                     return cached;
                 }
             } catch (Exception e) {
-                log.warn("[트렌드 요약] 캐시 조회 실패, GPT 호출: {}", e.getMessage());
+                log.warn("[트렌드 요약] 캐시 조회 실패, Gemini 호출: {}", e.getMessage());
             }
 
-            String summary = callGpt(content, language);
+            String summary = callGemini(content, language);
 
             try {
                 redisUtil.setData(cacheKey, summary, cacheTtlSeconds);
@@ -51,18 +60,41 @@ public class TrendAiService {
             return summary;
         }
 
-        return callGpt(content, language);
+        return callGemini(content, language);
     }
 
-    private String callGpt(String content, String language) {
-        String summary = openAiWebClient.post()
-                .uri("/chat/completions")
-                .bodyValue(createRequestBody(content, language))
+    private String callGemini(String content, String language) {
+        Map<String, Object> requestBody = Map.of(
+                "system_instruction", Map.of(
+                        "parts", List.of(Map.of("text", "이 기사를 " + language + "로 2줄 요약해줘."))
+                ),
+                "contents", List.of(
+                        Map.of("parts", List.of(Map.of("text", content)))
+                )
+        );
+
+        return geminiWebClient.post()
+                .uri("/v1beta/models/" + GEMINI_MODEL + ":generateContent?key=" + geminiApiKey)
+                .bodyValue(requestBody)
                 .retrieve()
                 .bodyToMono(Map.class)
-                .map(response -> extractContent(response))
+                .map(this::extractGeminiContent)
                 .block();
-        return summary;
+    }
+
+    @SuppressWarnings("unchecked")
+    private String extractGeminiContent(Map<String, Object> response) {
+        List<Map<String, Object>> candidates = (List<Map<String, Object>>) response.get("candidates");
+        if (candidates != null && !candidates.isEmpty()) {
+            Map<String, Object> content = (Map<String, Object>) candidates.get(0).get("content");
+            if (content != null) {
+                List<Map<String, Object>> parts = (List<Map<String, Object>>) content.get("parts");
+                if (parts != null && !parts.isEmpty()) {
+                    return (String) parts.get(0).get("text");
+                }
+            }
+        }
+        throw new BaseException(TrendErrorStatus._GPT_ERROR.getResponse());
     }
 
     private String hashUrl(String url) {
@@ -75,29 +107,37 @@ public class TrendAiService {
         }
     }
 
-    // OpenAI 요청 본문 생성 (기사 요약)
-    private Map<String, Object> createRequestBody(String content, String language) {
-        if (content == null || language == null) {
-            throw new IllegalArgumentException("content나 language는 null일 수 없습니다.");
-        }
 
-        return Map.of(
-                "model", "gpt-4o-mini",
-                "messages", List.of(
-                        Map.of("role", "system", "content", "이 기사를 " + language + "로 2줄 요약해줘."),
-                        Map.of("role", "user", "content", content)
-                ),
-                "stream", false  // 🔹 스트리밍 비활성화
-        );
-    }
-
-    // OpenAI 응답에서 'content' 추출
-    private String extractContent(Map<String, Object> response) {
-        List<Map<String, Object>> choices = (List<Map<String, Object>>) response.get("choices");
-        if (choices != null && !choices.isEmpty()) {
-            Map<String, Object> message = (Map<String, Object>) choices.get(0).get("message");
-            return (String) message.get("content");
-        }
-        throw new BaseException(TrendErrorStatus._GPT_ERROR.getResponse());
-    }
+    // ── GPT (비활성 / 주석 보존) ────────────────────────────────────────────
+    // private final WebClient openAiWebClient;
+    //
+    // private String callGpt(String content, String language) {
+    //     return openAiWebClient.post()
+    //             .uri("/chat/completions")
+    //             .bodyValue(createGptRequestBody(content, language))
+    //             .retrieve()
+    //             .bodyToMono(Map.class)
+    //             .map(response -> extractGptContent(response))
+    //             .block();
+    // }
+    //
+    // private Map<String, Object> createGptRequestBody(String content, String language) {
+    //     return Map.of(
+    //             "model", "gpt-4o-mini",
+    //             "messages", List.of(
+    //                     Map.of("role", "system", "content", "이 기사를 " + language + "로 2줄 요약해줘."),
+    //                     Map.of("role", "user", "content", content)
+    //             ),
+    //             "stream", false
+    //     );
+    // }
+    //
+    // private String extractGptContent(Map<String, Object> response) {
+    //     List<Map<String, Object>> choices = (List<Map<String, Object>>) response.get("choices");
+    //     if (choices != null && !choices.isEmpty()) {
+    //         Map<String, Object> message = (Map<String, Object>) choices.get(0).get("message");
+    //         return (String) message.get("content");
+    //     }
+    //     throw new BaseException(TrendErrorStatus._GPT_ERROR.getResponse());
+    // }
 }

--- a/src/main/java/com/example/globalTimes_be/domain/trend/service/TrendAiService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/trend/service/TrendAiService.java
@@ -3,7 +3,6 @@ package com.example.globalTimes_be.domain.trend.service;
 import com.example.globalTimes_be.domain.trend.exception.TrendErrorStatus;
 import com.example.globalTimes_be.global.exception.BaseException;
 import com.example.globalTimes_be.global.redis.RedisUtil;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -23,9 +22,9 @@ import java.util.Map;
 public class TrendAiService {
 
     private static final String CACHE_KEY_PREFIX = "trend:summary:";
-    private static final String GEMINI_MODEL = "gemini-2.0-flash";
+    private static final String GEMINI_MODEL = "gemini-2.5-flash";
 
-    // ── Gemini (현재 활성) ──────────────────────────────────────────────────
+    // Gemini (?? ??)
     @Qualifier("geminiWebClient")
     private final WebClient geminiWebClient;
 
@@ -43,11 +42,11 @@ public class TrendAiService {
             try {
                 String cached = redisUtil.getData(cacheKey);
                 if (cached != null) {
-                    log.debug("[트렌드 요약] 캐시 히트 url={}", url);
+                    log.debug("[??? ??] ?? ?? url={}", url);
                     return cached;
                 }
             } catch (Exception e) {
-                log.warn("[트렌드 요약] 캐시 조회 실패, Gemini 호출: {}", e.getMessage());
+                log.warn("[??? ??] ?? ?? ??, Gemini ??: {}", e.getMessage());
             }
 
             String summary = callGemini(content, language);
@@ -55,7 +54,7 @@ public class TrendAiService {
             try {
                 redisUtil.setData(cacheKey, summary, cacheTtlSeconds);
             } catch (Exception e) {
-                log.warn("[트렌드 요약] 캐시 저장 실패 (무시): {}", e.getMessage());
+                log.warn("[??? ??] ?? ?? ?? (??): {}", e.getMessage());
             }
             return summary;
         }
@@ -66,7 +65,7 @@ public class TrendAiService {
     private String callGemini(String content, String language) {
         Map<String, Object> requestBody = Map.of(
                 "system_instruction", Map.of(
-                        "parts", List.of(Map.of("text", "이 기사를 " + language + "로 2줄 요약해줘."))
+                        "parts", List.of(Map.of("text", "? ??? " + language + "? 2?? ????."))
                 ),
                 "contents", List.of(
                         Map.of("parts", List.of(Map.of("text", content)))
@@ -108,7 +107,7 @@ public class TrendAiService {
     }
 
 
-    // ── GPT (비활성 / 주석 보존) ────────────────────────────────────────────
+    // GPT (??? / ?? ??)
     // private final WebClient openAiWebClient;
     //
     // private String callGpt(String content, String language) {
@@ -125,7 +124,7 @@ public class TrendAiService {
     //     return Map.of(
     //             "model", "gpt-4o-mini",
     //             "messages", List.of(
-    //                     Map.of("role", "system", "content", "이 기사를 " + language + "로 2줄 요약해줘."),
+    //                     Map.of("role", "system", "content", "? ??? " + language + "? 2?? ????."),
     //                     Map.of("role", "user", "content", content)
     //             ),
     //             "stream", false

--- a/src/main/java/com/example/globalTimes_be/global/config/GeminiConfig.java
+++ b/src/main/java/com/example/globalTimes_be/global/config/GeminiConfig.java
@@ -1,0 +1,22 @@
+package com.example.globalTimes_be.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class GeminiConfig {
+
+    // Gemini는 API Key를 Authorization 헤더가 아닌 URL 쿼리 파라미터로 전달
+    // 실제 키는 각 서비스에서 @Value로 주입 후 URI에 직접 포함
+    @Bean
+    public WebClient geminiWebClient() {
+        return WebClient.builder()
+                .baseUrl("https://generativelanguage.googleapis.com")
+                .defaultHeader("Content-Type", "application/json")
+                .codecs(configurer -> configurer
+                        .defaultCodecs()
+                        .maxInMemorySize(10 * 1024 * 1024)) // 10MB
+                .build();
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/global/config/OpenAiConfig.java
+++ b/src/main/java/com/example/globalTimes_be/global/config/OpenAiConfig.java
@@ -7,7 +7,10 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 public class OpenAiConfig {
-    @Value("${spring.openai.api-key}")
+
+    // GPT 비활성 상태 - OPENAI_API_KEY 미설정 시에도 기동 가능하도록 기본값 처리
+    // 복구 시: ${spring.openai.api-key} 로 변경하고 .env에 OPENAI_API_KEY 추가
+    @Value("${spring.openai.api-key:disabled}")
     private String apiKey;
 
     @Bean

--- a/src/main/java/com/example/globalTimes_be/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/globalTimes_be/global/config/SecurityConfig.java
@@ -46,8 +46,9 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/error"
                         ).permitAll()
-                        // 사용자 정보 조회/히스토리 관련은 인증 필요
+                        // 사용자 정보 및 채팅 히스토리 조회는 인증 필요
                         .requestMatchers("/api/user/**").authenticated()
+                        .requestMatchers("/api/articles/*/chat-history").authenticated()
                         .anyRequest().permitAll()
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,9 +30,9 @@ spring:
             client-secret: ${GOOGLE_OAUTH_CLIENT_SECRET}
             scope: profile, email
 
-  #gpt
-  openai:
-    api-key: ${OPENAI_API_KEY}
+  # GPT (비활성 / 주석 보존)
+  # openai:
+  #   api-key: ${OPENAI_API_KEY}
 
   #news
   newsapi:
@@ -41,6 +41,10 @@ spring:
   #google translate
   google:
     api-key: ${GOOGLE_API_KEY}
+
+# Gemini API (GPT 대체, 무료 티어: 일 1,500회 / 분 15회)
+gemini:
+  api-key: ${GEMINI_API_KEY}
 
 # JWT 설정
 jwt:


### PR DESCRIPTION
### 📌 관련 이슈
Close #99

> #97 Google OAuth2 + JWT 로그인 구현 완료 후 진행.
> 로그인한 사용자의 기사별 질의 내역 저장/조회 기능 추가.
> 기존 GPT(gpt-4o-mini) → Gemini(gemini-2.0-flash)로 우선 변경 (GPT 부분 우선 주석화) : 일일 무료 크레딧 사용해서 테스트

---

### 📖 작업 배경

기존 GPT 질의 로직은 매 요청마다 새로운 프롬프트를 생성하는 일회성 구조로,
이전 대화 내용이 전혀 유지되지 않았음.

로그인(#97) 구현으로 사용자 식별이 가능해졌으므로,
기사별 질의 내역을 DB에 영속 저장하고 조회하는 기능을 추가.

또한, 기존 GPT(유료 전용)에서 무료 티어가 제공되는 Gemini로 변경하여
로컬 테스트 비용 부담을 제거함. GPT 코드는 주석으로 보존하여 복구 가능.

> 💡 현재 구조는 질의 단건이 독립적으로 처리됨 (Context 누적 없음).
> 이전 대화를 payload에 포함한 Context 기반 대화 개선은 별도 이슈로 분리 예정.
---

### 🔄 저장 플로우
```
① 로그인 사용자가 GET /api/ai/{id}/ask?question=... 호출
② Gemini SSE 스트리밍으로 답변 실시간 전달
③ 스트리밍 완료(doOnComplete) 시 question + 전체 answer → chat_history 저장
④ 비로그인 사용자는 저장 생략, 기존 동작 그대로 유지
```
---
### 🗃 DB 테이블 구조 및 관계
`chat_history` 는 `users` 와 `article` 두 테이블을 동시에 FK로 참조하는 구조.
| 관계 | 의미 |
|---|---|
| `users` 1 : N `chat_history` | 한 사용자가 여러 대화 가능 |
| `article` 1 : N `chat_history` | 한 기사에 여러 사용자의 여러 대화 가능 |
| `users` + `article` : `chat_history` | N:M 매핑 테이블 역할 + 대화 데이터 보관 |
```
chat_history
┌──────────┬──────────┬───────────┬──────────┬──────────┬────────────┐
│ chat_id  │ user_id  │ article_id│ question │  answer  │ created_at │
│    1     │    1     │    42     │ "핵심은?" │ "BTS..." │ 03-30 15시 │  ← 사용자1, 기사42
│    2     │    1     │    42     │ "배경은?" │ "공연..." │ 03-30 15시 │  ← 사용자1, 기사42 (다른 질문)
│    3     │    1     │    77     │ "요약해줘"│ "미국..." │ 03-30 16시 │  ← 사용자1, 다른 기사
│    4     │    2     │    42     │ "핵심은?" │ "BTS..." │ 03-30 17시 │  ← 사용자2, 기사42
└──────────┴──────────┴───────────┴──────────┴──────────┴────────────┘
```
---
### 📡 추가된 API
| Method | URI | 설명 | 인증 |
|---|---|---|---|
| `GET` | `/api/user/chat-history` | 기사별 마지막 대화 미리보기 목록 (팝업 리스트용) | 필요 |
| `GET` | `/api/articles/{id}/chat-history` | 특정 기사 전체 대화 내역 (상세 페이지용) | 필요 |
---
### 🗂 추가된 파일
| 파일 | 설명 |
|---|---|
| `domain/chat/entity/ChatHistory.java` | chat_history 테이블 엔티티 (user, article FK) |
| `domain/chat/repository/ChatHistoryRepository.java` | 사용자별 / 기사별 조회 쿼리 |
| `domain/chat/service/ChatHistoryService.java` | 저장 + 목록/상세 조회 로직 |
| `domain/chat/dto/ChatHistoryResDTO.java` | 기사 상세 페이지용 단건 DTO |
| `domain/chat/dto/ChatHistoryListResDTO.java` | 팝업 목록용 미리보기 DTO (썸네일, 제목, 100자 미리보기) |
| `domain/chat/controller/ChatHistoryController.java` | 히스토리 조회 엔드포인트 |
| `domain/chat/controller/ChatHistoryControllerDocs.java` | Swagger 문서 |
| `global/config/GeminiConfig.java` | Gemini WebClient Bean 등록 |
### 🛠 수정된 파일
| 파일 | 변경 내용 |
|---|---|
| `domain/ai/service/AiService.java` | Gemini 비스트리밍 호출로 교체, GPT 코드 주석 보존 |
| `domain/ai/service/AiSseService.java` | Gemini 스트리밍으로 교체 + `doOnComplete`에서 히스토리 저장, GPT 코드 주석 보존 |
| `domain/trend/service/TrendAiService.java` | Gemini 호출로 교체, GPT 코드 주석 보존 |
| `domain/ai/controller/AiController.java` | `askArticle`에 Authentication 주입, userId 추출 후 전달 |
| `domain/ai/controller/AiControllerDocs.java` | `askArticle` 인터페이스에 Authentication 파라미터 추가 |
| `global/config/SecurityConfig.java` | `/api/articles/*/chat-history` 인증 필요 경로 추가 |
| `application.yml` | `gemini.api-key` 설정 추가, GPT 설정 주석 처리 |
| `.env.example` | `GEMINI_API_KEY` 발급 안내 추가 |
---
### 🧪 테스트 방법
> `.env`에 `GEMINI_API_KEY` 세팅 필수.
> 발급: https://aistudio.google.com → Get API Key → Create API Key (무료, 카드 불필요)
**Step 1. 로그인 후 토큰 발급**
```
브라우저 → http://localhost:8080/oauth2/authorization/google
→ 주소창에서 token 복사
```
**Step 2. Swagger Authorize에 토큰 등록**
```
http://localhost:8080/swagger-ui/index.html → [Authorize] → Bearer {token}
```
**Step 3. Gemini 질의 후 히스토리 저장 확인**
```
GET /api/ai/{id}/ask?question=이 기사의 핵심은?
→ SSE 스트리밍으로 Gemini 답변 수신
→ MySQL: SELECT * FROM chat_history; 로 저장 확인
```
**Step 4. 히스토리 조회**
```
GET /api/user/chat-history          → 팝업 목록 응답 확인
GET /api/articles/{id}/chat-history → 특정 기사 전체 대화 확인
```
---
### 🔜 다음 이슈 (분리 예정)
- `[FEAT] 기사별 GPT 질의 Context 기반 대화 개선` (이전 대화 payload 누적 포함)
- 플로팅 버튼 + 채팅 목록 팝업 UI 구현 (FE 연동 시)
- 기사 상세 페이지 하단 히스토리 섹션 연동 (FE 연동 시)