### PR TITLE
[CHORE/#119] AI Reviewer Blocking 확인 스크립트 추가

### DIFF
--- a/docs/ai-workflow/review-blocking-check-script.md
+++ b/docs/ai-workflow/review-blocking-check-script.md
@@ -30,7 +30,7 @@ powershell -ExecutionPolicy Bypass -File .\scripts\ai-workflow\check-review-bloc
 
 | 상태 | 의미 |
 | --- | --- |
-| `MERGE_READY` | 최신 AI Reviewer comment의 Blocking 섹션이 비어 있거나 `없음`으로 판단된다. |
+| `MERGE_READY` | 최신 AI Reviewer comment의 Blocking 섹션이 `없음` 등 명시적 비어 있음 표현으로 판단된다. |
 | `CHANGES_REQUIRED` | Blocking 섹션에 수정이 필요한 항목이 있다. |
 | `REVIEW_NOT_FOUND` | AI Reviewer comment를 찾지 못했다. |
 
@@ -47,7 +47,7 @@ powershell -ExecutionPolicy Bypass -File .\scripts\ai-workflow\check-review-bloc
 - GitHub CLI(`gh`)가 설치되어 있어야 한다.
 - `gh auth login`으로 대상 저장소를 읽을 권한이 있어야 한다.
 - Reviewer comment는 `### Blocking`, `### Non-blocking`, `### 결론` 섹션을 사용하는 형식을 권장한다.
-- 스크립트는 제목 줄이 `AI Reviewer`를 포함하는 최신 comment를 Reviewer comment 후보로 사용한다.
+- 스크립트는 제목 줄이 `AI Reviewer 검토 결과` 형식을 포함하는 최신 comment를 Reviewer comment 후보로 사용한다.
 - GitHub comment 앞에 BOM 또는 공백이 붙는 경우를 고려해 제목 앞 숨은 문자를 허용한다.
 - Windows PowerShell 5.1의 UTF-8 파싱 차이를 줄이기 위해, 스크립트 내부의 일부 한글 판정은 유니코드 코드포인트 기반으로 처리한다.
 

--- a/docs/ai-workflow/review-blocking-check-script.md
+++ b/docs/ai-workflow/review-blocking-check-script.md
@@ -47,12 +47,16 @@ powershell -ExecutionPolicy Bypass -File .\scripts\ai-workflow\check-review-bloc
 - GitHub CLI(`gh`)가 설치되어 있어야 한다.
 - `gh auth login`으로 대상 저장소를 읽을 권한이 있어야 한다.
 - Reviewer comment는 `### Blocking`, `### Non-blocking`, `### 결론` 섹션을 사용하는 형식을 권장한다.
+- 스크립트는 제목 줄이 `AI Reviewer`를 포함하는 최신 comment를 Reviewer comment 후보로 사용한다.
+- GitHub comment 앞에 BOM 또는 공백이 붙는 경우를 고려해 제목 앞 숨은 문자를 허용한다.
+- Windows PowerShell 5.1의 UTF-8 파싱 차이를 줄이기 위해, 스크립트 내부의 일부 한글 판정은 유니코드 코드포인트 기반으로 처리한다.
 
 ## 한계
 
 - 자연어 comment를 완벽하게 해석하지 않는다.
 - 최신 AI Reviewer comment를 기준으로 판단하므로, 사람이 최종 merge 승인 전에 결과를 확인해야 한다.
 - `Blocking 없음`처럼 명시적으로 작성된 comment에 가장 안정적으로 동작한다.
+- `### Blocking` 섹션을 찾지 못하면 안전하게 `REVIEW_NOT_FOUND`로 처리한다.
 - PR comment 작성, 코드 수정, merge는 수행하지 않는다.
 
 ## 후속 자동화 후보

--- a/docs/ai-workflow/review-blocking-check-script.md
+++ b/docs/ai-workflow/review-blocking-check-script.md
@@ -1,0 +1,63 @@
+# AI Reviewer Blocking 확인 스크립트
+
+## 목적
+
+AI Reviewer가 GitHub PR comment에 남긴 검토 결과를 사람이 매번 눈으로 읽고 해석하는 반복 작업을 줄인다.
+이 스크립트는 최신 AI Reviewer comment에서 `Blocking`, `Non-blocking`, `결론` 섹션을 추출하고 merge 전 상태 판단을 보조한다.
+
+이 도구는 리뷰 자체를 대체하지 않는다.
+Reviewer가 남긴 comment를 읽기 쉬운 상태값으로 요약하는 보조 도구다.
+
+## 사용 방법
+
+```powershell
+.\scripts\ai-workflow\check-review-blocking.ps1 -PrNumber 118
+```
+
+Windows PowerShell 실행 정책으로 스크립트 실행이 막히는 경우에는 아래처럼 실행한다.
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\ai-workflow\check-review-blocking.ps1 -PrNumber 118
+```
+
+다른 저장소를 명시하려면 `-Repo`를 사용한다.
+
+```powershell
+.\scripts\ai-workflow\check-review-blocking.ps1 -PrNumber 118 -Repo "SKU-GlobalTimes/GlobalTimes_BeSide"
+```
+
+## 출력 상태
+
+| 상태 | 의미 |
+| --- | --- |
+| `MERGE_READY` | 최신 AI Reviewer comment의 Blocking 섹션이 비어 있거나 `없음`으로 판단된다. |
+| `CHANGES_REQUIRED` | Blocking 섹션에 수정이 필요한 항목이 있다. |
+| `REVIEW_NOT_FOUND` | AI Reviewer comment를 찾지 못했다. |
+
+## 종료 코드
+
+| Exit code | 의미 |
+| --- | --- |
+| `0` | Blocking 없음 |
+| `1` | Blocking 있음 |
+| `2` | Reviewer comment 없음 |
+
+## 전제 조건
+
+- GitHub CLI(`gh`)가 설치되어 있어야 한다.
+- `gh auth login`으로 대상 저장소를 읽을 권한이 있어야 한다.
+- Reviewer comment는 `### Blocking`, `### Non-blocking`, `### 결론` 섹션을 사용하는 형식을 권장한다.
+
+## 한계
+
+- 자연어 comment를 완벽하게 해석하지 않는다.
+- 최신 AI Reviewer comment를 기준으로 판단하므로, 사람이 최종 merge 승인 전에 결과를 확인해야 한다.
+- `Blocking 없음`처럼 명시적으로 작성된 comment에 가장 안정적으로 동작한다.
+- PR comment 작성, 코드 수정, merge는 수행하지 않는다.
+
+## 후속 자동화 후보
+
+- Reviewer comment 템플릿 강제화
+- Blocking 항목을 GitHub check 또는 label로 반영
+- 승인 상태와 결합한 merge gate 구현
+- 반복 패턴이 쌓인 뒤 MCP tool로 전환

--- a/docs/ai-workflow/reviewer-comment-workflow.md
+++ b/docs/ai-workflow/reviewer-comment-workflow.md
@@ -145,3 +145,6 @@ PR #<PR_NUMBER>의 AI Reviewer comment를 읽고 수정 계획을 세워줘.
 - 위험 파일 변경 감지
 - 승인 상태와 tool 실행 내역을 저장하는 audit log
 - 반복 패턴이 충분히 쌓인 뒤 MCP 서버로 도구화
+
+PR comment에서 Blocking 여부를 확인하는 보조 스크립트는
+[AI Reviewer Blocking 확인 스크립트](./review-blocking-check-script.md)를 참고한다.

--- a/scripts/ai-workflow/check-review-blocking.ps1
+++ b/scripts/ai-workflow/check-review-blocking.ps1
@@ -44,7 +44,8 @@ function Test-EmptySection {
 $json = gh pr view $PrNumber --repo $Repo --comments --json comments,url,state,mergeable | ConvertFrom-Json
 
 $bom = [char]0xFEFF
-$reviewHeadingPattern = "(?m)^[$bom\s]*##\s+.*AI Reviewer"
+$reviewResultKo = "$([char]0xAC80)$([char]0xD1A0) $([char]0xACB0)$([char]0xACFC)"
+$reviewHeadingPattern = "(?m)^[$bom\s]*##\s+.*AI Reviewer\s+$reviewResultKo\s*$"
 $reviewComments = @($json.comments | Where-Object {
         $_.body -match $reviewHeadingPattern
     } | Sort-Object createdAt -Descending)

--- a/scripts/ai-workflow/check-review-blocking.ps1
+++ b/scripts/ai-workflow/check-review-blocking.ps1
@@ -43,8 +43,10 @@ function Test-EmptySection {
 
 $json = gh pr view $PrNumber --repo $Repo --comments --json comments,url,state,mergeable | ConvertFrom-Json
 
+$bom = [char]0xFEFF
+$reviewHeadingPattern = "(?m)^[$bom\s]*##\s+.*AI Reviewer"
 $reviewComments = @($json.comments | Where-Object {
-        $_.body -match "AI Reviewer" -or $_.body -match "Blocking"
+        $_.body -match $reviewHeadingPattern
     } | Sort-Object createdAt -Descending)
 
 if ($reviewComments.Count -eq 0) {
@@ -63,6 +65,18 @@ $conclusion = Get-Section -Body $body -Name "Conclusion"
 if ([string]::IsNullOrWhiteSpace($conclusion)) {
     $conclusionKo = "$([char]0xACB0)$([char]0xB860)"
     $conclusion = Get-Section -Body $body -Name $conclusionKo
+}
+
+if ([string]::IsNullOrWhiteSpace($blocking)) {
+    Write-Output "PR #$PrNumber AI Reviewer Status"
+    Write-Output "PR URL: $($json.url)"
+    Write-Output "PR State: $($json.state)"
+    Write-Output "Mergeable: $($json.mergeable)"
+    Write-Output "Reviewer Comment: $($latest.url)"
+    Write-Output "Reviewer CreatedAt: $($latest.createdAt)"
+    Write-Output "Decision: REVIEW_NOT_FOUND"
+    Write-Output "Reason: Blocking section was not found in the latest AI Reviewer comment."
+    exit 2
 }
 
 $hasBlocking = -not (Test-EmptySection -Content $blocking)

--- a/scripts/ai-workflow/check-review-blocking.ps1
+++ b/scripts/ai-workflow/check-review-blocking.ps1
@@ -1,0 +1,104 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [int]$PrNumber,
+
+    [string]$Repo = "SKU-GlobalTimes/GlobalTimes_BeSide"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Section {
+    param([string]$Title)
+    Write-Output ""
+    Write-Output $Title
+    Write-Output ("-" * $Title.Length)
+}
+
+function Get-Section {
+    param(
+        [string]$Body,
+        [string]$Name
+    )
+
+    $pattern = "(?ms)^###\s+$([regex]::Escape($Name))\s*(.*?)(?=^###\s+|\z)"
+    $match = [regex]::Match($Body, $pattern)
+    if (-not $match.Success) {
+        return ""
+    }
+
+    return $match.Groups[1].Value.Trim()
+}
+
+function Test-EmptySection {
+    param([string]$Content)
+
+    if ([string]::IsNullOrWhiteSpace($Content)) {
+        return $true
+    }
+
+    $noneKo = "$([char]0xC5C6)$([char]0xC74C)"
+    $normalized = $Content.Trim()
+    return $normalized -match "^-?\s*($noneKo|N/A|None|none)\s*\.?$"
+}
+
+$json = gh pr view $PrNumber --repo $Repo --comments --json comments,url,state,mergeable | ConvertFrom-Json
+
+$reviewComments = @($json.comments | Where-Object {
+        $_.body -match "AI Reviewer" -or $_.body -match "Blocking"
+    } | Sort-Object createdAt -Descending)
+
+if ($reviewComments.Count -eq 0) {
+    Write-Output "PR #$PrNumber AI Reviewer Status"
+    Write-Output "Decision: REVIEW_NOT_FOUND"
+    Write-Output "Reason: AI Reviewer comment was not found."
+    exit 2
+}
+
+$latest = $reviewComments[0]
+$body = [string]$latest.body
+
+$blocking = Get-Section -Body $body -Name "Blocking"
+$nonBlocking = Get-Section -Body $body -Name "Non-blocking"
+$conclusion = Get-Section -Body $body -Name "Conclusion"
+if ([string]::IsNullOrWhiteSpace($conclusion)) {
+    $conclusionKo = "$([char]0xACB0)$([char]0xB860)"
+    $conclusion = Get-Section -Body $body -Name $conclusionKo
+}
+
+$hasBlocking = -not (Test-EmptySection -Content $blocking)
+$decision = if ($hasBlocking) { "CHANGES_REQUIRED" } else { "MERGE_READY" }
+
+Write-Output "PR #$PrNumber AI Reviewer Status"
+Write-Output "PR URL: $($json.url)"
+Write-Output "PR State: $($json.state)"
+Write-Output "Mergeable: $($json.mergeable)"
+Write-Output "Reviewer Comment: $($latest.url)"
+Write-Output "Reviewer CreatedAt: $($latest.createdAt)"
+Write-Output "Decision: $decision"
+
+Write-Section "Blocking"
+if ([string]::IsNullOrWhiteSpace($blocking)) {
+    Write-Output "(section not found)"
+} else {
+    Write-Output $blocking
+}
+
+Write-Section "Non-blocking"
+if ([string]::IsNullOrWhiteSpace($nonBlocking)) {
+    Write-Output "(section not found)"
+} else {
+    Write-Output $nonBlocking
+}
+
+Write-Section "Conclusion"
+if ([string]::IsNullOrWhiteSpace($conclusion)) {
+    Write-Output "(section not found)"
+} else {
+    Write-Output $conclusion
+}
+
+if ($hasBlocking) {
+    exit 1
+}
+
+exit 0


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #119

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)


## 📝 작업 내용
- AI Reviewer가 PR comment에 남긴 최신 검토 결과에서 `Blocking`, `Non-blocking`, `결론` 섹션을 추출하는 PowerShell 스크립트를 추가했습니다.
- Blocking이 없으면 `MERGE_READY`, Blocking이 있으면 `CHANGES_REQUIRED`, Reviewer comment를 찾지 못하면 `REVIEW_NOT_FOUND`로 출력합니다.
- 스크립트 사용법과 한계를 `docs/ai-workflow/review-blocking-check-script.md`에 문서화했습니다.
- 기존 Reviewer comment workflow 문서에서 Blocking 확인 스크립트 문서로 연결했습니다.

## 🔍 기술적 배경
- #116, #118 작업에서 AI Reviewer comment를 기준으로 리뷰 상태를 확인했지만, 사람이 긴 comment를 직접 읽고 Blocking 여부를 판단해야 했습니다.
- 이번 변경은 리뷰 자체를 자동화하는 것이 아니라, Reviewer comment 판독을 보조해 merge 전 상태 확인을 표준화하는 작은 자동화입니다.
- Windows PowerShell 실행 정책과 UTF-8 파싱 이슈를 고려해 스크립트 내부의 한글 판정은 유니코드 코드포인트 기반으로 처리했습니다.

## 🧪 테스트/검증 (필수)
- [x] `powershell -ExecutionPolicy Bypass -File .\scripts\ai-workflow\check-review-blocking.ps1 -PrNumber 118` 실행 결과 `Decision: MERGE_READY` 확인
- [x] `git diff --check`로 공백 오류가 없음을 확인
- [x] 애플리케이션 코드 변경 없이 문서와 스크립트만 포함되는지 확인

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [ ] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?


## 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
- 스크립트가 “리뷰 대체”가 아니라 “Reviewer comment 판독 보조 도구”로 명확한지 확인해주세요.
- 최신 AI Reviewer comment 기준으로 Blocking을 판정하는 방식이 현재 workflow 문서와 일관적인지 확인해주세요.


## ➕ 추후 계획(선택)
- Reviewer comment 템플릿을 더 엄격히 표준화합니다.
- Blocking 상태를 GitHub check 또는 label로 반영하는 방식을 검토합니다.
- 승인 상태와 결합해 MCP tool 후보로 발전시킵니다.