### PR TITLE
[DOCS/#117] AI Reviewer PR Comment Workflow 문서화

### DIFF
--- a/docs/ai-workflow/README.md
+++ b/docs/ai-workflow/README.md
@@ -11,6 +11,9 @@ AI를 단순 코드 생성 도구가 아니라 조사, 계획, 구현, 검토를
 조사 → 계획 제안 → 사용자 승인 → GitHub Issue → 작업 브랜치 → 구현 → 검증 및 리뷰 → PR → 사용자 확인 후 Merge
 ```
 
+Reviewer 세션을 별도로 운영하는 경우에는 GitHub PR comment를 중심으로 리뷰 결과와 반영 내역을 기록한다.
+자세한 흐름은 [AI Reviewer PR Comment Workflow](./reviewer-comment-workflow.md)를 따른다.
+
 ## 역할 분리
 
 | 역할 | 책임 | 코드 수정 권한 |
@@ -21,6 +24,7 @@ AI를 단순 코드 생성 도구가 아니라 조사, 계획, 구현, 검토를
 | 검토자 | 범위 이탈, 예외 처리, 누락 테스트, 운영 위험을 검토 | 없음 |
 
 한 작업에서 같은 AI가 역할을 수행할 수는 있지만, 검토 단계에서는 구현 관점과 분리해 확인한다.
+별도 Reviewer 세션은 코드 수정, 커밋, push, merge 권한 없이 PR diff 검토와 PR comment 작성만 수행한다.
 
 ## 승인 게이트
 
@@ -41,6 +45,7 @@ AI를 단순 코드 생성 도구가 아니라 조사, 계획, 구현, 검토를
 | 문제, 목표, 범위, 완료 기준 | GitHub Issue |
 | 실제 변경 이력 | 작업 브랜치와 커밋 |
 | 계획 대비 변경점, 테스트·성능 결과 | PR 본문 |
+| AI Reviewer 검토 결과와 반영 내역 | PR comment |
 | 중요한 기술 선택과 대안 | `docs/adr/` |
 | 개선 후보와 우선순위 | `docs/backend-improvement/BACKLOG.md` |
 

--- a/docs/ai-workflow/reviewer-comment-workflow.md
+++ b/docs/ai-workflow/reviewer-comment-workflow.md
@@ -1,0 +1,147 @@
+# AI Reviewer PR Comment Workflow
+
+## 목적
+
+Implementer 세션과 Reviewer 세션을 분리해 운영할 때 사용자가 리뷰 결과를 매번 복사해 전달하는 부담을 줄인다.
+GitHub PR comment를 AI 리뷰 결과, 반영 계획, 반영 완료 내역의 단일 기록 저장소로 사용한다.
+
+## AS-IS
+
+- Implementer 세션이 PR을 생성한 뒤, 사용자가 Reviewer 세션에 PR 링크와 검토 기준을 전달한다.
+- Reviewer 세션은 코드 수정 없이 리뷰 결과를 생성한다.
+- 사용자가 Reviewer 결과를 다시 Implementer 세션으로 복사해 전달한다.
+- Implementer 세션이 리뷰 결과를 PR comment로 옮기고 수정 계획을 제안한다.
+
+이 방식은 안전하지만 세션 사이에서 사용자가 수동으로 중개해야 하므로 누락과 반복 작업이 발생한다.
+
+## TO-BE
+
+- Reviewer 세션이 PR diff를 검토한 뒤 GitHub PR comment에 직접 리뷰 결과를 남긴다.
+- Implementer 세션은 PR comment를 조회해 Blocking과 Non-blocking을 분리하고 수정 계획을 제안한다.
+- 사용자는 수정 계획을 승인하거나 후속 이슈 분리를 지시한다.
+- 승인된 수정만 같은 브랜치에 추가 커밋으로 반영한다.
+
+## 역할과 권한
+
+| 역할 | 책임 | 허용 작업 | 금지 작업 |
+| --- | --- | --- | --- |
+| Implementer | 구현, 테스트, PR 생성, 승인된 리뷰 반영 | 코드 수정, 테스트 실행, 커밋, push, PR 생성·갱신 | 승인되지 않은 범위 변경 |
+| Reviewer | PR diff 검토, Blocking/Non-blocking 분류, PR comment 작성 | PR 조회, diff 검토, comment 작성 | 코드 수정, 커밋, push, merge |
+| User | 승인 게이트, 범위 판단, 최종 merge 승인 | 리뷰 반영 승인, 후속 이슈 분리 결정, merge 승인 | 없음 |
+
+Reviewer에게 PR comment 작성 권한은 줄 수 있지만, 코드 수정 권한은 주지 않는다.
+
+## 기본 흐름
+
+```text
+Issue 생성
+→ Implementer 작업 브랜치 생성
+→ 조사 및 계획
+→ 사용자 승인
+→ 구현 및 테스트
+→ PR 생성
+→ Reviewer 세션이 PR diff 검토
+→ Reviewer가 PR comment 작성
+→ Implementer가 PR comment 조회
+→ 수정 계획 제안
+→ 사용자 승인
+→ 추가 커밋 push
+→ 필요 시 Reviewer 재검토
+→ Blocking 없음 확인
+→ 사용자 승인 후 merge
+```
+
+## Reviewer comment 형식
+
+```md
+## AI Reviewer 검토 결과
+
+### Blocking
+- merge 전에 반드시 해결해야 하는 문제
+
+### Non-blocking
+- 이번 PR에서 선택적으로 반영하거나 후속 이슈로 분리할 개선점
+
+### 범위/구조 확인
+- Issue 범위 준수 여부
+- API 응답, DB, 설정, 외부 동작 변경 여부
+
+### 결론
+- Blocking 있음 / Blocking 없음
+- 코드 수정 없이 리뷰만 수행했는지 여부
+```
+
+## Blocking / Non-blocking 처리 기준
+
+### Blocking
+
+아래 항목은 merge 전에 같은 PR에서 해결한다.
+
+- 테스트 실패 또는 컴파일 오류
+- 보안, 인증, 권한, 민감 정보 노출 위험
+- Issue 요구사항과 충돌하는 구현
+- API 응답 구조의 의도치 않은 변경
+- DB 데이터 손상 가능성
+- 문서에 명시한 운영 원칙과 코드의 충돌
+
+### Non-blocking
+
+아래 항목은 같은 PR에서 반영하거나 후속 이슈로 분리할 수 있다.
+
+- 로그 필드 추가 개선
+- requestId, tracing, metrics 등 관측성 고도화
+- 테스트 케이스 확장
+- 네이밍, 구조, 중복 제거
+- 운영 정책 문서화
+
+반영하지 않는 Non-blocking 의견은 PR comment 또는 PR 본문에 사유를 남긴다.
+
+## Reviewer 세션 표준 프롬프트
+
+```text
+너는 Reviewer Agent다.
+코드 수정은 하지 말고 PR diff만 검토해줘.
+
+Repo: SKU-GlobalTimes/GlobalTimes_BeSide
+PR: <PR URL>
+Issue: #<ISSUE_NUMBER>
+
+검토 관점:
+1. Issue 범위를 벗어난 변경이 있는가?
+2. 테스트 또는 검증 계획에 누락이 있는가?
+3. 보안, 민감 정보 로그, DB 영향, API 응답 변경 위험이 있는가?
+4. Blocking / Non-blocking을 구분해줘.
+5. 검토 결과를 GitHub PR comment로 남겨줘.
+
+제약:
+- 코드 직접 수정 금지
+- 커밋, push, merge 금지
+- 리뷰 결과만 PR comment로 기록
+```
+
+## Implementer 세션 표준 프롬프트
+
+```text
+PR #<PR_NUMBER>의 AI Reviewer comment를 읽고 수정 계획을 세워줘.
+
+원칙:
+- Blocking은 같은 PR에서 수정한다.
+- Non-blocking은 같은 PR 반영 / 후속 이슈 분리 / 미반영 사유 기록 중 하나로 분류한다.
+- 코드 변경 전 사용자 승인을 먼저 받는다.
+```
+
+## 기록 기준
+
+- Reviewer 검토 결과는 PR comment에 남긴다.
+- Implementer 반영 계획과 반영 완료 내역도 PR comment에 남긴다.
+- 최종 Reviewer 확인 결과는 “Blocking 없음” comment로 남긴다.
+- merge는 사용자의 명시적 승인 후에만 수행한다.
+
+## 후속 자동화 후보
+
+- PR comment에서 Blocking만 추출하는 스크립트
+- Reviewer comment 템플릿 자동 생성
+- Issue 범위와 PR 변경 파일 비교
+- 위험 파일 변경 감지
+- 승인 상태와 tool 실행 내역을 저장하는 audit log
+- 반복 패턴이 충분히 쌓인 뒤 MCP 서버로 도구화


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #117

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)


## 📝 작업 내용
- AI Reviewer가 PR diff 검토 결과를 GitHub PR comment에 직접 남기는 반자동 운영 흐름을 문서화했습니다.
- Implementer / Reviewer / User 역할과 권한을 구분했습니다.
- Blocking / Non-blocking 처리 기준을 정리했습니다.
- Reviewer 세션과 Implementer 세션에서 사용할 표준 프롬프트 예시를 추가했습니다.
- 기존 `docs/ai-workflow/README.md`에서 Reviewer comment workflow 문서로 연결했습니다.

## 🔍 기술적 배경
- #116 작업에서 Implementer 세션과 Reviewer 세션을 분리해 운영하면서, 사용자가 리뷰 결과를 세션 사이에서 직접 복사해야 하는 반복 비용이 있었습니다.
- 이번 변경은 완전 자동화가 아니라 GitHub PR comment를 AI 리뷰 결과와 반영 내역의 단일 기록 저장소로 사용하는 운영 규칙 표준화입니다.
- 반복적인 comment 조회, Blocking 추출, 승인 상태 확인은 후속 스크립트 또는 MCP 서버 자동화 후보로 분리했습니다.

## 🧪 테스트/검증 (필수)
- [x] 문서 변경만 포함되는지 diff로 확인했습니다.
- [x] `git diff --check`로 공백 오류가 없음을 확인했습니다.
- [x] Issue → PR → Reviewer comment → 반영 커밋 → merge 흐름이 문서에 포함되어 있는지 확인했습니다.

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [ ] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?


## 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
- 이 문서가 “완전 자동화 구현”이 아니라 “PR comment 중심 반자동 운영 규칙 표준화”로 명확히 읽히는지 확인해주세요.
- Reviewer에게 comment 작성 권한은 주되 코드 수정 권한은 주지 않는 경계가 충분히 명확한지 확인해주세요.


## ➕ 추후 계획(선택)
- PR comment에서 Blocking만 추출하는 스크립트를 추가합니다.
- 승인 상태, 위험 파일 변경 감지, audit log를 후속 자동화 후보로 분리합니다.
- 반복 패턴이 충분히 쌓이면 MCP 서버로 도구화합니다.