### PR TITLE
[FEAT] 비로그인 상태 질의 내역 제공 API 추가(플로팅UI 관련)

### DIFF
--- a/src/main/java/com/example/globalTimes_be/domain/ai/controller/AiController.java
+++ b/src/main/java/com/example/globalTimes_be/domain/ai/controller/AiController.java
@@ -107,4 +107,24 @@ public class AiController implements AiControllerDocs {
                 anonymousChatSessionService.getFullHistory(anonymousSessionId.trim(), id)
         );
     }
+
+    /**
+     * 비로그인: 세션별 대화한 기사 목록 (플로팅 히스토리). 유효한 세션 ID 없으면 빈 배열.
+     */
+    @Override
+    @GetMapping("/anonymous/chat-history")
+    public ResponseEntity<ApiResponse> getAnonymousChatHistoryList(
+            @RequestHeader(value = "X-Anonymous-Session", required = false) String anonymousSessionHeader,
+            @RequestParam(value = "anonymousSession", required = false) String anonymousSessionQuery) {
+        String anonymousSessionId = (anonymousSessionHeader != null && !anonymousSessionHeader.isBlank())
+                ? anonymousSessionHeader
+                : anonymousSessionQuery;
+        if (!AnonymousChatSessionService.isValidSessionId(anonymousSessionId)) {
+            return ApiResponse.success(GlobalSuccessStatus._OK.getResponse(), Collections.emptyList());
+        }
+        return ApiResponse.success(
+                GlobalSuccessStatus._OK.getResponse(),
+                anonymousChatSessionService.getAnonymousChatHistoryList(anonymousSessionId.trim())
+        );
+    }
 }

--- a/src/main/java/com/example/globalTimes_be/domain/ai/controller/AiControllerDocs.java
+++ b/src/main/java/com/example/globalTimes_be/domain/ai/controller/AiControllerDocs.java
@@ -226,4 +226,16 @@ public interface AiControllerDocs {
             @Parameter(description = "비로그인 세션 UUID (헤더)") @RequestHeader(value = "X-Anonymous-Session", required = false) String anonymousSessionHeader,
             @Parameter(description = "비로그인 세션 UUID (쿼리)") @RequestParam(value = "anonymousSession", required = false) String anonymousSessionQuery
     );
+
+    @Operation(
+            summary = "비로그인 채팅 기사 목록",
+            description = "X-Anonymous-Session(UUID)으로 대화한 기사를 최근 활동순으로 반환합니다. 로그인 사용자의 chat-history와 동일한 필드 스키마입니다. 세션이 없거나 형식이 잘못되면 빈 배열입니다."
+    )
+    @ApiResponse(responseCode = "200", description = "성공",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = com.example.globalTimes_be.global.apiPayload.code.ApiResponse.class)))
+    ResponseEntity<?> getAnonymousChatHistoryList(
+            @Parameter(description = "비로그인 세션 UUID (헤더)") @RequestHeader(value = "X-Anonymous-Session", required = false) String anonymousSessionHeader,
+            @Parameter(description = "비로그인 세션 UUID (쿼리)") @RequestParam(value = "anonymousSession", required = false) String anonymousSessionQuery
+    );
 }

--- a/src/main/java/com/example/globalTimes_be/domain/chat/dto/ChatHistoryListResDTO.java
+++ b/src/main/java/com/example/globalTimes_be/domain/chat/dto/ChatHistoryListResDTO.java
@@ -1,5 +1,6 @@
 package com.example.globalTimes_be.domain.chat.dto;
 
+import com.example.globalTimes_be.domain.article.entity.Article;
 import com.example.globalTimes_be.domain.chat.entity.ChatHistory;
 import lombok.Builder;
 import lombok.Getter;
@@ -33,6 +34,28 @@ public class ChatHistoryListResDTO {
                 .lastQuestion(latestChat.getQuestion())
                 .lastAnswerPreview(preview)
                 .lastChatAt(latestChat.getCreatedAt())
+                .build();
+    }
+
+    /** 비로그인 Redis 기사별 마지막 턴 → 플로팅 목록용 */
+    public static ChatHistoryListResDTO fromAnonymous(
+            Article article,
+            String lastQuestion,
+            String lastAnswer,
+            LocalDateTime lastChatAt
+    ) {
+        String answer = lastAnswer != null ? lastAnswer : "";
+        String preview = answer.length() > PREVIEW_MAX_LENGTH
+                ? answer.substring(0, PREVIEW_MAX_LENGTH) + "..."
+                : answer;
+
+        return ChatHistoryListResDTO.builder()
+                .articleId(article.getId())
+                .articleTitle(article.getTitle())
+                .thumbnailUrl(article.getUrlToImage())
+                .lastQuestion(lastQuestion != null ? lastQuestion : "")
+                .lastAnswerPreview(preview)
+                .lastChatAt(lastChatAt)
                 .build();
     }
 }

--- a/src/main/java/com/example/globalTimes_be/domain/chat/service/AnonymousChatSessionService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/chat/service/AnonymousChatSessionService.java
@@ -1,5 +1,8 @@
 package com.example.globalTimes_be.domain.chat.service;
 
+import com.example.globalTimes_be.domain.article.entity.Article;
+import com.example.globalTimes_be.domain.article.repository.ArticleRepository;
+import com.example.globalTimes_be.domain.chat.dto.ChatHistoryListResDTO;
 import com.example.globalTimes_be.domain.chat.dto.ChatMessagePair;
 import com.example.globalTimes_be.global.redis.RedisUtil;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -9,10 +12,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -20,9 +30,12 @@ import java.util.UUID;
 public class AnonymousChatSessionService {
 
     private static final String KEY_PREFIX = "chat:anon:";
+    /** 세션별 기사 ID → 마지막 활동 시각(epoch ms), TTL은 기사 키와 동일 */
+    private static final String INDEX_PREFIX = "chat:anon:index:";
 
     private final RedisUtil redisUtil;
     private final ObjectMapper objectMapper;
+    private final ArticleRepository articleRepository;
 
     @Value("${ai.anonymous-chat.ttl-seconds:604800}")
     private long ttlSeconds;
@@ -55,9 +68,57 @@ public class AnonymousChatSessionService {
 
     /**
      * 상세 채팅 UI용: 저장된 전체 턴 (오래된 순).
+     * 기존 Redis만 있고 인덱스가 없을 때 목록 API용 인덱스를 보정한다.
      */
     public List<ChatMessagePair> getFullHistory(String sessionId, Long articleId) {
-        return loadAll(sessionId, articleId);
+        List<ChatMessagePair> all = loadAll(sessionId, articleId);
+        if (!all.isEmpty()) {
+            ensureIndexContains(sessionId.trim(), articleId);
+        }
+        return all;
+    }
+
+    /**
+     * 플로팅 히스토리: 세션별로 대화한 기사를 최근 활동순으로, 로그인 {@code GET /api/user/chat-history}와 동일 DTO.
+     */
+    public List<ChatHistoryListResDTO> getAnonymousChatHistoryList(String sessionId) {
+        if (!isValidSessionId(sessionId)) {
+            return Collections.emptyList();
+        }
+        String sid = sessionId.trim();
+        Map<Long, Long> index = loadIndexMap(sid);
+        if (index.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Long> orderedArticleIds = index.entrySet().stream()
+                .sorted(Map.Entry.<Long, Long>comparingByValue().reversed())
+                .map(Map.Entry::getKey)
+                .toList();
+
+        List<Article> articles = articleRepository.findAllById(orderedArticleIds);
+        Map<Long, Article> byId = articles.stream().collect(Collectors.toMap(Article::getId, a -> a, (a, b) -> a));
+
+        ZoneId zone = ZoneId.of("Asia/Seoul");
+        List<ChatHistoryListResDTO> out = new ArrayList<>();
+        for (Long articleId : orderedArticleIds) {
+            Article article = byId.get(articleId);
+            if (article == null) {
+                continue;
+            }
+            List<ChatMessagePair> history = loadAll(sid, articleId);
+            if (history.isEmpty()) {
+                continue;
+            }
+            ChatMessagePair last = history.get(history.size() - 1);
+            Long epochMs = index.get(articleId);
+            LocalDateTime lastChatAt = epochMs != null
+                    ? LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMs), zone)
+                    : LocalDateTime.now(zone);
+            out.add(ChatHistoryListResDTO.fromAnonymous(
+                    article, last.question(), last.answer(), lastChatAt));
+        }
+        return out;
     }
 
     public void appendTurn(String sessionId, Long articleId, String question, String answer, int maxTurns) {
@@ -73,6 +134,7 @@ public class AnonymousChatSessionService {
             }
             String json = objectMapper.writeValueAsString(list);
             redisUtil.setData(key, json, ttlSeconds);
+            touchIndex(sessionId.trim(), articleId);
         } catch (Exception e) {
             log.error("[AnonymousChat] 저장 실패 sessionId={}, articleId={}", sessionId, articleId, e);
         }
@@ -98,5 +160,59 @@ public class AnonymousChatSessionService {
 
     private static String buildKey(String sessionId, Long articleId) {
         return KEY_PREFIX + sessionId.trim() + ":" + articleId;
+    }
+
+    private static String buildIndexKey(String sessionId) {
+        return INDEX_PREFIX + sessionId.trim();
+    }
+
+    private Map<Long, Long> loadIndexMap(String sessionId) {
+        String key = buildIndexKey(sessionId);
+        try {
+            String json = redisUtil.getData(key);
+            if (json == null || json.isBlank()) {
+                return new HashMap<>();
+            }
+            Map<String, Long> raw = objectMapper.readValue(json, new TypeReference<>() {
+            });
+            Map<Long, Long> out = new HashMap<>();
+            for (Map.Entry<String, Long> e : raw.entrySet()) {
+                out.put(Long.parseLong(e.getKey()), e.getValue());
+            }
+            return out;
+        } catch (Exception e) {
+            log.warn("[AnonymousChat] 인덱스 파싱 실패 sessionId={}: {}", sessionId, e.getMessage());
+            return new HashMap<>();
+        }
+    }
+
+    private void saveIndexMap(String sessionId, Map<Long, Long> map) throws Exception {
+        String key = buildIndexKey(sessionId);
+        Map<String, Long> forJson = new LinkedHashMap<>();
+        map.forEach((k, v) -> forJson.put(String.valueOf(k), v));
+        String json = objectMapper.writeValueAsString(forJson);
+        redisUtil.setData(key, json, ttlSeconds);
+    }
+
+    private void touchIndex(String sessionId, Long articleId) {
+        try {
+            Map<Long, Long> map = loadIndexMap(sessionId);
+            map.put(articleId, System.currentTimeMillis());
+            saveIndexMap(sessionId, map);
+        } catch (Exception e) {
+            log.warn("[AnonymousChat] 인덱스 갱신 실패 sessionId={}, articleId={}", sessionId, articleId, e);
+        }
+    }
+
+    private void ensureIndexContains(String sessionId, Long articleId) {
+        try {
+            Map<Long, Long> map = loadIndexMap(sessionId);
+            if (!map.containsKey(articleId)) {
+                map.put(articleId, System.currentTimeMillis());
+                saveIndexMap(sessionId, map);
+            }
+        } catch (Exception e) {
+            log.warn("[AnonymousChat] 인덱스 보정 실패 sessionId={}, articleId={}", sessionId, articleId, e);
+        }
     }
 }


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #111

## 🧭 변경 타입
- [x] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [ ] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- 비로그인 `anonymousSession` 기준으로, 대화한 기사 목록을 로그인 사용자의 `GET /api/user/chat-history`와 동일한 DTO 스키마(`ChatHistoryListResDTO`)로 조회할 수 있는 API 추가
- Redis에 세션별 기사 인덱스(`chat:anon:index:{sessionId}`)를 두어 최근 활동순 목록 구성
- 기사별 대화 저장(`appendTurn`) 시 인덱스 갱신, `getFullHistory` 호출 시 구 데이터만 있고 인덱스가 없을 경우 보정

## 🔍 기술적 배경
- 기존에는 기사별 키(`chat:anon:{sessionId}:{articleId}`)만 존재해 세션 → 기사 목록을 한 번에 나열하기 어려움
- 인덱스에 `articleId → 마지막 활동 시각(epoch ms)`을 저장하고 TTL은 기존 익명 채팅 TTL과 동일하게 유지
- `GET /api/ai/anonymous/chat-history` — 쿼리/헤더 `anonymousSession`(UUID), 응답은 `List<ChatHistoryListResDTO>`
- `ChatHistoryListResDTO.fromAnonymous(Article, …)` 정적 팩토리로 DB 메타(제목·썸네일)와 Redis 마지막 턴 미리보기 조합

## 🧪 테스트/검증 (필수)
- [x] 비로그인 세션으로 기사에서 대화 후 위 API 호출 시 해당 기사가 목록에 포함되는지
- [x] 세션 UUID 없음/형식 오류 시 빈 배열·200 정책 확인
- [x] 로그인 전용 `GET /api/user/chat-history` 동작 변화 없음 확인

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [ ] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?

## 💬 리뷰 요구사항(선택)
- 프론트는 `GET /api/ai/anonymous/chat-history?anonymousSession=` 또는 동일 파라미터 헤더로 연동 예정