### PR TITLE
[PERF] Perspectives API Redis 캐시 정책 및 정합성 점검

### DIFF
--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -608,17 +608,14 @@ GlobalTimes_BeSide 백엔드 개선 작업을 이어서 진행하려고 합니�
 먼저 docs/backend-improvement/WORK_PROGRESS.md 를 읽고 현재까지의 작업 흐름을 파악해줘.
 우리는 Issue → Branch → 조사 → 계획 → 승인 → 구현 → 테스트 → PR → AI Reviewer comment → Blocking 확인 → merge 순서로 작업합니다.
 
-다음 작업은 #127 입니다.
-Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/127
-목표: Perspectives API cold cache와 warm cache 부하 테스트를 분리해 Redis 캐시 효과를 수치화
-
 바로 구현하지 말고,
 1. 현재 develop 최신화
-2. #127 작업 브랜치 확인 또는 생성
-3. `PerspectivesService`, Redis key/TTL, 기존 k6 스크립트 조사
-4. cold/warm cache 측정 방식 분석
-5. 수정 계획 제안
-6. 사용자 승인 후 구현
+2. `WORK_PROGRESS.md`의 In Progress 작업과 최근 merged PR을 확인
+3. 진행 중인 작업이 있으면 해당 Issue/PR/브랜치 상태를 확인
+4. 진행 중인 작업이 없으면 이후 개선 로드맵에서 다음 후보를 제안
+5. 관련 코드와 문서를 조사
+6. 원인/범위/수정 계획을 제안
+7. 사용자 승인 후 구현
 순서로 진행해주세요.
 ```
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -328,7 +328,8 @@ PERSPECTIVES_DURATION=15s
 ### #127 - Perspectives API cold/warm cache 부하 테스트 분리
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/127
-- 상태: In Progress
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/128
+- 상태: merged
 - 작업 브랜치: `perf/#127-perspectives-cache-load-test`
 
 목표:
@@ -381,6 +382,37 @@ WARM_DURATION=15s
 - 현재 Perspectives 관련 기사 탐색은 제목 기반 키워드 추출과 MySQL FULLTEXT 검색에 의존한다.
 - 이는 진정한 의미의 semantic similarity가 아니므로, 같은 사건이라도 표현이 다르면 누락될 수 있다.
 - 이번 작업은 검색 품질 개선이 아니라 cache hit/miss 성능 차이를 분리 측정하는 작업이다.
+
+---
+
+### #129 - Perspectives API Redis 캐시 정책 및 정합성 점검
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/129
+- 상태: In Progress
+- 작업 브랜치: `perf/#129-perspectives-redis-cache-policy`
+- 주요 파일:
+  - `docs/backend-improvement/perspectives-redis-cache-policy.md`
+
+목표:
+
+- #127에서 확인한 Redis warm cache 효과를 바탕으로, `PerspectivesService`의 cache key, TTL, 실패 처리, stale cache 허용 기준을 설명 가능하게 정리한다.
+- Redis를 단순 성능 도구로만 쓰는 것이 아니라, 캐시 정합성 trade-off까지 문서화한다.
+
+현재 확인한 정책:
+
+- Redis key: `perspectives:article:{articleId}`
+- TTL: `perspectives.cache-ttl-seconds`, 기본 3600초
+- `perspectives.cache-ttl-seconds=0`이면 캐시 미사용
+- Redis read 실패, JSON 역직렬화 실패는 warn 로그 후 DB/FULLTEXT 재계산
+- Redis write 실패는 warn 로그 후 무시하고 API 응답은 반환
+- 명시적 invalidation은 현재 없음
+
+정합성 판단:
+
+- 현재 서비스는 뉴스 수집 후 읽기 중심이며, 기사 제목/국가/category/source를 수정하는 API는 없다.
+- `viewCount`, `summary`, `crawledContent` 변경은 Perspectives 응답에 포함되지 않아 무효화 대상이 아니다.
+- 새 관련 기사 삽입, base article title 변경, country/category/source 변경은 stale cache 가능성이 있지만 현재는 1시간 TTL 기반 stale 허용으로 충분하다고 판단한다.
+- 명시적 invalidation은 관리자 수정 API나 더 긴 TTL이 필요해질 때 별도 이슈로 검토한다.
 
 ## 4. 이후 개선 로드맵
 

--- a/docs/backend-improvement/perspectives-cache-load-test.md
+++ b/docs/backend-improvement/perspectives-cache-load-test.md
@@ -112,6 +112,7 @@ $env:WARM_DURATION = "15s"
 - cold cache p95가 높다면 병목 후보는 기준 기사 조회, 키워드 추출, 번역, FULLTEXT 검색, 그룹핑 중 하나다.
 - warm cache p95가 높다면 Redis 조회, JSON 역직렬화, 네트워크, 응답 크기를 추가로 확인한다.
 - 캐시 key, TTL, 정합성 정책 변경은 측정 결과를 근거로 후속 이슈에서 다룬다.
+- 현재 Redis key, TTL, 실패 처리, stale cache 허용 판단은 `docs/backend-improvement/perspectives-redis-cache-policy.md`에 기록한다.
 
 ## 주의사항
 

--- a/docs/backend-improvement/perspectives-redis-cache-policy.md
+++ b/docs/backend-improvement/perspectives-redis-cache-policy.md
@@ -1,0 +1,122 @@
+# Perspectives Redis cache policy
+
+## Purpose
+
+`GET /api/news/{id}/perspectives` groups related articles by country after keyword extraction, optional translation, and MySQL FULLTEXT search.
+Because this path is more expensive than a simple article lookup, `PerspectivesService` stores the computed response in Redis.
+
+This document records the current cache policy, failure behavior, and stale data trade-off so later performance work can change it deliberately.
+
+## Terms
+
+| Term | Meaning in this project |
+| --- | --- |
+| Cache deletion | Directly removing a Redis key, for example deleting `perspectives:article:8449`. This is useful for tests or manual cleanup. |
+| Cache invalidation | Removing or refreshing cache automatically when source data changes in a way that makes the cached value outdated. |
+| Stale cache | A cached response that is still served even though the underlying DB data changed after it was cached. |
+| Stale allowance | A deliberate decision to tolerate stale cache for a bounded time, usually controlled by TTL, because the data is read-heavy and not mission critical. |
+
+## Current policy
+
+| Item | Current behavior |
+| --- | --- |
+| Key prefix | `perspectives:article:` |
+| Key shape | `perspectives:article:{articleId}` |
+| Value | Serialized `PerspectivesResDTO` JSON |
+| TTL property | `perspectives.cache-ttl-seconds` |
+| Default TTL | `3600` seconds |
+| Cache disabled condition | `perspectives.cache-ttl-seconds=0` |
+| Explicit invalidation | Not implemented |
+
+Configuration:
+
+```yaml
+perspectives:
+  cache-ttl-seconds: 3600
+```
+
+## Runtime flow
+
+### Cache hit
+
+1. Read `perspectives:article:{articleId}` from Redis.
+2. Deserialize JSON into `PerspectivesResDTO`.
+3. Return the cached response.
+4. Log `cacheHit=true`, `cacheReadMs`, `totalMs`, `countriesFound`, and `totalArticles`.
+
+### Cache miss
+
+1. Load base article from MySQL.
+2. Extract plain and FULLTEXT boolean keywords from the title.
+3. Translate non-English article keywords to English.
+4. Search related articles with MySQL FULLTEXT.
+5. Group results by country and limit each country to 3 articles.
+6. Serialize the response and store it in Redis with TTL.
+7. Log `cacheHit=false` and step-level timings.
+
+## Failure behavior
+
+| Failure case | Current behavior | API impact |
+| --- | --- | --- |
+| Redis read failure | Warn and recompute from DB/FULLTEXT | Response can still succeed |
+| Cache JSON deserialize failure | Warn and recompute from DB/FULLTEXT | Response can still succeed |
+| Redis write failure | Warn and ignore | Response succeeds, next request may be cold again |
+| Base article missing | Throw domain exception | Response fails as before |
+
+Redis is treated as an optimization layer, not the source of truth.
+The source of truth remains MySQL.
+
+## Stale cache analysis
+
+The current service is mostly read-heavy after news ingestion.
+For this reason, bounded stale cache is acceptable for Perspectives responses as long as TTL remains short enough for the product expectation.
+
+| Data change | Can affect Perspectives response? | Current handling | Notes |
+| --- | --- | --- | --- |
+| New related articles inserted | Yes | Existing cache remains until TTL expires | Newly inserted related articles may not appear immediately. |
+| Base article title changed | Yes | Existing cache remains until TTL expires | Keyword extraction result can become outdated. |
+| Article country/category changed | Yes | Existing cache remains until TTL expires | Country grouping can become outdated. |
+| Article source changed | Maybe | Existing cache remains until TTL expires | Source name is included in child article DTOs. |
+| View count increased | No | No invalidation needed | View count is not part of Perspectives response. |
+| Summary updated | No | No invalidation needed | Summary is not part of Perspectives response. |
+| Crawled content updated | No | No invalidation needed | Crawled content is not part of Perspectives response. |
+| Scrap/chat data changed | No | No invalidation needed | Not used by Perspectives response. |
+
+## Decision
+
+For the current project stage, keep TTL-based stale allowance instead of adding explicit invalidation.
+
+Reasons:
+
+- Perspectives is a read-heavy derived response.
+- Article edits that affect Perspectives appear rare in the current API surface.
+- News ingestion can add related articles, but showing them after at most the TTL window is acceptable for this feature.
+- Explicit invalidation would require wiring cache deletion into every write path that can affect related article matching.
+- The current 1-hour TTL bounds stale responses while preserving the measured warm cache benefit.
+
+## When to add invalidation
+
+Add explicit invalidation if one of these becomes true:
+
+- Admin APIs start editing article title, country, category, source, or language.
+- News ingestion becomes frequent enough that newly inserted related articles must appear immediately.
+- Users report stale Perspectives results as a correctness issue.
+- Cache TTL needs to be raised significantly beyond the current 1-hour window.
+
+Potential invalidation targets:
+
+```text
+perspectives:article:{baseArticleId}
+```
+
+Full correctness is harder than deleting only the changed article key.
+If a newly inserted article is related to many existing base articles, those existing base article caches can also become stale.
+That broader invalidation problem should be handled in a separate design issue.
+
+## Follow-up candidates
+
+- Measure cold cache with multiple article IDs to understand FULLTEXT variance.
+- Use MySQL `EXPLAIN` on `ArticleRepository.findPerspectives`.
+- Revisit TTL after measuring warm cache hit ratio and stale tolerance.
+- Consider local cache only if Redis hit path itself becomes a bottleneck.
+- Consider asynchronous precomputation only if cold cache latency becomes user-visible at higher traffic.


### PR DESCRIPTION
## Summary
- Perspectives API Redis cache key, TTL, 실패 처리, stale cache 허용 기준을 문서화했습니다.
- cache deletion, cache invalidation, stale cache, stale allowance 개념을 프로젝트 맥락에 맞게 정리했습니다.
- 현재 서비스는 뉴스 수집 후 읽기 중심이므로 명시적 invalidation보다 1시간 TTL 기반 stale allowance를 유지하는 판단을 기록했습니다.
- #127 cold/warm cache 측정 문서와 WORK_PROGRESS.md에서 새 정책 문서를 연결했습니다.

## Issue
- Closes #129

## Policy Notes
- Redis key: perspectives:article:{articleId}
- TTL: perspectives.cache-ttl-seconds, 기본 3600초
- Redis read failure: warn 후 DB/FULLTEXT 재계산
- JSON deserialize failure: warn 후 DB/FULLTEXT 재계산
- Redis write failure: warn 후 무시, API 응답은 반환
- Explicit invalidation: 현재 미구현, TTL 기반 stale 허용

## Stale Cache 판단
- viewCount, summary, crawledContent 변경은 Perspectives 응답에 포함되지 않아 무효화 대상이 아닙니다.
- 새 관련 기사 삽입, base article title 변경, country/category/source 변경은 stale 가능성이 있습니다.
- 현재는 기사 수정 API가 거의 없고 읽기 중심이므로 1시간 TTL로 bounded stale을 허용합니다.
- 관리자 수정 API, 긴 TTL, 즉시 최신 관련 기사 노출 요구가 생기면 명시적 invalidation을 후속 이슈로 다룹니다.

## Test
- ./gradlew.bat test
- git diff --check

## Notes
- 이번 PR은 문서/정책 정리 중심입니다.
- Redis TTL 변경, 로컬 캐시 도입, MySQL EXPLAIN 쿼리 튜닝, semantic similarity 개선, 비동기 처리는 범위에서 제외했습니다.