### PR TITLE
✨ [FEAT/#103] 스크랩 기능 서버 저장 전환 (localStorage → DB)

### DIFF
--- a/src/main/java/com/example/globalTimes_be/domain/scrap/controller/ScrapController.java
+++ b/src/main/java/com/example/globalTimes_be/domain/scrap/controller/ScrapController.java
@@ -6,26 +6,65 @@ import com.example.globalTimes_be.global.apiPayload.code.ApiResponse;
 import com.example.globalTimes_be.global.apiPayload.code.status.GlobalSuccessStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/scrap")
-public class ScrapController implements ScrapControllerDocs{
+@RequestMapping("/api")
+public class ScrapController implements ScrapControllerDocs {
+
     private final ScrapService scrapService;
 
-    //id값을 리스트로 받으면 리스트 형식으로 데이터 반환
+    // 기존 API 유지 (localStorage 기반 비로그인 호환)
     @Override
-    @GetMapping
+    @GetMapping("/scrap")
     public ResponseEntity<ApiResponse> getScrapArticle(@RequestParam List<Long> id) {
-        //서비스단에서 리스트형식 받으면 리스트 형식으로 article 데이터 반환
         List<ScrapResDTO> scrapResDTOs = scrapService.getScrap(id);
-
         return ApiResponse.success(GlobalSuccessStatus._OK.getResponse(), scrapResDTOs);
+    }
+
+    // 스크랩 토글 (로그인 필요)
+    @Override
+    @PostMapping("/articles/{id}/scrap")
+    public ResponseEntity<ApiResponse> toggleScrap(
+            @PathVariable("id") Long articleId,
+            Authentication authentication
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        boolean scrapped = scrapService.toggle(userId, articleId);
+        return ApiResponse.success(
+                GlobalSuccessStatus._OK.getResponse(),
+                Map.of("scrapped", scrapped)
+        );
+    }
+
+    // 내 스크랩 목록 (로그인 필요)
+    @Override
+    @GetMapping("/user/scraps")
+    public ResponseEntity<ApiResponse> getMyScrapList(Authentication authentication) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ApiResponse.success(
+                GlobalSuccessStatus._OK.getResponse(),
+                scrapService.getScrapList(userId)
+        );
+    }
+
+    // 특정 기사 스크랩 여부 (로그인 필요)
+    @Override
+    @GetMapping("/articles/{id}/scrap/status")
+    public ResponseEntity<ApiResponse> getScrapStatus(
+            @PathVariable("id") Long articleId,
+            Authentication authentication
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        boolean scrapped = scrapService.isScrapped(userId, articleId);
+        return ApiResponse.success(
+                GlobalSuccessStatus._OK.getResponse(),
+                Map.of("scrapped", scrapped)
+        );
     }
 }

--- a/src/main/java/com/example/globalTimes_be/domain/scrap/controller/ScrapControllerDocs.java
+++ b/src/main/java/com/example/globalTimes_be/domain/scrap/controller/ScrapControllerDocs.java
@@ -1,86 +1,140 @@
 package com.example.globalTimes_be.domain.scrap.controller;
 
+import com.example.globalTimes_be.global.apiPayload.code.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
-@Tag(name = "마이스크랩 페이지", description = "마이스크랩 페이지 관련 API입니다.")
+@Tag(name = "스크랩", description = "스크랩 관련 API")
 public interface ScrapControllerDocs {
-    @Operation(summary = "마이스크랩 기사 데이터 응답",
-            description = "마이스크랩에 대한 기사의 간략한 정보 응답 API")
+
+    @Operation(summary = "스크랩 기사 정보 조회 (비로그인 호환)",
+            description = "localStorage의 기사 ID 목록을 받아 기사 정보를 반환합니다. 비로그인 사용자용 기존 API 유지.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "응답 성공",
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "응답 성공",
                     content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = com.example.globalTimes_be.global.apiPayload.code.ApiResponse.class),
+                            schema = @Schema(implementation = ApiResponse.class),
                             examples = @ExampleObject(value = """
                                 {
-                                     "timestamp": "2025-04-03T10:38:27.3875865",
-                                     "isSuccess": true,
-                                     "message": "응답에 성공했습니다.",
-                                     "data": [
-                                         {
-                                             "id": 1,
-                                             "sourceName": "the-washington-post",
-                                             "title": "Duke looks a cut above as it beats Alabama to reach 18th Final Four - The Washington Post",
-                                             "description": "The Blue Devils were dominant in the East Region final Saturday night, pulling away from the Crimson Tide, 85-65.",
-                                             "urlToImage": "https://www.washingtonpost.com/wp-apps/imrs.php?src=https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/HGUFEQVDJCK5ORKRD6ASZKBICE_size-normalized.JPG&w=1440",
-                                             "publishedAt": "2025-03-30T08:37:33"
-                                         },
-                                         {
-                                             "id": 2,
-                                             "sourceName": "cnn",
-                                             "title": "Trial will determine who will pay $600 million settlement in disastrous Norfolk Southern derailment - Yahoo",
-                                             "description": "Norfolk Southern wants two other companies to help pay for the $600 million class-action settlement it agreed to over its disastrous 2023 train derailment near the Ohio-Pennsylvania border and the toxic chemicals that were released and burned.",
-                                             "urlToImage": "https://media.cnn.com/api/v1/images/stellar/prod/ap25087719392130.jpg?c=16x9&q=w_800,c_fill",
-                                             "publishedAt": "2025-03-30T06:08:00"
-                                         },
-                                         {
-                                             "id": 4,
-                                             "sourceName": "cbs-news",
-                                             "title": "Comedian Amber Ruffin pulled from White House Correspondents' Dinner - CBS News",
-                                             "description": "White House Correspondents Association President Eugene Daniels said that the WHCA board had \\"unanimously decided we are no longer featuring a comedic performance this year.\\"",
-                                             "urlToImage": "https://assets1.cbsnewsstatic.com/hub/i/r/2025/03/30/3b6c22cd-4725-4c08-88c0-c3225f224d99/thumbnail/1200x630/d1f191a5b437275a2a414f629d579810/gettyimages-2207109898.jpg?v=95354023eeb6141c58c08d9a5716f291",
-                                             "publishedAt": "2025-03-30T03:27:00"
-                                         }
-                                     ]
-                                 }
+                                    "timestamp": "2025-04-03T10:38:27",
+                                    "isSuccess": true,
+                                    "message": "응답에 성공했습니다.",
+                                    "data": [
+                                        {
+                                            "id": 1,
+                                            "sourceName": "the-washington-post",
+                                            "title": "Duke looks a cut above...",
+                                            "description": "The Blue Devils were dominant...",
+                                            "urlToImage": "https://example.com/image.jpg",
+                                            "publishedAt": "2025-03-30T08:37:33"
+                                        }
+                                    ]
+                                }
                             """)
                     )
-            ),
-            @ApiResponse(responseCode = "500", description = "서버 에러가 발생하였습니다.",
+            )
+    })
+    ResponseEntity<ApiResponse> getScrapArticle(
+            @Parameter(description = "뉴스기사 ID 목록", example = "?id=1&id=2&id=4")
+            @NotNull(message = "뉴스기사 ID는 비어있을 수 없습니다.")
+            @RequestParam List<Long> id);
+
+    @Operation(summary = "스크랩 토글 (추가/취소)",
+            description = "기사를 스크랩하거나 취소합니다. 이미 스크랩된 경우 취소, 아닌 경우 추가됩니다. 로그인 필요.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "토글 성공",
                     content = @Content(mediaType = "application/json",
-                            examples = {@ExampleObject(name = "서버에러", value = """
-                                    {
-                                      "timestamp": "2024-10-30T15:38:12.43483271",
-                                      "isSuccess": false,
-                                      "message": "서버 에러가 발생하였습니다.",
-                                      "data": null
-                                    }
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "스크랩 추가", value = """
+                                        {
+                                            "timestamp": "2026-03-31T17:00:00",
+                                            "isSuccess": true,
+                                            "message": "응답에 성공했습니다.",
+                                            "data": { "scrapped": true }
+                                        }
                                     """),
-                                    @ExampleObject(name = "기사정보 없음 에러", value = """
-                                            {
-                                              "timestamp": "2024-10-30T15:38:12.43483271",
-                                              "isSuccess": false,
-                                              "message": "요청한 기사에 대한 정보가 없습니다.",
-                                              "data": null
-                                            }
+                                    @ExampleObject(name = "스크랩 취소", value = """
+                                        {
+                                            "timestamp": "2026-03-31T17:00:00",
+                                            "isSuccess": true,
+                                            "message": "응답에 성공했습니다.",
+                                            "data": { "scrapped": false }
+                                        }
                                     """)
                             }
                     )
             ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")
     })
-    public ResponseEntity<?> getScrapArticle(
-            @Parameter(description = "뉴스기사 ID", example = "?id=1&id=2&id=4")
-            @NotNull(message = "뉴스기사id는 비어있을 수 없습니다.")
-            @RequestParam List<Long> id);
+    ResponseEntity<ApiResponse> toggleScrap(
+            @Parameter(description = "기사 ID", example = "7285") @PathVariable("id") Long articleId,
+            Authentication authentication);
+
+    @Operation(summary = "내 스크랩 목록 조회",
+            description = "로그인 유저의 스크랩 목록을 최신순으로 반환합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(value = """
+                                {
+                                    "timestamp": "2026-03-31T17:00:00",
+                                    "isSuccess": true,
+                                    "message": "응답에 성공했습니다.",
+                                    "data": [
+                                        {
+                                            "articleId": 7285,
+                                            "title": "기사 제목...",
+                                            "sourceName": "yna",
+                                            "urlToImage": "https://example.com/photo.jpg",
+                                            "description": "기사 설명...",
+                                            "publishedAt": "2026-03-26T17:41:00",
+                                            "scrappedAt": "2026-03-31T17:14:35"
+                                        }
+                                    ]
+                                }
+                            """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")
+    })
+    ResponseEntity<ApiResponse> getMyScrapList(Authentication authentication);
+
+    @Operation(summary = "특정 기사 스크랩 여부 조회",
+            description = "로그인 유저가 특정 기사를 스크랩했는지 여부를 반환합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(value = """
+                                {
+                                    "timestamp": "2026-03-31T17:00:00",
+                                    "isSuccess": true,
+                                    "message": "응답에 성공했습니다.",
+                                    "data": { "scrapped": true }
+                                }
+                            """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")
+    })
+    ResponseEntity<ApiResponse> getScrapStatus(
+            @Parameter(description = "기사 ID", example = "7285") @PathVariable("id") Long articleId,
+            Authentication authentication);
 }

--- a/src/main/java/com/example/globalTimes_be/domain/scrap/dto/response/ScrapListResDTO.java
+++ b/src/main/java/com/example/globalTimes_be/domain/scrap/dto/response/ScrapListResDTO.java
@@ -1,0 +1,47 @@
+package com.example.globalTimes_be.domain.scrap.dto.response;
+
+import com.example.globalTimes_be.domain.scrap.entity.Scrap;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@Schema(description = "내 스크랩 목록 응답 DTO")
+public class ScrapListResDTO {
+
+    @Schema(description = "기사 ID", example = "7285")
+    private Long articleId;
+
+    @Schema(description = "기사 제목", example = "Trump Auto Tariffs...")
+    private String title;
+
+    @Schema(description = "언론사명", example = "BBC News")
+    private String sourceName;
+
+    @Schema(description = "기사 썸네일 URL", example = "https://img.example.com/photo.jpg")
+    private String urlToImage;
+
+    @Schema(description = "기사 설명", example = "Article description...")
+    private String description;
+
+    @Schema(description = "기사 발행일", example = "2025-03-30T08:37:33")
+    private LocalDateTime publishedAt;
+
+    @Schema(description = "스크랩 등록일", example = "2026-03-31T17:14:35")
+    private LocalDateTime scrappedAt;
+
+    public static ScrapListResDTO from(Scrap scrap) {
+        return ScrapListResDTO.builder()
+                .articleId(scrap.getArticle().getId())
+                .title(scrap.getArticle().getTitle())
+                .sourceName(scrap.getArticle().getSource().getSourceName())
+                .urlToImage(scrap.getArticle().getUrlToImage())
+                .description(scrap.getArticle().getDescription())
+                .publishedAt(scrap.getArticle().getPublishedAt())
+                .scrappedAt(scrap.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/domain/scrap/entity/Scrap.java
+++ b/src/main/java/com/example/globalTimes_be/domain/scrap/entity/Scrap.java
@@ -1,0 +1,44 @@
+package com.example.globalTimes_be.domain.scrap.entity;
+
+import com.example.globalTimes_be.domain.article.entity.Article;
+import com.example.globalTimes_be.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "scrap", indexes = {
+        @Index(name = "idx_scrap_user_id", columnList = "user_id"),
+        @Index(name = "idx_scrap_user_article", columnList = "user_id, article_id", unique = true)
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Scrap {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "scrap_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id", nullable = false)
+    private Article article;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    public static Scrap create(User user, Article article) {
+        return Scrap.builder()
+                .user(user)
+                .article(article)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/domain/scrap/exception/ScrapErrorStatus.java
+++ b/src/main/java/com/example/globalTimes_be/domain/scrap/exception/ScrapErrorStatus.java
@@ -11,6 +11,8 @@ public enum ScrapErrorStatus implements BaseResponse {
     _CUSTOM_ERROR(HttpStatus.BAD_REQUEST, "에러테스트 요청입니다."),
 
     _EMPTY_SCRAP_ARTICLE(HttpStatus.INTERNAL_SERVER_ERROR, "요청한 기사에 대한 정보가 없습니다."),
+    _SCRAP_ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 기사입니다."),
+    _SCRAP_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/globalTimes_be/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/example/globalTimes_be/domain/scrap/repository/ScrapRepository.java
@@ -1,0 +1,21 @@
+package com.example.globalTimes_be.domain.scrap.repository;
+
+import com.example.globalTimes_be.domain.scrap.entity.Scrap;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ScrapRepository extends JpaRepository<Scrap, Long> {
+
+    // 스크랩 여부 확인
+    Optional<Scrap> findByUserIdAndArticleId(Long userId, Long articleId);
+
+    // 사용자 스크랩 목록 (최신순)
+    List<Scrap> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    // 스크랩 존재 여부 (boolean)
+    boolean existsByUserIdAndArticleId(Long userId, Long articleId);
+}

--- a/src/main/java/com/example/globalTimes_be/domain/scrap/service/ScrapService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/scrap/service/ScrapService.java
@@ -2,51 +2,91 @@ package com.example.globalTimes_be.domain.scrap.service;
 
 import com.example.globalTimes_be.domain.article.entity.Article;
 import com.example.globalTimes_be.domain.article.repository.ArticleRepository;
+import com.example.globalTimes_be.domain.scrap.dto.response.ScrapListResDTO;
 import com.example.globalTimes_be.domain.scrap.dto.response.ScrapResDTO;
+import com.example.globalTimes_be.domain.scrap.entity.Scrap;
 import com.example.globalTimes_be.domain.scrap.exception.ScrapErrorStatus;
+import com.example.globalTimes_be.domain.scrap.repository.ScrapRepository;
+import com.example.globalTimes_be.domain.user.entity.User;
+import com.example.globalTimes_be.domain.user.repository.UserRepository;
 import com.example.globalTimes_be.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class ScrapService {
-    private final ArticleRepository articleRepository;
 
+    private final ArticleRepository articleRepository;
+    private final ScrapRepository scrapRepository;
+    private final UserRepository userRepository;
+
+    // 기존 API 유지 (localStorage 기반 비로그인 호환)
     public List<ScrapResDTO> getScrap(List<Long> articleIds) {
         List<ScrapResDTO> scrapResDTOs = new ArrayList<>();
 
-        for(Long articleId : articleIds) {
-            //기사 id로 db에서 정보 가져옴
+        for (Long articleId : articleIds) {
             Article article = articleRepository.findById(articleId).orElse(null);
+            if (article == null) continue;
 
-            //만약 해당 기사의 정보가 없으면 패스
-            if (article == null) {
-                continue;
-            }
-
-            //응답 DTO 생성
-            ScrapResDTO scrapResDTO = ScrapResDTO.builder()
+            scrapResDTOs.add(ScrapResDTO.builder()
                     .id(article.getId())
                     .sourceName(article.getSource().getSourceName())
                     .title(article.getTitle())
                     .description(article.getDescription())
                     .urlToImage(article.getUrlToImage())
                     .publishedAt(article.getPublishedAt())
-                    .build();
-
-            // dto리스트에 추가
-            scrapResDTOs.add(scrapResDTO);
+                    .build());
         }
 
-        //만약 리스트가 비었다면 에러처리 (프론트 확인용)
         if (scrapResDTOs.isEmpty()) {
             throw new BaseException(ScrapErrorStatus._EMPTY_SCRAP_ARTICLE.getResponse());
         }
 
         return scrapResDTOs;
+    }
+
+    // 스크랩 토글 (추가/취소)
+    @Transactional
+    public boolean toggle(Long userId, Long articleId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(ScrapErrorStatus._SCRAP_USER_NOT_FOUND.getResponse()));
+        Article article = articleRepository.findById(articleId)
+                .orElseThrow(() -> new BaseException(ScrapErrorStatus._SCRAP_ARTICLE_NOT_FOUND.getResponse()));
+
+        Optional<Scrap> existing = scrapRepository.findByUserIdAndArticleId(userId, articleId);
+
+        if (existing.isPresent()) {
+            scrapRepository.delete(existing.get());
+            log.info("[Scrap] 취소 - userId={}, articleId={}", userId, articleId);
+            return false; // 취소됨
+        } else {
+            scrapRepository.save(Scrap.create(user, article));
+            log.info("[Scrap] 추가 - userId={}, articleId={}", userId, articleId);
+            return true; // 추가됨
+        }
+    }
+
+    // 내 스크랩 목록 조회
+    @Transactional(readOnly = true)
+    public List<ScrapListResDTO> getScrapList(Long userId) {
+        return scrapRepository.findByUserIdOrderByCreatedAtDesc(userId)
+                .stream()
+                .map(ScrapListResDTO::from)
+                .collect(Collectors.toList());
+    }
+
+    // 특정 기사 스크랩 여부 조회
+    @Transactional(readOnly = true)
+    public boolean isScrapped(Long userId, Long articleId) {
+        return scrapRepository.existsByUserIdAndArticleId(userId, articleId);
     }
 }

--- a/src/main/java/com/example/globalTimes_be/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/globalTimes_be/global/config/SecurityConfig.java
@@ -46,9 +46,12 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/error"
                         ).permitAll()
-                        // 사용자 정보 및 채팅 히스토리 조회는 인증 필요
+                        // 사용자 정보 및 채팅 히스토리는 인증 필요
                         .requestMatchers("/api/user/**").authenticated()
                         .requestMatchers("/api/articles/*/chat-history").authenticated()
+                        // 스크랩 토글 및 상태 조회는 인증 필요
+                        .requestMatchers("/api/articles/*/scrap").authenticated()
+                        .requestMatchers("/api/articles/*/scrap/status").authenticated()
                         .anyRequest().permitAll()
                 )
                 .oauth2Login(oauth2 -> oauth2


### PR DESCRIPTION
## ✨ [FEAT] 스크랩 기능 서버 저장 전환 (localStorage → DB)

Closes #103

---

## 📌 배경

기존 스크랩 기능은 브라우저 `localStorage`에 기사 ID만 저장하고,
해당 ID 목록을 백엔드에 넘기면 기사 정보를 반환하는 구조.

소셜 로그인(OAuth2 + JWT) 구현 이후, 로그인 유저에 한해
스크랩 데이터를 서버 DB에 영속 저장하도록 전환.
**비로그인 사용자는 기존 localStorage 방식이 그대로 유지**됨.

---

## 🛠 작업 내용

### 신규 생성
| 파일 | 설명 |
|---|---|
| `domain/scrap/entity/Scrap.java` | 스크랩 엔티티 (user_id + article_id 복합 유니크 인덱스) |
| `domain/scrap/repository/ScrapRepository.java` | 스크랩 JPA 레포지토리 |
| `domain/scrap/dto/response/ScrapListResDTO.java` | 내 스크랩 목록 응답 DTO |

### 수정
| 파일 | 설명 |
|---|---|
| `ScrapService.java` | 기존 `getScrap()` 유지 + `toggle()`, `getScrapList()`, `isScrapped()` 추가 |
| `ScrapController.java` | 기존 `GET /api/scrap` 유지 + 신규 엔드포인트 3개 추가 |
| `ScrapControllerDocs.java` | Swagger 문서 전면 재작성 |
| `ScrapErrorStatus.java` | `_SCRAP_ARTICLE_NOT_FOUND`, `_SCRAP_USER_NOT_FOUND` 추가 |
| `SecurityConfig.java` | 스크랩 토글·상태 조회 엔드포인트 인증 필요 설정 |

---

## 📡 신규 API

| Method | URL | 인증 | 설명 |
|---|---|---|---|
| `GET` | `/api/scrap?id=1&id=2` | 불필요 | 기존 localStorage 호환 API (유지) |
| `POST` | `/api/articles/{id}/scrap` | JWT 필요 | 스크랩 토글 (추가/취소) |
| `GET` | `/api/user/scraps` | JWT 필요 | 내 스크랩 목록 (최신순) |
| `GET` | `/api/articles/{id}/scrap/status` | JWT 필요 | 특정 기사 스크랩 여부 확인 |

> **토글 응답**: `{ "scrapped": true }` / `{ "scrapped": false }`

---

## 🧪 테스트 방법

### 사전 준비

1. 서버 실행 (`.\gradlew.bat bootRun`)
2. Swagger (`http://localhost:8080/swagger-ui/index.html`) 접속
3. `GET /oauth2/authorization/google` 로 로그인 후 JWT 토큰 발급
4. Swagger Authorize 버튼에 토큰 입력

### 시나리오 1 - 스크랩 추가/취소 토글

1. 기사 목록 조회 후 적당한 `articleId` 확인
2. `POST /api/articles/{id}/scrap` 호출 → `{ "scrapped": true }` 확인 (추가)
3. 동일 API 재호출 → `{ "scrapped": false }` 확인 (취소)

### 시나리오 2 - 내 스크랩 목록 조회

1. 스크랩 추가 후 `GET /api/user/scraps` 호출
2. 스크랩한 기사 목록이 최신순으로 반환되는 것 확인
3. `scrappedAt` 필드로 스크랩 등록 시각 확인

### 시나리오 3 - 특정 기사 스크랩 여부 확인

1. `GET /api/articles/{id}/scrap/status` 호출
2. 스크랩한 기사 → `{ "scrapped": true }`, 아닌 기사 → `{ "scrapped": false }` 확인

### 시나리오 4 - 비로그인 호환 확인

1. Swagger Authorize 해제 (토큰 제거)
2. `GET /api/scrap?id=1&id=2` 호출 → 기존대로 기사 정보 반환 확인
3. `POST /api/articles/{id}/scrap` 호출 → 401 반환 확인 (인증 필요)