### PR TITLE
feat: 탐색 필터와 키워드 검색 기능 결합 추가

### DIFF
--- a/src/main/java/com/example/globalTimes_be/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/com/example/globalTimes_be/domain/article/repository/ArticleRepository.java
@@ -42,6 +42,30 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     List<Article> searchByDescriptionOrTitle(@Param("text1") String text,
                                              @Param("text2") String translatedText);
 
+    /**
+     * FULLTEXT 검색 + 탐색(Explore)과 동일 필터(country / category / 하루 date).
+     * 필터 파라미터가 null이면 해당 조건은 적용하지 않음(기존 검색-only와 동일).
+     */
+    @Query(value =
+            "SELECT * FROM article " +
+            "WHERE (MATCH(title, description) AGAINST(:text1 IN BOOLEAN MODE) " +
+            "   OR MATCH(title, description) AGAINST(:text2 IN BOOLEAN MODE)) " +
+            "AND (:country IS NULL OR country = :country) " +
+            "AND (:category IS NULL OR category = :category) " +
+            "AND (:dateFrom IS NULL OR published_at >= :dateFrom) " +
+            "AND (:dateTo IS NULL OR published_at <= :dateTo) " +
+            "ORDER BY published_at DESC " +
+            "LIMIT 100",
+            nativeQuery = true)
+    List<Article> searchByDescriptionOrTitleWithExploreFilters(
+            @Param("text1") String text1,
+            @Param("text2") String text2,
+            @Param("country") String country,
+            @Param("category") String category,
+            @Param("dateFrom") LocalDateTime dateFrom,
+            @Param("dateTo") LocalDateTime dateTo
+    );
+
     // 국가별 시각 비교: 특정 기사 제외 후 키워드 FULLTEXT 탐색, 최신순 최대 50개
     @Query(value =
             "SELECT * FROM article " +

--- a/src/main/java/com/example/globalTimes_be/domain/search/controller/SearchController.java
+++ b/src/main/java/com/example/globalTimes_be/domain/search/controller/SearchController.java
@@ -12,8 +12,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.io.Serializable;
-
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/search")
@@ -23,12 +21,21 @@ public class SearchController implements SearchControllerDocs {
 
     @Override
     @GetMapping
-    public ResponseEntity<ApiResponse> getSearchArticles(@RequestParam String text){
-        //검색어를 영어로 번역
+    public ResponseEntity<ApiResponse> getSearchArticles(
+            @RequestParam String text,
+            @RequestParam(required = false) String country,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String date
+    ) {
         String translatedText = translationService.translateToEnglish(text);
 
-        //원본 검색어 + 번역된 검색어로 기사 검색
-        SearchResDTO searchResDTO = searchArticlesService.getSearchArticles(text, translatedText);
+        SearchResDTO searchResDTO = searchArticlesService.getSearchArticles(
+                text,
+                translatedText,
+                country,
+                category,
+                date
+        );
 
         return ApiResponse.success(GlobalSuccessStatus._OK.getResponse(), searchResDTO);
     }

--- a/src/main/java/com/example/globalTimes_be/domain/search/controller/SearchControllerDocs.java
+++ b/src/main/java/com/example/globalTimes_be/domain/search/controller/SearchControllerDocs.java
@@ -90,5 +90,12 @@ public interface SearchControllerDocs {
             @Parameter(description = "검색 문자열", example = "트럼프")
             @NotBlank(message = "검색어는 비어있을 수 없습니다.")
             @Size(min = 1, message = "검색어는 최소 1자 이상이어야 합니다.")
-            @RequestParam String text);
+            @RequestParam String text,
+            @Parameter(description = "탐색과 동일: 국가 코드(미지정 시 필터 없음)", required = false)
+            @RequestParam(required = false) String country,
+            @Parameter(description = "탐색과 동일: 카테고리(미지정 시 필터 없음)", required = false)
+            @RequestParam(required = false) String category,
+            @Parameter(description = "탐색과 동일: 하루 단위 날짜 yyyy-MM-dd(미지정 시 필터 없음)", required = false)
+            @RequestParam(required = false) String date
+    );
 }

--- a/src/main/java/com/example/globalTimes_be/domain/search/service/SearchArticlesService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/search/service/SearchArticlesService.java
@@ -7,6 +7,10 @@ import com.example.globalTimes_be.domain.search.dto.response.SearchResDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,8 +19,38 @@ import java.util.List;
 public class SearchArticlesService {
     private final ArticleRepository articleRepository;
 
-    public SearchResDTO getSearchArticles(String text, String translatedText){
-        List<Article> articles = articleRepository.searchByDescriptionOrTitle(text, translatedText);
+    /**
+     * @param date 탐색과 동일: 하루 단위(yyyy-MM-dd). null/공백이면 날짜 필터 없음.
+     */
+    public SearchResDTO getSearchArticles(
+            String text,
+            String translatedText,
+            String country,
+            String category,
+            String date
+    ) {
+        LocalDateTime dateFrom = null;
+        LocalDateTime dateTo = null;
+        if (date != null && !date.isBlank()) {
+            try {
+                LocalDate localDate = LocalDate.parse(date);
+                dateFrom = localDate.atStartOfDay();
+                dateTo = localDate.atTime(LocalTime.MAX);
+            } catch (DateTimeParseException ignored) {
+            }
+        }
+
+        String countryParam = (country != null && !country.isBlank()) ? country : null;
+        String categoryParam = (category != null && !category.isBlank()) ? category : null;
+
+        List<Article> articles = articleRepository.searchByDescriptionOrTitleWithExploreFilters(
+                text,
+                translatedText,
+                countryParam,
+                categoryParam,
+                dateFrom,
+                dateTo
+        );
         
         // 검색결과에 대한 기사 DTO 리스트 생성
         List<SearchArticleDTO> searchArticleDTOs = new ArrayList<>();


### PR DESCRIPTION
## 요약

`GET /api/search`에 탐색(Explore)과 동일한 **선택** 쿼리 파라미터(`country`, `category`, `date`)를 추가해, **키워드 FULLTEXT 검색 결과를 해당 조건으로 추려진 데이터로도 작동하도록 설계함
**검색어 없이 조건만** 보는 흐름은 기존처럼 **`/api/articles/explore`**를 그대로 사용

## 배경

- 메인에서 **탐색으로 좁힌 집합 안에서만** 검색하고 싶은 요구가 있음.
- 백엔드에서 검색과 동일한 필터 의미(국가·카테고리·하루 날짜)를 search 쿼리에 붙일 수 있도록 확장.

## 변경 사항

| 구분 | 내용 |
|------|------|
| `ArticleRepository` | `searchByDescriptionOrTitleWithExploreFilters` 추가: 기존 `MATCH(title, description) …` + `country` / `category` / `published_at` 구간 필터, `LIMIT 100` |
| `SearchArticlesService` | `date`를 `yyyy-MM-dd`로 파싱(Explore와 동일), 빈 값은 필터 미적용 |
| `SearchController` / `SearchControllerDocs` | 선택 파라미터 `country`, `category`, `date` 문서화 |

## API

- `GET /api/search?text=...` — 기존과 동일(필터 없음).
- `GET /api/search?text=...&country=...&category=...&date=yyyy-MM-dd` — 검색 + 탐색 조건 결합.

## 비고

- `text`는 여전히 필수. 조건만 탐색은 Explore API 유지.
- 기존 `searchByDescriptionOrTitle` 메서드는 Repository에 유지(다른 용도·호환).

## 테스트 제안

- [x] 필터 없이 검색: 기존과 결과 성격이 동일한지
- [x] `country`/`category`/`date` 조합별로 결과가 필터링되는지
- [x] 잘못된 `date` 형식 시 날짜 필터 무시 동작