### PR TITLE
[FIX] 검색 API LazyInitializationException으로 인한 500 응답 수정

### DIFF
--- a/src/main/java/com/example/globalTimes_be/domain/search/service/SearchArticlesService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/search/service/SearchArticlesService.java
@@ -7,6 +7,7 @@ import com.example.globalTimes_be.domain.search.dto.response.SearchResDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -24,6 +25,7 @@ public class SearchArticlesService {
     /**
      * @param date 탐색과 동일: 하루 단위(yyyy-MM-dd). null/공백이면 날짜 필터 없음.
      */
+    @Transactional(readOnly = true)
     public SearchResDTO getSearchArticles(
             String text,
             String translatedText,


### PR DESCRIPTION
## Summary
- 검색 결과 DTO 변환까지 read-only transaction 범위 안에서 수행되도록 SearchArticlesService#getSearchArticles에 @Transactional(readOnly = true)를 추가했습니다.
- Article.source가 LAZY 연관관계이고 spring.jpa.open-in-view=false인 상태에서 DTO 변환 중 sourceName 접근 시 발생할 수 있는 LazyInitializationException을 방지합니다.
- 응답 DTO 구조와 검색 쿼리는 변경하지 않았습니다.

## Issue
- Closes #123

## Test
- ./gradlew.bat test
- git diff --check
- /api/search?text=war -> 200
- /api/search?text=korea -> 200
- /api/search?text=economy -> 200
- /api/search?text=technology -> 200
- k6 smoke test: http_req_failed=0.00% (0 out of 86), checks_failed=0.00% (0 out of 172)

## k6 Smoke Test Details
조건:
- BASE_URL=http://localhost:8080
- ARTICLE_ID=8449
- SEARCH_TEXT=war
- ARTICLES_VUS=1, SEARCH_VUS=1, PERSPECTIVES_VUS=1
- ARTICLES_DURATION=15s, SEARCH_DURATION=15s, PERSPECTIVES_DURATION=15s

결과:
- 전체 p95: 63.9ms
- articles p95: 45.21ms
- search p95: 64.12ms
- perspectives p95: 59.97ms

## Notes
- #121/#122 기준 동일 smoke 조건의 기존 실패율은 http_req_failed=16.25%였습니다.
- 이번 검증 기준 http_req_failed=0.00%로 개선을 확인했습니다.
- 상세 검증 comment: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/126#issuecomment-4862466460
- AI Reviewer 검토 결과: Blocking 없음.