### PR TITLE
[PERF/#115] 주요 API 성능 기준 수립 및 관측 가능성 개선

### DIFF
--- a/docs/backend-improvement/performance-observability-baseline.md
+++ b/docs/backend-improvement/performance-observability-baseline.md
@@ -1,0 +1,51 @@
+# 주요 API 성능 관측 기준
+
+## 목적
+
+주요 API의 응답 지연 원인을 감으로 추정하지 않고, 로그를 통해 요청 경로의 병목 후보를 비교할 수 있게 만든다.
+이번 기준선은 최적화 자체가 아니라 이후 캐시, 쿼리, 외부 API 호출 개선 전후를 비교하기 위한 관측 기반이다.
+
+## 관측 대상 API
+
+| API | 관측 이유 | 주요 관측 항목 |
+| --- | --- | --- |
+| `GET /api/news/{id}/perspectives` | 다국가 시선 제공의 핵심 경로이며 Redis 캐시, 번역, FULLTEXT 검색이 함께 수행된다. | 캐시 hit/miss, 번역 요청 여부, 검색 시간, 국가 수, 기사 수 |
+| `GET /api/search` | 검색어 번역 캐시와 FULLTEXT 검색 성능을 함께 확인할 수 있다. | 번역 캐시 hit/miss, 외부 번역 호출 여부, DB 검색 시간, 결과 수 |
+| `GET /api/articles/explore` | 탐색 필터와 cursor 기반 페이징의 DB 조회 비용을 확인할 수 있다. | 필터 조건, cursor 여부, DB 조회 시간, 결과 수 |
+| `GET /api/articles/latest` | 기본 기사 목록 API의 페이지 기반 조회 비용을 확인할 수 있다. | page, size, DB 조회 시간, 결과 수 |
+| `GET /api/articles/cursor` | cursor 기반 목록 조회의 성능 기준을 확인할 수 있다. | cursor 여부, DB 조회 시간, 결과 수, hasNext |
+| `GET /api/articles/popular` | 조회수 기반 정렬과 최근 기간 필터의 조회 비용을 확인할 수 있다. | page, size, 조회 기준일, DB 조회 시간, 결과 수 |
+
+## 로그 필드 기준
+
+### 공통
+
+- `totalMs`: 서비스 메서드 전체 수행 시간
+- `dbQueryMs`, `dbSearchMs`: Repository 조회 시간
+- `resultCount`: 응답에 포함된 결과 수
+
+### 번역
+
+- `cacheHit`: Redis 번역 캐시 hit 여부
+- `externalCall`: 외부 번역 API 호출 여부
+- `fallback`: 번역 실패 시 원문 사용 여부
+- `textLength`, `translatedLength`: 민감한 원문 대신 길이만 기록
+
+### Perspectives
+
+- `cacheHit`: Perspectives 응답 캐시 hit 여부
+- `baseLookupMs`: 기준 기사 조회 시간
+- `keywordMs`: 키워드 추출 시간
+- `translationRequested`: 번역 시도 여부
+- `translationFallback`: 번역 실패 후 원문 키워드 사용 여부
+- `translatedSearchMs`: 번역 키워드 기반 FULLTEXT 검색 시간
+- `originalSearchMs`: 원문 키워드 기반 추가 FULLTEXT 검색 시간
+- `countriesFound`: 관련 기사가 발견된 국가 수
+- `totalArticles`: 관련 기사 수
+
+## 기록 원칙
+
+- 검색어와 번역 결과 원문은 로그에 남기지 않고 길이만 기록한다.
+- API 키, 인증 정보, 외부 API 응답 전문은 기록하지 않는다.
+- 이번 변경은 관측 기준 추가이며 캐시 TTL, DB 인덱스, 쿼리 전략은 변경하지 않는다.
+- p50, p95, 오류율 등 부하 테스트 지표는 별도 작업에서 동일 로그 기준으로 수집한다.

--- a/docs/backend-improvement/performance-observability-baseline.md
+++ b/docs/backend-improvement/performance-observability-baseline.md
@@ -28,6 +28,7 @@
 
 - `cacheHit`: Redis 번역 캐시 hit 여부
 - `externalCall`: 외부 번역 API 호출 여부
+- `externalCallMs`: 외부 번역 API 순수 호출 시간
 - `fallback`: 번역 실패 시 원문 사용 여부
 - `textLength`, `translatedLength`: 민감한 원문 대신 길이만 기록
 

--- a/src/main/java/com/example/globalTimes_be/domain/article/service/ArticleService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/article/service/ArticleService.java
@@ -4,6 +4,7 @@ import com.example.globalTimes_be.domain.article.entity.Article;
 import com.example.globalTimes_be.domain.article.dto.ArticleResponseDto;
 import com.example.globalTimes_be.domain.article.dto.CursorArticleResponseDto;
 import com.example.globalTimes_be.domain.article.repository.ArticleRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -13,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
+@Slf4j
 @Service
 public class ArticleService {
 
@@ -25,22 +27,37 @@ public class ArticleService {
     // 최신순 기사
     @Transactional(readOnly = true)
     public Page<ArticleResponseDto> getArticlesByPublishedAt(int page, int size) {
+        long startedAt = System.nanoTime();
         Pageable pageable = PageRequest.of(page, size);
+        long queryStartedAt = System.nanoTime();
         Page<Article> articles = articleRepository.findAllByOrderByPublishedAtDesc(pageable);
+        long queryMs = elapsedMs(queryStartedAt);
 
-       return articles.map(ArticleResponseDto::fromEntity);
+        Page<ArticleResponseDto> response = articles.map(ArticleResponseDto::fromEntity);
+        log.info("[ArticlesLatest] page={} size={} resultCount={} totalElements={} dbQueryMs={} totalMs={}",
+                page,
+                size,
+                response.getNumberOfElements(),
+                response.getTotalElements(),
+                queryMs,
+                elapsedMs(startedAt));
+
+       return response;
     }
 
     // Cursor 기반 최신순 페이징
     // size+1개를 조회해 hasNext 판별, published_at 인덱스 활용으로 Offset 대비 일정한 탐색 속도
     @Transactional(readOnly = true)
     public CursorArticleResponseDto getArticlesByCursor(String cursor, int size) {
+        long startedAt = System.nanoTime();
         Pageable pageable = PageRequest.of(0, size + 1);
 
+        long queryStartedAt = System.nanoTime();
         List<Article> articles = (cursor == null)
                 ? articleRepository.findFirstPage(pageable)
                 : articleRepository.findByCursor(
                         LocalDateTime.parse(cursor, DateTimeFormatter.ISO_LOCAL_DATE_TIME), pageable);
+        long queryMs = elapsedMs(queryStartedAt);
 
         boolean hasNext = articles.size() > size;
         List<Article> result = hasNext ? articles.subList(0, size) : articles;
@@ -53,20 +70,45 @@ public class ArticleService {
                 .map(ArticleResponseDto::fromEntity)
                 .toList();
 
+        log.info("[ArticlesCursor] cursorProvided={} size={} resultCount={} hasNext={} dbQueryMs={} totalMs={}",
+                cursor != null,
+                size,
+                dtos.size(),
+                hasNext,
+                queryMs,
+                elapsedMs(startedAt));
+
         return new CursorArticleResponseDto(dtos, nextCursor, hasNext);
     }
 
     // Hot News : 조회수 높은 순 (최근 30일 이내 기사 대상)
     @Transactional(readOnly = true)
     public Page<ArticleResponseDto> getArticlesByViewCount(int page, int size) {
+        long startedAt = System.nanoTime();
         Pageable pageable = PageRequest.of(page, size);
 
         // 최근 30일 이내 기사 중 조회수 높은 순으로 정렬
         // (기존 2일 필터는 실시간 수집 환경에서만 유효 → 로컬/테스트 환경에서 데이터 없음 이슈 방지)
         LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
 
+        long queryStartedAt = System.nanoTime();
         Page<Article> articles = articleRepository.findByPublishedAtAfterOrderByViewCountDesc(thirtyDaysAgo, pageable);
+        long queryMs = elapsedMs(queryStartedAt);
 
-        return articles.map(ArticleResponseDto::fromEntity);
+        Page<ArticleResponseDto> response = articles.map(ArticleResponseDto::fromEntity);
+        log.info("[ArticlesPopular] page={} size={} from={} resultCount={} totalElements={} dbQueryMs={} totalMs={}",
+                page,
+                size,
+                thirtyDaysAgo,
+                response.getNumberOfElements(),
+                response.getTotalElements(),
+                queryMs,
+                elapsedMs(startedAt));
+
+        return response;
+    }
+
+    private long elapsedMs(long startedAt) {
+        return (System.nanoTime() - startedAt) / 1_000_000;
     }
 }

--- a/src/main/java/com/example/globalTimes_be/domain/article/service/ExploreService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/article/service/ExploreService.java
@@ -5,6 +5,7 @@ import com.example.globalTimes_be.domain.article.dto.CursorArticleResponseDto;
 import com.example.globalTimes_be.domain.article.entity.Article;
 import com.example.globalTimes_be.domain.article.repository.ArticleRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +17,7 @@ import java.time.format.DateTimeParseException;
 import java.util.List;
 
 @RequiredArgsConstructor
+@Slf4j
 @Service
 public class ExploreService {
 
@@ -29,6 +31,7 @@ public class ExploreService {
             String cursorStr,
             int size
     ) {
+        long startedAt = System.nanoTime();
         LocalDateTime dateFrom = null;
         LocalDateTime dateTo = null;
         if (date != null && !date.isBlank()) {
@@ -51,10 +54,12 @@ public class ExploreService {
         String countryParam = (country != null && !country.isBlank()) ? country : null;
         String categoryParam = (category != null && !category.isBlank()) ? category : null;
 
+        long queryStartedAt = System.nanoTime();
         List<Article> fetched = articleRepository.findByExploreFilters(
                 countryParam, categoryParam, dateFrom, dateTo, cursor,
                 PageRequest.of(0, size + 1)
         );
+        long queryMs = elapsedMs(queryStartedAt);
 
         boolean hasNext = fetched.size() > size;
         List<Article> articles = hasNext ? fetched.subList(0, size) : fetched;
@@ -68,6 +73,21 @@ public class ExploreService {
                 .map(ArticleResponseDto::fromEntity)
                 .toList();
 
+        log.info("[Explore] country={} category={} date={} cursorProvided={} size={} resultCount={} hasNext={} dbQueryMs={} totalMs={}",
+                countryParam,
+                categoryParam,
+                date,
+                cursor != null,
+                size,
+                dtos.size(),
+                hasNext,
+                queryMs,
+                elapsedMs(startedAt));
+
         return new CursorArticleResponseDto(dtos, nextCursor, hasNext);
+    }
+
+    private long elapsedMs(long startedAt) {
+        return (System.nanoTime() - startedAt) / 1_000_000;
     }
 }

--- a/src/main/java/com/example/globalTimes_be/domain/detail/service/PerspectivesService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/detail/service/PerspectivesService.java
@@ -38,13 +38,21 @@ public class PerspectivesService {
 
     @Transactional(readOnly = true)
     public PerspectivesResDTO getPerspectives(Long articleId) {
+        long totalStartedAt = System.nanoTime();
         if (cacheTtlSeconds > 0) {
             try {
+                long cacheStartedAt = System.nanoTime();
                 String cached = redisUtil.getData(CACHE_KEY_PREFIX + articleId);
                 if (cached != null) {
                     try {
-                        log.debug("[Perspectives] 캐시 히트 articleId={}", articleId);
-                        return objectMapper.readValue(cached, PerspectivesResDTO.class);
+                        PerspectivesResDTO response = objectMapper.readValue(cached, PerspectivesResDTO.class);
+                        log.info("[Perspectives] articleId={} cacheHit=true cacheReadMs={} totalMs={} countriesFound={} totalArticles={}",
+                                articleId,
+                                elapsedMs(cacheStartedAt),
+                                elapsedMs(totalStartedAt),
+                                response.getCountriesFound(),
+                                response.getTotalArticles());
+                        return response;
                     } catch (Exception e) {
                         log.warn("[Perspectives] 캐시 역직렬화 실패, 재계산: {}", e.getMessage());
                     }
@@ -54,31 +62,47 @@ public class PerspectivesService {
             }
         }
 
+        long baseLookupStartedAt = System.nanoTime();
         Article base = articleRepository.findById(articleId)
                 .orElseThrow(() -> new BaseException(DetailErrorStatus._EMPTY_NEWS_DATA.getResponse()));
+        long baseLookupMs = elapsedMs(baseLookupStartedAt);
 
+        long keywordStartedAt = System.nanoTime();
         String plainKeyword = KeywordExtractor.extractPlain(base.getTitle());
         String booleanKeyword = KeywordExtractor.extract(base.getTitle());
+        long keywordMs = elapsedMs(keywordStartedAt);
 
-        log.info("[Perspectives] 기사 id={} 키워드 추출: '{}'", articleId, plainKeyword);
+        log.info("[Perspectives] 기사 id={} 키워드 추출: '{}' keywordMs={}", articleId, plainKeyword, keywordMs);
 
         // 영어가 아닌 기사는 제목을 영어로 번역해 영어권 기사도 탐색
         String searchKeyword = booleanKeyword;
+        boolean translationRequested = false;
+        boolean translationFallback = false;
+        long translationMs = 0;
         if (!"en".equals(base.getLanguage())) {
             try {
+                translationRequested = true;
+                long translationStartedAt = System.nanoTime();
                 String translated = translationService.translateToEnglish(plainKeyword);
+                translationMs = elapsedMs(translationStartedAt);
                 searchKeyword = KeywordExtractor.extract(translated);
-                log.info("[Perspectives] 번역된 키워드: '{}'", translated);
+                log.info("[Perspectives] 번역된 키워드: '{}' translationMs={}", translated, translationMs);
             } catch (Exception e) {
+                translationFallback = true;
                 log.warn("[Perspectives] 번역 실패, 원문 키워드로 탐색: {}", e.getMessage());
             }
         }
 
+        long searchStartedAt = System.nanoTime();
         List<Article> results = articleRepository.findPerspectives(articleId, searchKeyword);
+        long translatedSearchMs = elapsedMs(searchStartedAt);
+        long originalSearchMs = 0;
 
         // 원문 키워드로도 추가 탐색 (번역 키워드와 다를 경우)
         if (!searchKeyword.equals(booleanKeyword) && !booleanKeyword.isBlank()) {
+            long originalSearchStartedAt = System.nanoTime();
             List<Article> originalResults = articleRepository.findPerspectives(articleId, booleanKeyword);
+            originalSearchMs = elapsedMs(originalSearchStartedAt);
             // 중복 제거 후 병합
             List<Long> existingIds = results.stream().map(Article::getId).toList();
             originalResults.stream()
@@ -103,8 +127,18 @@ public class PerspectivesService {
                 .mapToInt(List::size)
                 .sum();
 
-        log.info("[Perspectives] 기사 id={} | 키워드='{}' | {}개 국가, {}개 기사 반환",
-                articleId, plainKeyword, perspectives.size(), totalArticles);
+        log.info("[Perspectives] articleId={} cacheHit=false baseLookupMs={} keywordMs={} translationRequested={} translationFallback={} translationMs={} translatedSearchMs={} originalSearchMs={} countriesFound={} totalArticles={} totalMs={}",
+                articleId,
+                baseLookupMs,
+                keywordMs,
+                translationRequested,
+                translationFallback,
+                translationMs,
+                translatedSearchMs,
+                originalSearchMs,
+                perspectives.size(),
+                totalArticles,
+                elapsedMs(totalStartedAt));
 
         PerspectivesResDTO response = PerspectivesResDTO.builder()
                 .keyword(plainKeyword)
@@ -125,5 +159,9 @@ public class PerspectivesService {
         }
 
         return response;
+    }
+
+    private long elapsedMs(long startedAt) {
+        return (System.nanoTime() - startedAt) / 1_000_000;
     }
 }

--- a/src/main/java/com/example/globalTimes_be/domain/detail/service/PerspectivesService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/detail/service/PerspectivesService.java
@@ -72,7 +72,10 @@ public class PerspectivesService {
         String booleanKeyword = KeywordExtractor.extract(base.getTitle());
         long keywordMs = elapsedMs(keywordStartedAt);
 
-        log.info("[Perspectives] 기사 id={} 키워드 추출: '{}' keywordMs={}", articleId, plainKeyword, keywordMs);
+        log.info("[Perspectives] articleId={} keywordLength={} keywordMs={}",
+                articleId,
+                plainKeyword.length(),
+                keywordMs);
 
         // 영어가 아닌 기사는 제목을 영어로 번역해 영어권 기사도 탐색
         String searchKeyword = booleanKeyword;
@@ -86,7 +89,11 @@ public class PerspectivesService {
                 String translated = translationService.translateToEnglish(plainKeyword);
                 translationMs = elapsedMs(translationStartedAt);
                 searchKeyword = KeywordExtractor.extract(translated);
-                log.info("[Perspectives] 번역된 키워드: '{}' translationMs={}", translated, translationMs);
+                log.info("[Perspectives] articleId={} translationRequested=true sourceLanguage={} translatedLength={} translationMs={}",
+                        articleId,
+                        base.getLanguage(),
+                        translated.length(),
+                        translationMs);
             } catch (Exception e) {
                 translationFallback = true;
                 log.warn("[Perspectives] 번역 실패, 원문 키워드로 탐색: {}", e.getMessage());

--- a/src/main/java/com/example/globalTimes_be/domain/search/service/SearchArticlesService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/search/service/SearchArticlesService.java
@@ -5,6 +5,7 @@ import com.example.globalTimes_be.domain.article.repository.ArticleRepository;
 import com.example.globalTimes_be.domain.search.dto.response.SearchArticleDTO;
 import com.example.globalTimes_be.domain.search.dto.response.SearchResDTO;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -15,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @RequiredArgsConstructor
+@Slf4j
 @Service
 public class SearchArticlesService {
     private final ArticleRepository articleRepository;
@@ -29,6 +31,7 @@ public class SearchArticlesService {
             String category,
             String date
     ) {
+        long startedAt = System.nanoTime();
         LocalDateTime dateFrom = null;
         LocalDateTime dateTo = null;
         if (date != null && !date.isBlank()) {
@@ -43,6 +46,7 @@ public class SearchArticlesService {
         String countryParam = (country != null && !country.isBlank()) ? country : null;
         String categoryParam = (category != null && !category.isBlank()) ? category : null;
 
+        long searchStartedAt = System.nanoTime();
         List<Article> articles = articleRepository.searchByDescriptionOrTitleWithExploreFilters(
                 text,
                 translatedText,
@@ -51,6 +55,7 @@ public class SearchArticlesService {
                 dateFrom,
                 dateTo
         );
+        long searchMs = elapsedMs(searchStartedAt);
         
         // 검색결과에 대한 기사 DTO 리스트 생성
         List<SearchArticleDTO> searchArticleDTOs = new ArrayList<>();
@@ -75,11 +80,25 @@ public class SearchArticlesService {
             searchArticleDTOs.add(searchArticleDTO);
         }
         
+        log.info("[Search] textLength={} translatedLength={} country={} category={} date={} resultCount={} dbSearchMs={} totalMs={}",
+                text.length(),
+                translatedText.length(),
+                countryParam,
+                categoryParam,
+                date,
+                searchArticleDTOs.size(),
+                searchMs,
+                elapsedMs(startedAt));
+
         //결과 반환
         return SearchResDTO.builder()
                 .originalText(text)
                 .translatedText(translatedText)
                 .searchArticles(searchArticleDTOs)
                 .build();
+    }
+
+    private long elapsedMs(long startedAt) {
+        return (System.nanoTime() - startedAt) / 1_000_000;
     }
 }

--- a/src/main/java/com/example/globalTimes_be/domain/search/service/TranslationService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/search/service/TranslationService.java
@@ -15,25 +15,34 @@ public class TranslationService {
 
     //redis에서 변역결과를 조회하고 없으면 구글 번역
     public String translateToEnglish(String text){
+        long startedAt = System.nanoTime();
+
         // Redis에서 text 조회
         String cachedTranslation = redisUtil.getData("translation:" + text);
 
         // Redis에 저장된 번역본이 있다면 바로 반환
         if (cachedTranslation != null){
-            log.info("Redis에 저장되어있는 번역 전: {}, 번역 후: {}", text, cachedTranslation);
+            log.info("[Translation] cacheHit=true elapsedMs={} textLength={}",
+                    elapsedMs(startedAt), text.length());
             return cachedTranslation;
         }
 
         // 구글번역 (API 키 미설정 또는 호출 실패 시 원문 그대로 사용)
         try {
             String translatedText = translateUtil.translateToEnglish(text);
-            log.info("Redis에 저장될 번역 전: {}, 번역 후: {}", text, translatedText);
             redisUtil.setData("translation:" + text, translatedText, 86400);
+            log.info("[Translation] cacheHit=false externalCall=true elapsedMs={} textLength={} translatedLength={}",
+                    elapsedMs(startedAt), text.length(), translatedText.length());
             return translatedText;
         } catch (Exception e) {
-            log.warn("[번역 실패] 원문으로 검색 진행: {} / 원인: {}", text, e.getMessage());
+            log.warn("[Translation] cacheHit=false externalCall=true fallback=original elapsedMs={} textLength={} reason={}",
+                    elapsedMs(startedAt), text.length(), e.getMessage());
             return text;
         }
+    }
+
+    private long elapsedMs(long startedAt) {
+        return (System.nanoTime() - startedAt) / 1_000_000;
     }
 
 }

--- a/src/main/java/com/example/globalTimes_be/domain/search/service/TranslationService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/search/service/TranslationService.java
@@ -28,8 +28,9 @@ public class TranslationService {
         }
 
         // 구글번역 (API 키 미설정 또는 호출 실패 시 원문 그대로 사용)
+        long externalCallStartedAt = 0;
         try {
-            long externalCallStartedAt = System.nanoTime();
+            externalCallStartedAt = System.nanoTime();
             String translatedText = translateUtil.translateToEnglish(text);
             long externalCallMs = elapsedMs(externalCallStartedAt);
             redisUtil.setData("translation:" + text, translatedText, 86400);
@@ -37,8 +38,9 @@ public class TranslationService {
                     externalCallMs, elapsedMs(startedAt), text.length(), translatedText.length());
             return translatedText;
         } catch (Exception e) {
-            log.warn("[Translation] cacheHit=false externalCall=true fallback=original elapsedMs={} textLength={} reason={}",
-                    elapsedMs(startedAt), text.length(), e.getMessage());
+            long externalCallMs = (externalCallStartedAt > 0) ? elapsedMs(externalCallStartedAt) : 0;
+            log.warn("[Translation] cacheHit=false externalCall=true fallback=original externalCallMs={} elapsedMs={} textLength={} reason={}",
+                    externalCallMs, elapsedMs(startedAt), text.length(), e.getMessage());
             return text;
         }
     }

--- a/src/main/java/com/example/globalTimes_be/domain/search/service/TranslationService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/search/service/TranslationService.java
@@ -29,10 +29,12 @@ public class TranslationService {
 
         // 구글번역 (API 키 미설정 또는 호출 실패 시 원문 그대로 사용)
         try {
+            long externalCallStartedAt = System.nanoTime();
             String translatedText = translateUtil.translateToEnglish(text);
+            long externalCallMs = elapsedMs(externalCallStartedAt);
             redisUtil.setData("translation:" + text, translatedText, 86400);
-            log.info("[Translation] cacheHit=false externalCall=true elapsedMs={} textLength={} translatedLength={}",
-                    elapsedMs(startedAt), text.length(), translatedText.length());
+            log.info("[Translation] cacheHit=false externalCall=true externalCallMs={} elapsedMs={} textLength={} translatedLength={}",
+                    externalCallMs, elapsedMs(startedAt), text.length(), translatedText.length());
             return translatedText;
         } catch (Exception e) {
             log.warn("[Translation] cacheHit=false externalCall=true fallback=original elapsedMs={} textLength={} reason={}",

--- a/src/main/java/com/example/globalTimes_be/global/translate/TranslateUtil.java
+++ b/src/main/java/com/example/globalTimes_be/global/translate/TranslateUtil.java
@@ -24,7 +24,7 @@ public class TranslateUtil {
 
     //자동으로 언어 감지 후 영어로 번역
     public String translateToEnglish(String text){
-        log.debug("[번역 요청] text: {}", text);
+        log.debug("[TranslateUtil] request textLength={}", text.length());
         try {
             Translation translation = translate.translate(
                     text,
@@ -32,7 +32,9 @@ public class TranslateUtil {
                     Translate.TranslateOption.model("base") // 기본 모델 사용
             );
 
-            log.info("번역 전: {}, 번역 후: {}", text, translation.getTranslatedText());
+            log.info("[TranslateUtil] success textLength={} translatedLength={}",
+                    text.length(),
+                    translation.getTranslatedText().length());
 
             return translation.getTranslatedText();
         } catch (Exception e) {


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #115

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)


## 📝 작업 내용
- 주요 API의 성능 병목 후보를 확인할 수 있도록 서비스 레이어 관측 로그를 추가했습니다.
- Perspectives API에 캐시 hit/miss, 기준 기사 조회, 키워드 추출, 번역 요청, FULLTEXT 검색, 국가/기사 수, 전체 처리 시간 로그를 추가했습니다.
- Search API에 번역 캐시 hit/miss, 외부 번역 호출 여부, DB 검색 시간, 결과 수 로그를 추가했습니다.
- 기사 목록/탐색 API에 DB 조회 시간, 결과 수, cursor/필터 여부, 전체 처리 시간 로그를 추가했습니다.
- 성능 관측 대상 API와 로그 필드 기준을 `docs/backend-improvement/performance-observability-baseline.md`에 문서화했습니다.

## 🔍 기술적 배경
- 기존에는 기사 조회, 검색, 번역, 캐시, FULLTEXT 검색 중 어느 구간에서 지연이 발생하는지 요청 단위로 비교하기 어려웠습니다.
- 이번 변경은 최적화 자체가 아니라 캐시/쿼리/외부 API 개선 전후를 비교하기 위한 기준선 수립입니다.
- 검색어와 번역 결과 원문은 로그에 남기지 않고 길이만 기록해 운영 로그의 민감 정보 노출 가능성을 낮췄습니다.
- DB 인덱스, 캐시 TTL, 쿼리 전략, API 응답 구조는 변경하지 않았습니다.

## 🧪 테스트/검증 (필수)
- [x] `./gradlew.bat test` 실행 결과 `BUILD SUCCESSFUL` 확인
- [x] `git diff --check`로 공백 오류 없음 확인
- [x] `application.yml`의 기존 로컬 변경은 PR 커밋에서 제외됨을 확인

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [ ] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?


## 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
- 별도 Reviewer 세션에서는 관측 로그가 과도하지 않은지, 민감 정보가 로그에 남지 않는지, #115 범위를 넘어선 로직 변경이 없는지 확인해주세요.


## ➕ 추후 계획(선택)
- 동일 로그 기준으로 부하 테스트를 수행해 p50/p95 응답 시간과 오류율을 기록합니다.
- 측정 결과를 바탕으로 캐시 전략, FULLTEXT 검색, 번역 호출 구조 개선 여부를 별도 Issue에서 결정합니다.