### PR TITLE
✨ [FEAT/#101] 기사별 AI 질의 Context 기반 대화 개선 (슬라이딩 윈도우)

### DIFF
--- a/src/main/java/com/example/globalTimes_be/domain/ai/service/AiSseService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/ai/service/AiSseService.java
@@ -1,5 +1,6 @@
 package com.example.globalTimes_be.domain.ai.service;
 
+import com.example.globalTimes_be.domain.chat.entity.ChatHistory;
 import com.example.globalTimes_be.domain.chat.service.ChatHistoryService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -25,6 +27,9 @@ public class AiSseService {
 
     @Value("${gemini.api-key}")
     private String geminiApiKey;
+
+    @Value("${ai.context-window-size:10}")
+    private int contextWindowSize;
 
     private static final String GEMINI_MODEL = "gemini-2.5-flash";
 
@@ -42,14 +47,26 @@ public class AiSseService {
 
     public SseEmitter askGPT(String crawledContent, String question, Long userId, Long articleId) {
         SseEmitter emitter = new SseEmitter(10 * 60 * 1000L);
-        Map<String, Object> body = createGeminiRequestBody(
-                "?? ?? ??? ???? ??? ??? ???? ????.",
-                "?? ??:\n" + crawledContent + "\n\n??? ??:\n" + question
-        );
+
+        Map<String, Object> body;
+        if (userId != null && articleId != null) {
+            // ??? ??: ?? ?? ??? ???? ???? ??? ???? ??
+            List<ChatHistory> history = chatHistoryService.getRecentContext(userId, articleId, contextWindowSize);
+            body = createContextualRequestBody(crawledContent, question, history);
+            log.debug("[Gemini SSE] ???? {}? ???? ?? - userId: {}, articleId: {}", history.size(), userId, articleId);
+        } else {
+            // ????: ?? ?? (?? ?? ??)
+            body = createGeminiRequestBody(
+                    "?? ?? ??? ???? ??? ??? ???? ????.",
+                    "?? ??:\n" + crawledContent + "\n\n??? ??:\n" + question
+            );
+        }
+
         processGeminiStreaming(emitter, body, question, userId, articleId);
         return emitter;
     }
 
+    // ?? ??? (summarizeContent, ???? askGPT)
     private Map<String, Object> createGeminiRequestBody(String systemPrompt, String userMessage) {
         return Map.of(
                 "system_instruction", Map.of(
@@ -58,6 +75,40 @@ public class AiSseService {
                 "contents", List.of(
                         Map.of("parts", List.of(Map.of("text", userMessage)))
                 )
+        );
+    }
+
+    // ???? ?? ??? (??? ?? askGPT) - ???? ??? ?? ?? ??
+    private Map<String, Object> createContextualRequestBody(String crawledContent, String question,
+                                                             List<ChatHistory> history) {
+        // ?? ??? system_instruction? ?? (? turn ?? ??)
+        String systemPrompt = "?? ?? ??? ???? ??? ??? ???? ????.\n\n?? ??:\n" + crawledContent;
+
+        List<Map<String, Object>> contents = new ArrayList<>();
+
+        // ?? ?? ?? (user ? model ??)
+        for (ChatHistory chat : history) {
+            contents.add(Map.of(
+                    "role", "user",
+                    "parts", List.of(Map.of("text", chat.getQuestion()))
+            ));
+            contents.add(Map.of(
+                    "role", "model",
+                    "parts", List.of(Map.of("text", chat.getAnswer()))
+            ));
+        }
+
+        // ?? ??
+        contents.add(Map.of(
+                "role", "user",
+                "parts", List.of(Map.of("text", question))
+        ));
+
+        return Map.of(
+                "system_instruction", Map.of(
+                        "parts", List.of(Map.of("text", systemPrompt))
+                ),
+                "contents", contents
         );
     }
 

--- a/src/main/java/com/example/globalTimes_be/domain/ai/service/AiSseService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/ai/service/AiSseService.java
@@ -21,7 +21,7 @@ import java.util.Map;
 @Service
 public class AiSseService {
 
-    // Gemini (?? ??)
+    // Gemini (현재 활성)
     @Qualifier("geminiWebClient")
     private final WebClient geminiWebClient;
 
@@ -38,7 +38,7 @@ public class AiSseService {
     public SseEmitter summarizeContent(String crawledContent, String language) {
         SseEmitter emitter = new SseEmitter(10 * 60 * 1000L);
         Map<String, Object> body = createGeminiRequestBody(
-                "? ??? " + language + "? ????.",
+                "이 기사를 " + language + "로 요약해줘.",
                 crawledContent
         );
         processGeminiStreaming(emitter, body, null, null, null);
@@ -50,15 +50,15 @@ public class AiSseService {
 
         Map<String, Object> body;
         if (userId != null && articleId != null) {
-            // ??? ??: ?? ?? ??? ???? ???? ??? ???? ??
+            // 로그인 유저: 슬라이딩 윈도우로 이전 대화 내역 가져와 컨텍스트 구성
             List<ChatHistory> history = chatHistoryService.getRecentContext(userId, articleId, contextWindowSize);
             body = createContextualRequestBody(crawledContent, question, history);
-            log.debug("[Gemini SSE] ???? {}? ???? ?? - userId: {}, articleId: {}", history.size(), userId, articleId);
+            log.debug("[Gemini SSE] 컨텍스트 {}턴 포함 요청 - userId={}, articleId={}", history.size(), userId, articleId);
         } else {
-            // ????: ?? ?? (?? ?? ??)
+            // 비로그인: 단일 질의 (기존 동작 유지)
             body = createGeminiRequestBody(
-                    "?? ?? ??? ???? ??? ??? ???? ????.",
-                    "?? ??:\n" + crawledContent + "\n\n??? ??:\n" + question
+                    "다음 기사 내용을 주요 참고 자료로 활용하되, 기사에 없는 정보는 일반 지식을 활용해 자세하게 답변해줘.",
+                    "기사 내용:\n" + crawledContent + "\n\n사용자 질문:\n" + question
             );
         }
 
@@ -66,7 +66,7 @@ public class AiSseService {
         return emitter;
     }
 
-    // ?? ??? (summarizeContent, ???? askGPT)
+    // 단일 질의용 (summarizeContent, 비로그인 askGPT)
     private Map<String, Object> createGeminiRequestBody(String systemPrompt, String userMessage) {
         return Map.of(
                 "system_instruction", Map.of(
@@ -78,15 +78,15 @@ public class AiSseService {
         );
     }
 
-    // ???? ?? ??? (??? ?? askGPT) - ???? ??? ?? ?? ??
+    // 컨텍스트 기반 질의용 (로그인 유저 askGPT) - 슬라이딩 윈도우 이전 대화 포함
     private Map<String, Object> createContextualRequestBody(String crawledContent, String question,
                                                              List<ChatHistory> history) {
-        // ?? ??? system_instruction? ?? (? turn ?? ??)
-        String systemPrompt = "?? ?? ??? ???? ??? ??? ???? ????.\n\n?? ??:\n" + crawledContent;
+        // 기사 내용은 system_instruction에 포함 (매 turn 반복 전달 방지)
+        String systemPrompt = "다음 기사 내용을 주요 참고 자료로 활용하되, 기사에 없는 정보는 일반 지식을 활용해 자세하게 답변해줘.\n\n기사 내용:\n" + crawledContent;
 
         List<Map<String, Object>> contents = new ArrayList<>();
 
-        // ?? ?? ?? (user ? model ??)
+        // 이전 대화 내역 (user -> model 교대)
         for (ChatHistory chat : history) {
             contents.add(Map.of(
                     "role", "user",
@@ -98,7 +98,7 @@ public class AiSseService {
             ));
         }
 
-        // ?? ??
+        // 현재 질문
         contents.add(Map.of(
                 "role", "user",
                 "parts", List.of(Map.of("text", question))
@@ -144,104 +144,34 @@ public class AiSseService {
                             emitter.send(resultBuilder.toString());
                         }
                     } catch (Exception e) {
-                        log.warn("[Gemini SSE] JSON ?? ??: {}", e.getMessage());
+                        log.warn("[Gemini SSE] JSON 파싱 오류: {}", e.getMessage());
                     }
                 })
                 .doOnComplete(() -> {
-                    // ???? ?? ? ???? ??
+                    // 스트리밍 완료 후 히스토리 저장
                     if (userId != null && articleId != null && question != null) {
                         chatHistoryService.save(userId, articleId, question, resultBuilder.toString());
                     }
                     try {
                         emitter.complete();
                     } catch (Exception e) {
-                        log.warn("[Gemini SSE] emitter complete ??: {}", e.getMessage());
+                        log.warn("[Gemini SSE] emitter complete 오류: {}", e.getMessage());
                     }
                 })
                 .doOnError(error -> {
-                    log.error("[Gemini SSE] ?? ? ?? ??", error);
+                    log.error("[Gemini SSE] 처리 중 오류 발생", error);
                     emitter.completeWithError(error);
                 })
                 .subscribe();
     }
 
 
-    // GPT (??? / ?? ??)
+    // GPT (비활성 / 주석 보존)
     // private final WebClient openAiWebClient;
     //
-    // public SseEmitter summarizeContent(String crawledContent, String language) {
-    //     SseEmitter emitter = new SseEmitter(10 * 60 * 1000L);
-    //     processStreamingRequest(emitter, createRequestBody(crawledContent, language), null, null, null);
-    //     return emitter;
-    // }
-    //
-    // public SseEmitter askGPT(String crawledContent, String question, Long userId, Long articleId) {
-    //     SseEmitter emitter = new SseEmitter(10 * 60 * 1000L);
-    //     processStreamingRequest(emitter, createQuestionRequestBody(crawledContent, question), question, userId, articleId);
-    //     return emitter;
-    // }
-    //
-    // private void processStreamingRequest(SseEmitter emitter, Map<String, Object> requestBody,
-    //                                      String question, Long userId, Long articleId) {
-    //     StringBuilder resultBuilder = new StringBuilder();
-    //     openAiWebClient.post()
-    //             .uri("/chat/completions")
-    //             .accept(MediaType.TEXT_EVENT_STREAM)
-    //             .bodyValue(requestBody)
-    //             .retrieve()
-    //             .bodyToFlux(String.class)
-    //             .doOnNext(data -> {
-    //                 String jsonPart = data.trim();
-    //                 if ("[DONE]".equals(jsonPart)) {
-    //                     if (userId != null && articleId != null && question != null) {
-    //                         chatHistoryService.save(userId, articleId, question, resultBuilder.toString());
-    //                     }
-    //                     emitter.complete();
-    //                     return;
-    //                 }
-    //                 try {
-    //                     Map response = new ObjectMapper().readValue(jsonPart, Map.class);
-    //                     List<Map<String, Object>> choices = (List<Map<String, Object>>) response.get("choices");
-    //                     if (choices != null && !choices.isEmpty()) {
-    //                         Map<String, Object> delta = (Map<String, Object>) choices.get(0).get("delta");
-    //                         if (delta != null && delta.containsKey("content")) {
-    //                             String contentText = (String) delta.get("content");
-    //                             resultBuilder.append(contentText);
-    //                             emitter.send(resultBuilder.toString());
-    //                         }
-    //                     }
-    //                 } catch (Exception e) {
-    //                     log.warn("JSON ?? ?? ??!", e);
-    //                     emitter.completeWithError(e);
-    //                 }
-    //             })
-    //             .doOnError(error -> {
-    //                 log.error("OpenAI SSE ?? ? ?? ??", error);
-    //                 emitter.completeWithError(error);
-    //             })
-    //             .subscribe();
-    // }
-    //
-    // private Map<String, Object> createRequestBody(String crawledContent, String language) {
-    //     return Map.of(
-    //             "model", "gpt-4o-mini",
-    //             "messages", List.of(
-    //                     Map.of("role", "system", "content", "? ??? " + language + "? ????."),
-    //                     Map.of("role", "user", "content", crawledContent)
-    //             ),
-    //             "stream", true
-    //     );
-    // }
-    //
-    // private Map<String, Object> createQuestionRequestBody(String crawledContent, String question) {
-    //     return Map.of(
-    //             "model", "gpt-4o-mini",
-    //             "messages", List.of(
-    //                     Map.of("role", "system", "content", "?? ?? ??? ???? ??? ??? ???? ????."),
-    //                     Map.of("role", "user", "content", "?? ??:\n" + crawledContent),
-    //                     Map.of("role", "user", "content", "??? ??:\n" + question)
-    //             ),
-    //             "stream", true
-    //     );
-    // }
+    // public SseEmitter summarizeContent(String crawledContent, String language) { ... }
+    // public SseEmitter askGPT(...) { ... }
+    // private void processStreamingRequest(...) { ... }
+    // private Map<String, Object> createRequestBody(...) { ... }
+    // private Map<String, Object> createQuestionRequestBody(...) { ... }
 }

--- a/src/main/java/com/example/globalTimes_be/domain/chat/repository/ChatHistoryRepository.java
+++ b/src/main/java/com/example/globalTimes_be/domain/chat/repository/ChatHistoryRepository.java
@@ -1,6 +1,7 @@
 package com.example.globalTimes_be.domain.chat.repository;
 
 import com.example.globalTimes_be.domain.chat.entity.ChatHistory;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,4 +15,7 @@ public interface ChatHistoryRepository extends JpaRepository<ChatHistory, Long> 
 
     // 특정 기사의 사용자 히스토리 (오래된순) - 상세 페이지 대화 흐름용
     List<ChatHistory> findByUserIdAndArticleIdOrderByCreatedAtAsc(Long userId, Long articleId);
+
+    // 슬라이딩 윈도우 컨텍스트용: 최근 N건만 최신순으로 조회
+    List<ChatHistory> findByUserIdAndArticleIdOrderByCreatedAtDesc(Long userId, Long articleId, Pageable pageable);
 }

--- a/src/main/java/com/example/globalTimes_be/domain/chat/service/ChatHistoryService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/chat/service/ChatHistoryService.java
@@ -13,6 +13,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,5 +72,16 @@ public class ChatHistoryService {
                 .stream()
                 .map(ChatHistoryResDTO::from)
                 .collect(Collectors.toList());
+    }
+
+    // 컨텍스트 창용: 최근 N턴을 오래된 순으로 반환 (AiSseService에서 Gemini payload 구성에 사용)
+    @Transactional(readOnly = true)
+    public List<ChatHistory> getRecentContext(Long userId, Long articleId, int windowSize) {
+        PageRequest pageable = PageRequest.of(0, windowSize, Sort.by(Sort.Direction.DESC, "createdAt"));
+        List<ChatHistory> recent = new ArrayList<>(
+                chatHistoryRepository.findByUserIdAndArticleIdOrderByCreatedAtDesc(userId, articleId, pageable)
+        );
+        Collections.reverse(recent); // 최신순 → 오래된 순으로 뒤집어 대화 흐름 유지
+        return recent;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,3 +68,7 @@ perspectives:
 # 트렌드 기사 요약 캐시 (0이면 미사용, 동일 URL 반복 요청 시 GPT 호출 절감)
 trend:
   summary-cache-ttl-seconds: 21600
+
+# AI 컨텍스트 대화 슬라이딩 윈도우 크기 (최근 N턴만 Gemini에 전달, 토큰 비용 제어)
+ai:
+  context-window-size: 10


### PR DESCRIPTION
## 📋 개요

기존 `/api/ai/{id}/ask` 는 매 요청이 독립적으로 처리되어 이전 대화 맥락을 인식하지 못함
로그인 유저의 경우 `ChatHistory` 에 저장된 이전 대화 내역을 슬라이딩 윈도우 방식으로
Gemini payload 에 누적 전달하여, 실제 채팅방처럼 맥락을 이어가는 대화를 구현.

또한 기존의 하드코딩 되어있던 질의문을 변경함.
Gemini 시스템 프롬프트를 개선하여 기사에 없는 정보는 기존의 학습한 정보로 답변하도록 수정.
-> 기준 : Knowledge cutoff(2025년 1월)

## 🔗 Related Issue
Closes #101

## ✅ 작업 내용

### ChatHistoryRepository
- 슬라이딩 윈도우 컨텍스트용 최근 N건 조회 메서드 추가 (`Pageable` 기반)

### ChatHistoryService
- `getRecentContext()` 메서드 추가
- `Pageable`로 최신순 N건 조회 후 `Collections.reverse()`로 오래된 순 정렬하여 반환
- 대화 흐름(오래된 → 최신) 순서 보장

### AiSseService
- `askGPT()` 로그인/비로그인 분기 처리
  - **로그인**: 이전 대화 내역 포함 `createContextualRequestBody()` 호출
  - **비로그인**: 기존 단일 질의 유지

- `createContextualRequestBody()` 신규 추가
  - 기사 내용을 `system_instruction`에 포함 (각 turn 중복 전달 방지)
  - `contents` 배열에 `user → model` 교대 구조로 이전 대화 누적
  - 마지막에 현재 질문 추가

- 시스템 프롬프트 개선
  - 기존: 기사 내용만 참고하여 답변
  - 변경: 기사 내용을 주요 참고 자료로 활용하되, **기사에 없는 정보는 일반 지식으로 보완 답변**

### application.yml

- `ai.context-window-size: 10` 설정 추가 (조정 가능)
- 
## 💡 Gemini 컨텍스트 payload 구조

```
json
{
  "system_instruction": {
    "parts": [{ "text": "기사 내용을 참고하여 답변해줘.\n\n기사 내용: ..." }]
  },
  "contents": [
    { "role": "user",  "parts": [{ "text": "이전 질문 1" }] },
    { "role": "model", "parts": [{ "text": "이전 답변 1" }] },
    { "role": "user",  "parts": [{ "text": "현재 질문" }] }
  ]
}
```
## 🧪 테스트 방법

### 사전 준비

1. 서버 실행 (`.\gradlew.bat bootRun`)
2. Swagger (`http://localhost:8080/swagger-ui/index.html`) 접속
3. `GET /oauth2/authorization/google` 로 로그인 후 JWT 토큰 발급
4. Swagger **Authorize** 버튼에 토큰 입력

---

### 시나리오 1 - 컨텍스트 연결 확인 (로그인)

1. 기사 목록 조회 후 적당한 `articleId` 확인
2. `GET /api/ai/{id}/ask?question=이 기사의 주인공이 누구야?` 질의 → 답변 확인 및 저장
3. `GET /api/ai/{id}/ask?question=그 사람의 이전 성적은 어때?` 재질의
4. **"그 사람"** 을 이전 답변의 인물로 인식하여 답하면 ✅ 성공
6. 서버 로그에서 `[Gemini SSE] 컨텍스트 1턴 포함하여 요청` 확인

---

### 시나리오 2 - 비로그인 단일 질의 유지
1. Swagger **Authorize 해제** (토큰 제거)
2. 동일 질문 전송
3. 컨텍스트 없이 단일 질의로 처리되면 ✅ 성공

---

### 시나리오 3 - 슬라이딩 윈도우 동작 확인

1. 같은 기사에 **11번 이상** 질의
2. `context-window-size: 10` 설정으로 인해 가장 오래된 1턴은 제외되고 최근 10턴만 전달되면 ✅ 성공