### PR TITLE
[FEAT/#108]: 비 로그인 상태 기사 Context 유지하도록 수정(Redis 익명세션)

### DIFF
--- a/src/main/java/com/example/globalTimes_be/domain/ai/controller/AiController.java
+++ b/src/main/java/com/example/globalTimes_be/domain/ai/controller/AiController.java
@@ -2,6 +2,7 @@ package com.example.globalTimes_be.domain.ai.controller;
 
 import com.example.globalTimes_be.domain.ai.service.AiService;
 import com.example.globalTimes_be.domain.ai.service.AiSseService;
+import com.example.globalTimes_be.domain.chat.service.AnonymousChatSessionService;
 import com.example.globalTimes_be.domain.detail.exception.DetailErrorStatus;
 import com.example.globalTimes_be.domain.detail.exception.DetailSuccessStatus;
 import com.example.globalTimes_be.domain.detail.service.DetailService;
@@ -15,6 +16,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.Collections;
+
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/ai")
@@ -22,6 +25,7 @@ public class AiController implements AiControllerDocs {
     public final AiService aiService;
     public final AiSseService aiSseService;
     public final DetailService detailService;
+    public final AnonymousChatSessionService anonymousChatSessionService;
 
     @Override
     @GetMapping(value = "/{id}/summary")
@@ -65,6 +69,8 @@ public class AiController implements AiControllerDocs {
     @GetMapping(value = "/{id}/ask", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter askArticle(@PathVariable Long id,
                                  @RequestParam String question,
+                                 @RequestHeader(value = "X-Anonymous-Session", required = false) String anonymousSessionHeader,
+                                 @RequestParam(value = "anonymousSession", required = false) String anonymousSessionQuery,
                                  Authentication authentication) {
         String crawledContent = detailService.getArticleCrawledContent(id);
 
@@ -72,9 +78,33 @@ public class AiController implements AiControllerDocs {
             throw new BaseException(DetailErrorStatus._CRAWLER_ERROR.getResponse());
         }
 
-        // 로그인 사용자면 userId 전달 → 스트리밍 완료 후 히스토리 저장
-        // 비로그인이면 null 전달 → 저장 생략 (기존 동작 유지)
         Long userId = (authentication != null) ? (Long) authentication.getPrincipal() : null;
-        return aiSseService.askGPT(crawledContent, question, userId, id);
+        // 로그인 시 DB 히스토리만 사용 (익명 식별자 무시)
+        String anonymousSessionId = (userId != null) ? null
+                : (anonymousSessionHeader != null && !anonymousSessionHeader.isBlank()
+                ? anonymousSessionHeader
+                : anonymousSessionQuery);
+        return aiSseService.askGPT(crawledContent, question, userId, id, anonymousSessionId);
+    }
+
+    /**
+     * 비로그인 전용: Redis에 저장된 해당 기사 대화 목록 (오래된 순). 유효한 X-Anonymous-Session 필요.
+     */
+    @Override
+    @GetMapping("/{id}/ask/history")
+    public ResponseEntity<ApiResponse> getAnonymousArticleChatHistory(
+            @PathVariable Long id,
+            @RequestHeader(value = "X-Anonymous-Session", required = false) String anonymousSessionHeader,
+            @RequestParam(value = "anonymousSession", required = false) String anonymousSessionQuery) {
+        String anonymousSessionId = (anonymousSessionHeader != null && !anonymousSessionHeader.isBlank())
+                ? anonymousSessionHeader
+                : anonymousSessionQuery;
+        if (!AnonymousChatSessionService.isValidSessionId(anonymousSessionId)) {
+            return ApiResponse.success(GlobalSuccessStatus._OK.getResponse(), Collections.emptyList());
+        }
+        return ApiResponse.success(
+                GlobalSuccessStatus._OK.getResponse(),
+                anonymousChatSessionService.getFullHistory(anonymousSessionId.trim(), id)
+        );
     }
 }

--- a/src/main/java/com/example/globalTimes_be/domain/ai/controller/AiControllerDocs.java
+++ b/src/main/java/com/example/globalTimes_be/domain/ai/controller/AiControllerDocs.java
@@ -15,6 +15,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -205,5 +206,24 @@ public interface AiControllerDocs {
             @Size(min = 1, message = "질문은 최소 1자 이상이어야 합니다.")
             @RequestParam String question,
 
+            @Parameter(description = "비로그인 시 대화 맥락·Redis 저장용 UUID (헤더). EventSource는 헤더 불가 시 쿼리 anonymousSession 사용.", example = "550e8400-e29b-41d4-a716-446655440000")
+            @RequestHeader(value = "X-Anonymous-Session", required = false) String anonymousSessionHeader,
+
+            @Parameter(description = "비로그인 세션 UUID (쿼리). 헤더와 동일 우선순위: 헤더가 있으면 헤더 사용.")
+            @RequestParam(value = "anonymousSession", required = false) String anonymousSessionQuery,
+
             @Parameter(hidden = true) Authentication authentication);
+
+    @Operation(
+            summary = "비로그인 기사 채팅 히스토리 조회",
+            description = "X-Anonymous-Session(UUID)과 기사 ID로 Redis에 저장된 질문·답변 목록을 반환합니다. 세션이 없거나 형식이 잘못되면 빈 배열입니다."
+    )
+    @ApiResponse(responseCode = "200", description = "성공",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = com.example.globalTimes_be.global.apiPayload.code.ApiResponse.class)))
+    ResponseEntity<?> getAnonymousArticleChatHistory(
+            @Parameter(description = "뉴스기사 ID", example = "1") @PathVariable Long id,
+            @Parameter(description = "비로그인 세션 UUID (헤더)") @RequestHeader(value = "X-Anonymous-Session", required = false) String anonymousSessionHeader,
+            @Parameter(description = "비로그인 세션 UUID (쿼리)") @RequestParam(value = "anonymousSession", required = false) String anonymousSessionQuery
+    );
 }

--- a/src/main/java/com/example/globalTimes_be/domain/ai/service/AiSseService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/ai/service/AiSseService.java
@@ -1,6 +1,8 @@
 package com.example.globalTimes_be.domain.ai.service;
 
+import com.example.globalTimes_be.domain.chat.dto.ChatMessagePair;
 import com.example.globalTimes_be.domain.chat.entity.ChatHistory;
+import com.example.globalTimes_be.domain.chat.service.AnonymousChatSessionService;
 import com.example.globalTimes_be.domain.chat.service.ChatHistoryService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +36,7 @@ public class AiSseService {
     private static final String GEMINI_MODEL = "gemini-2.5-flash";
 
     private final ChatHistoryService chatHistoryService;
+    private final AnonymousChatSessionService anonymousChatSessionService;
 
     public SseEmitter summarizeContent(String crawledContent, String language) {
         SseEmitter emitter = new SseEmitter(10 * 60 * 1000L);
@@ -41,22 +44,32 @@ public class AiSseService {
                 "이 기사를 " + language + "로 요약해줘.",
                 crawledContent
         );
-        processGeminiStreaming(emitter, body, null, null, null);
+        processGeminiStreaming(emitter, body, null, null, null, null);
         return emitter;
     }
 
-    public SseEmitter askGPT(String crawledContent, String question, Long userId, Long articleId) {
+    public SseEmitter askGPT(String crawledContent, String question, Long userId, Long articleId,
+                             String anonymousSessionId) {
         SseEmitter emitter = new SseEmitter(10 * 60 * 1000L);
 
         Map<String, Object> body;
+        String effectiveAnonId = (userId == null && AnonymousChatSessionService.isValidSessionId(anonymousSessionId))
+                ? anonymousSessionId.trim()
+                : null;
+
         if (userId != null && articleId != null) {
             // 로그인 유저: 슬라이딩 윈도우로 이전 대화 내역 가져와 컨텍스트 구성
             List<ChatHistory> history = chatHistoryService.getRecentContext(userId, articleId, contextWindowSize);
-            body = createContextualRequestBody(crawledContent, question, history);
+            List<ChatMessagePair> pairs = ChatMessagePair.fromChatHistories(history);
+            body = createContextualRequestBody(crawledContent, question, pairs);
             log.debug("[Gemini SSE] 컨텍스트 {}턴 포함 요청 - userId={}, articleId={}", history.size(), userId, articleId);
+        } else if (effectiveAnonId != null && articleId != null) {
+            List<ChatMessagePair> prior = anonymousChatSessionService.getRecentContext(
+                    effectiveAnonId, articleId, contextWindowSize);
+            body = createContextualRequestBody(crawledContent, question, prior);
+            log.debug("[Gemini SSE] 익명 컨텍스트 {}턴 포함 요청 - articleId={}", prior.size(), articleId);
         } else {
-            // 비로그인: 단일 질의
-            // 기사 내용을 참고하되, 인사·감사 등 일상 대화에는 간결하게 응답
+            // 비로그인·세션 없음: 단일 질의
             body = createGeminiRequestBody(
                     "당신은 기사 내용을 기반으로 질문에 답하는 AI 어시스턴트입니다.\n" +
                     "- 기사 내용과 관련된 질문이면 기사를 주요 참고 자료로 활용하되, 기사에 없는 정보는 일반 지식을 활용해 자세하게 답변하세요.\n" +
@@ -66,7 +79,7 @@ public class AiSseService {
             );
         }
 
-        processGeminiStreaming(emitter, body, question, userId, articleId);
+        processGeminiStreaming(emitter, body, question, userId, articleId, effectiveAnonId);
         return emitter;
     }
 
@@ -82,27 +95,25 @@ public class AiSseService {
         );
     }
 
-    // 컨텍스트 기반 질의용 (로그인 유저 askGPT) - 슬라이딩 윈도우 이전 대화 포함
+    // 컨텍스트 기반 질의용 (로그인 DB / 익명 Redis) - 슬라이딩 윈도우 이전 대화 포함
     private Map<String, Object> createContextualRequestBody(String crawledContent, String question,
-                                                             List<ChatHistory> history) {
+                                                             List<ChatMessagePair> priorTurns) {
         // 기사 내용은 system_instruction에 포함 (매 turn 반복 전달 방지)
         String systemPrompt = "다음 기사 내용을 주요 참고 자료로 활용하되, 기사에 없는 정보는 일반 지식을 활용해 자세하게 답변해줘.\n\n기사 내용:\n" + crawledContent;
 
         List<Map<String, Object>> contents = new ArrayList<>();
 
-        // 이전 대화 내역 (user -> model 교대)
-        for (ChatHistory chat : history) {
+        for (ChatMessagePair chat : priorTurns) {
             contents.add(Map.of(
                     "role", "user",
-                    "parts", List.of(Map.of("text", chat.getQuestion()))
+                    "parts", List.of(Map.of("text", chat.question()))
             ));
             contents.add(Map.of(
                     "role", "model",
-                    "parts", List.of(Map.of("text", chat.getAnswer()))
+                    "parts", List.of(Map.of("text", chat.answer()))
             ));
         }
 
-        // 현재 질문
         contents.add(Map.of(
                 "role", "user",
                 "parts", List.of(Map.of("text", question))
@@ -118,7 +129,7 @@ public class AiSseService {
 
     @SuppressWarnings("unchecked")
     private void processGeminiStreaming(SseEmitter emitter, Map<String, Object> requestBody,
-                                        String question, Long userId, Long articleId) {
+                                        String question, Long userId, Long articleId, String anonymousSessionId) {
         StringBuilder resultBuilder = new StringBuilder();
 
         geminiWebClient.post()
@@ -155,6 +166,9 @@ public class AiSseService {
                     // 스트리밍 완료 후 히스토리 저장
                     if (userId != null && articleId != null && question != null) {
                         chatHistoryService.save(userId, articleId, question, resultBuilder.toString());
+                    } else if (anonymousSessionId != null && articleId != null && question != null) {
+                        anonymousChatSessionService.appendTurn(
+                                anonymousSessionId, articleId, question, resultBuilder.toString(), contextWindowSize);
                     }
                     try {
                         emitter.complete();

--- a/src/main/java/com/example/globalTimes_be/domain/chat/dto/ChatMessagePair.java
+++ b/src/main/java/com/example/globalTimes_be/domain/chat/dto/ChatMessagePair.java
@@ -1,0 +1,17 @@
+package com.example.globalTimes_be.domain.chat.dto;
+
+import com.example.globalTimes_be.domain.chat.entity.ChatHistory;
+
+import java.util.List;
+
+/**
+ * Gemini 멀티턴 payload 구성용 질문·답변 쌍 (로그인 DB / 익명 Redis 공통).
+ */
+public record ChatMessagePair(String question, String answer) {
+
+    public static List<ChatMessagePair> fromChatHistories(List<ChatHistory> history) {
+        return history.stream()
+                .map(h -> new ChatMessagePair(h.getQuestion(), h.getAnswer()))
+                .toList();
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/domain/chat/service/AnonymousChatSessionService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/chat/service/AnonymousChatSessionService.java
@@ -1,0 +1,102 @@
+package com.example.globalTimes_be.domain.chat.service;
+
+import com.example.globalTimes_be.domain.chat.dto.ChatMessagePair;
+import com.example.globalTimes_be.global.redis.RedisUtil;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AnonymousChatSessionService {
+
+    private static final String KEY_PREFIX = "chat:anon:";
+
+    private final RedisUtil redisUtil;
+    private final ObjectMapper objectMapper;
+
+    @Value("${ai.anonymous-chat.ttl-seconds:604800}")
+    private long ttlSeconds;
+
+    public static boolean isValidSessionId(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return false;
+        }
+        try {
+            UUID.fromString(raw.trim());
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    /**
+     * 컨텍스트용: 오래된 순, 최대 windowSize턴.
+     */
+    public List<ChatMessagePair> getRecentContext(String sessionId, Long articleId, int windowSize) {
+        List<ChatMessagePair> all = loadAll(sessionId, articleId);
+        if (all.isEmpty() || windowSize <= 0) {
+            return all;
+        }
+        if (all.size() <= windowSize) {
+            return all;
+        }
+        return new ArrayList<>(all.subList(all.size() - windowSize, all.size()));
+    }
+
+    /**
+     * 상세 채팅 UI용: 저장된 전체 턴 (오래된 순).
+     */
+    public List<ChatMessagePair> getFullHistory(String sessionId, Long articleId) {
+        return loadAll(sessionId, articleId);
+    }
+
+    public void appendTurn(String sessionId, Long articleId, String question, String answer, int maxTurns) {
+        if (!isValidSessionId(sessionId) || articleId == null) {
+            return;
+        }
+        String key = buildKey(sessionId, articleId);
+        try {
+            List<ChatMessagePair> list = new ArrayList<>(loadAll(sessionId, articleId));
+            list.add(new ChatMessagePair(question, answer));
+            if (maxTurns > 0 && list.size() > maxTurns) {
+                list = new ArrayList<>(list.subList(list.size() - maxTurns, list.size()));
+            }
+            String json = objectMapper.writeValueAsString(list);
+            redisUtil.setData(key, json, ttlSeconds);
+        } catch (Exception e) {
+            log.error("[AnonymousChat] 저장 실패 sessionId={}, articleId={}", sessionId, articleId, e);
+        }
+    }
+
+    private List<ChatMessagePair> loadAll(String sessionId, Long articleId) {
+        if (!isValidSessionId(sessionId) || articleId == null) {
+            return Collections.emptyList();
+        }
+        String key = buildKey(sessionId, articleId);
+        try {
+            String json = redisUtil.getData(key);
+            if (json == null || json.isBlank()) {
+                return Collections.emptyList();
+            }
+            return objectMapper.readValue(json, new TypeReference<>() {
+            });
+        } catch (Exception e) {
+            log.warn("[AnonymousChat] 조회 실패 sessionId={}, articleId={}: {}", sessionId, articleId, e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
+    private static String buildKey(String sessionId, Long articleId) {
+        return KEY_PREFIX + sessionId.trim() + ":" + articleId;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.application.name=globalTimes_be
+
+# 비로그인 기사 채팅 Redis TTL (초). 기본 7일.
+ai.anonymous-chat.ttl-seconds=604800


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) ✨ [FEAT/#1] 로그인 페이지 UI 구현 -->

## 🚀 관련 이슈
- closed #108 

## 🧭 변경 타입
- [x] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [ ] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- 비로그인 사용자도 **동일 기사**에서 이전 질문·답변을 반영한 연속 질의가 가능하도록 Redis에 익명 세션 단위로 대화를 저장.
- `GET /api/ai/{id}/ask`(SSE)에 **`X-Anonymous-Session`(UUID)** 또는 쿼리 **`anonymousSession`**을 넘기면 컨텍스트를 구성하고, 스트리밍 완료 후 턴을 Redis에 갱신. 브라우저 `EventSource`는 헤더를 붙이기 어려워 **쿼리 파라미터**를 함께 지원.
- `GET /api/ai/{id}/ask/history`로 해당 기사·세션의 저장된 질문·답변 목록을 로그인 상태와 유사하게 확인 가능 
- 로그인 사용자는 기존과 동일하게 **DB `chat_history`만** 사용하며, 익명 식별자는 무시
- `application.properties`에 **`ai.anonymous-chat.ttl-seconds`**(기본 7일)를 추가해 Redis TTL을 설정

## 🔍 기술적 배경
- 기존에는 `user_id`가 있는 경우에만 `ChatHistory`에서 슬라이딩 윈도우로 맥락을 읽고 저장했고, 비로그인은 단일
질의만 가능했었음. 
- {sessionId}:{articleId}`에 JSON 배열로 저장합니다. `ai.context-window-size`와 동일한 최대 턴 수로 슬라이딩합니다.
- Gemini 요청 본문 구성은 로그인·비로그인 모두 **`ChatMessagePair` 목록**으로 통일해 중복 최소화

## 🧪 테스트/검증 (필수)
- [x] Redis가 떠 있는 환경에서 **비로그인**으로 동일 기사에 두 번째 질문 시, 첫 답변을 전제로 한 후속 질문에 모델이 자연스럽게 이어지는지 확인했습니다.
- [x] **로그인** 상태에서 기존처럼 DB에 저장·조회되고, 익명 헤더/쿼리가 있어도 영향이 없는지 확인했습니다.
- [x] `./gradlew compileJava`로 컴파일이 성공하는지 확인했습니다.