### PR TITLE
[PERF] 검색 API FULLTEXT 성능 및 검색어별 안정성 분석

### DIFF
--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -420,7 +420,8 @@ WARM_DURATION=15s
 ### #131 - Perspectives API FULLTEXT 쿼리 EXPLAIN 분석
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/131
-- 상태: In Progress
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/132
+- 상태: merged
 - 작업 브랜치: `perf/#131-perspectives-fulltext-explain`
 - 주요 파일:
   - `docs/backend-improvement/perspectives-fulltext-explain.md`
@@ -445,6 +446,42 @@ WARM_DURATION=15s
 - 현재 데이터 규모에서는 `findPerspectives` 쿼리가 FULLTEXT 인덱스를 사용하며, 즉시 쿼리/인덱스 변경이 필요한 병목으로 보이지 않는다.
 - `Using filesort`는 매칭 결과가 커질 때 p95에 영향을 줄 수 있으므로 후속 관찰 포인트로 남긴다.
 - 검색 품질, 다국어 매칭, semantic similarity는 별도 품질 개선 이슈로 분리한다.
+
+---
+
+### #133 - 검색 API FULLTEXT 성능 및 검색어별 안정성 분석
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/133
+- 상태: In Progress
+- 작업 브랜치: `perf/#133-search-fulltext-analysis`
+- 주요 파일:
+  - `src/main/java/com/example/globalTimes_be/domain/article/repository/ArticleRepository.java`
+  - `src/main/java/com/example/globalTimes_be/domain/search/service/SearchArticlesService.java`
+  - `docs/backend-improvement/search-fulltext-analysis.md`
+
+목표:
+
+- `/api/search`가 검색어별로 어떤 FULLTEXT 실행 계획을 사용하는지 확인한다.
+- #123에서 수정한 영어 검색어 500 문제 이후, 영어/한국어/다국어 검색어별 매칭 수와 실행 계획 차이를 정리한다.
+
+조사 결과:
+
+- 검색 API는 원문 검색어와 번역 검색어를 `OR MATCH`로 묶어 검색한다.
+- `war`, `economy`, `technology`, `대구` API 호출은 모두 200 응답을 반환했다.
+- 로컬 DB 기준 FULLTEXT 매칭 수는 `war=404`, `technology=82`, `economy=39`, `대구 OR daegu=0`이었다.
+- 단일 MATCH 쿼리는 `ft_article_title_description` FULLTEXT 인덱스를 사용했다.
+- 원문과 번역어가 같은 영어 검색어에서도 기존 쿼리는 중복 `OR MATCH`가 되어 MySQL이 `idx_article_published_at` 역방향 스캔을 선택했다.
+
+수정:
+
+- `text`와 `translatedText`가 trim/case-insensitive 기준으로 같으면 단일 MATCH 쿼리를 사용하도록 분기했다.
+- 원문과 번역어가 다르면 기존 OR MATCH 쿼리를 유지한다.
+- API 응답 구조는 변경하지 않았다.
+
+판단:
+
+- 영어처럼 원문/번역어가 같은 검색어에서는 중복 OR를 제거해 의도한 FULLTEXT 인덱스를 사용하도록 하는 것이 작고 안전한 개선이다.
+- 한국어/다국어 검색 품질, 형태소 분석, Elasticsearch/vector search는 별도 품질 개선 이슈로 분리한다.
 
 ## 4. 이후 개선 로드맵
 

--- a/docs/backend-improvement/search-fulltext-analysis.md
+++ b/docs/backend-improvement/search-fulltext-analysis.md
@@ -48,6 +48,8 @@ OR MATCH(...) AGAINST('war' ...)
 
 On the local development dataset, a single `MATCH` query used the FULLTEXT index.
 The duplicated `OR MATCH` query chose a reverse scan on `idx_article_published_at` and applied MATCH as a filter.
+The representative `EXPLAIN ANALYZE` examples below use the default search path without optional `country`, `category`, or `date` filters.
+Queries with those filters can choose different execution plans depending on selectivity.
 
 Dataset:
 

--- a/docs/backend-improvement/search-fulltext-analysis.md
+++ b/docs/backend-improvement/search-fulltext-analysis.md
@@ -1,0 +1,157 @@
+# Search API FULLTEXT analysis
+
+## Purpose
+
+This document records the current MySQL FULLTEXT behavior of `GET /api/search`.
+The goal is to explain how the search query behaves by keyword and to document a small optimization for cases where the original search text and translated text are the same.
+
+## Target flow
+
+```text
+SearchController
+-> TranslationService.translateToEnglish(text)
+-> SearchArticlesService.getSearchArticles(...)
+-> ArticleRepository.searchByDescriptionOrTitleWithExploreFilters(...)
+```
+
+The API searches both the original text and the English translation.
+
+## Previous query shape
+
+`searchByDescriptionOrTitleWithExploreFilters` used two FULLTEXT predicates joined by `OR`:
+
+```sql
+SELECT *
+FROM article
+WHERE (
+  MATCH(title, description) AGAINST(:text1 IN BOOLEAN MODE)
+  OR MATCH(title, description) AGAINST(:text2 IN BOOLEAN MODE)
+)
+AND (:country IS NULL OR country = :country)
+AND (:category IS NULL OR category = :category)
+AND (:dateFrom IS NULL OR published_at >= :dateFrom)
+AND (:dateTo IS NULL OR published_at <= :dateTo)
+ORDER BY published_at DESC
+LIMIT 100;
+```
+
+This is necessary when the original text and translated text differ.
+However, for English inputs such as `war`, translation can return the same text.
+In that case, the previous query effectively repeated the same FULLTEXT predicate:
+
+```sql
+MATCH(...) AGAINST('war' ...)
+OR MATCH(...) AGAINST('war' ...)
+```
+
+## Finding
+
+On the local development dataset, a single `MATCH` query used the FULLTEXT index.
+The duplicated `OR MATCH` query chose a reverse scan on `idx_article_published_at` and applied MATCH as a filter.
+
+Dataset:
+
+| Item | Value |
+| --- | --- |
+| Table | `article` |
+| Total rows | `9853` |
+| FULLTEXT index | `ft_article_title_description(title, description)` |
+
+Keyword match counts:
+
+| Keyword | Match count |
+| --- | --- |
+| `war` | 404 |
+| `technology` | 82 |
+| `economy` | 39 |
+| `대구` OR `daegu` | 0 |
+
+### Single MATCH
+
+```sql
+EXPLAIN ANALYZE
+SELECT *
+FROM article
+WHERE MATCH(title, description) AGAINST('war' IN BOOLEAN MODE)
+ORDER BY published_at DESC
+LIMIT 100;
+```
+
+Summary:
+
+```text
+Full-text index search on article using ft_article_title_description
+actual time=0.575..7.04 rows=404
+
+Sort row IDs: article.published_at DESC
+actual time=10.3..10.7 rows=100
+```
+
+### Duplicated OR MATCH
+
+```sql
+EXPLAIN ANALYZE
+SELECT *
+FROM article
+WHERE (
+  MATCH(title, description) AGAINST('war' IN BOOLEAN MODE)
+  OR MATCH(title, description) AGAINST('war' IN BOOLEAN MODE)
+)
+ORDER BY published_at DESC
+LIMIT 100;
+```
+
+Summary:
+
+```text
+Index scan on article using idx_article_published_at (reverse)
+actual time=0.233..25.2 rows=4186
+
+Filter
+actual time=2.75..27.1 rows=100
+```
+
+Interpretation:
+
+- Single MATCH uses the intended FULLTEXT index.
+- Duplicated OR MATCH can make MySQL prefer the `published_at` index and evaluate MATCH as a filter.
+- This is visible for English inputs where original and translated text are effectively the same.
+
+## Change
+
+`SearchArticlesService` now checks whether `text` and `translatedText` are the same after trimming and case-insensitive comparison.
+
+- If they are the same, it calls a single-MATCH repository query.
+- If they differ, it keeps the existing OR-MATCH query to preserve multilingual search behavior.
+
+No API response structure changed.
+
+## API check
+
+Representative API calls after the previous #123 fix:
+
+| Request | Status | Notes |
+| --- | --- | --- |
+| `/api/search?text=war` | 200 | English, many matches |
+| `/api/search?text=economy` | 200 | English, fewer matches |
+| `/api/search?text=technology` | 200 | English, medium matches |
+| `/api/search?text=대구` | 200 | Translates to `daegu`, zero current FULLTEXT matches |
+
+## Decision
+
+Keep the OR-MATCH query for different original/translated terms, but avoid duplicated OR-MATCH when both terms are the same.
+
+Reasons:
+
+- It is a small scoped change.
+- It preserves the response shape and existing multilingual search behavior.
+- It lets English same-term searches use the intended FULLTEXT index.
+- Broader search quality topics, such as Korean morphology, multilingual ranking, Elasticsearch, or vector search, remain separate follow-up work.
+
+## Follow-up candidates
+
+- Measure `/api/search` p95 before/after for same-term English searches with k6.
+- Analyze OR-MATCH cases where original and translated terms differ.
+- Compare current FULLTEXT results with expected results for representative Korean and multilingual queries.
+- Consider a query rewrite with `UNION` only if OR-MATCH remains a measurable bottleneck.
+- Define search quality samples before introducing Elasticsearch or semantic search.

--- a/src/main/java/com/example/globalTimes_be/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/com/example/globalTimes_be/domain/article/repository/ArticleRepository.java
@@ -66,6 +66,28 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
             @Param("dateTo") LocalDateTime dateTo
     );
 
+    /**
+     * FULLTEXT 검색 + 탐색 필터.
+     * 원문 검색어와 번역 검색어가 같을 때 OR MATCH를 피하기 위한 단일 MATCH 쿼리.
+     */
+    @Query(value =
+            "SELECT * FROM article " +
+            "WHERE MATCH(title, description) AGAINST(:text IN BOOLEAN MODE) " +
+            "AND (:country IS NULL OR country = :country) " +
+            "AND (:category IS NULL OR category = :category) " +
+            "AND (:dateFrom IS NULL OR published_at >= :dateFrom) " +
+            "AND (:dateTo IS NULL OR published_at <= :dateTo) " +
+            "ORDER BY published_at DESC " +
+            "LIMIT 100",
+            nativeQuery = true)
+    List<Article> searchByDescriptionOrTitleWithExploreFilters(
+            @Param("text") String text,
+            @Param("country") String country,
+            @Param("category") String category,
+            @Param("dateFrom") LocalDateTime dateFrom,
+            @Param("dateTo") LocalDateTime dateTo
+    );
+
     // 국가별 시각 비교: 특정 기사 제외 후 키워드 FULLTEXT 탐색, 최신순 최대 50개
     @Query(value =
             "SELECT * FROM article " +

--- a/src/main/java/com/example/globalTimes_be/domain/search/service/SearchArticlesService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/search/service/SearchArticlesService.java
@@ -49,14 +49,25 @@ public class SearchArticlesService {
         String categoryParam = (category != null && !category.isBlank()) ? category : null;
 
         long searchStartedAt = System.nanoTime();
-        List<Article> articles = articleRepository.searchByDescriptionOrTitleWithExploreFilters(
-                text,
-                translatedText,
-                countryParam,
-                categoryParam,
-                dateFrom,
-                dateTo
-        );
+        List<Article> articles;
+        if (isSameSearchText(text, translatedText)) {
+            articles = articleRepository.searchByDescriptionOrTitleWithExploreFilters(
+                    text,
+                    countryParam,
+                    categoryParam,
+                    dateFrom,
+                    dateTo
+            );
+        } else {
+            articles = articleRepository.searchByDescriptionOrTitleWithExploreFilters(
+                    text,
+                    translatedText,
+                    countryParam,
+                    categoryParam,
+                    dateFrom,
+                    dateTo
+            );
+        }
         long searchMs = elapsedMs(searchStartedAt);
         
         // 검색결과에 대한 기사 DTO 리스트 생성
@@ -102,5 +113,12 @@ public class SearchArticlesService {
 
     private long elapsedMs(long startedAt) {
         return (System.nanoTime() - startedAt) / 1_000_000;
+    }
+
+    private boolean isSameSearchText(String text, String translatedText) {
+        if (text == null || translatedText == null) {
+            return false;
+        }
+        return text.trim().equalsIgnoreCase(translatedText.trim());
     }
 }


### PR DESCRIPTION
## Summary
- /api/search FULLTEXT 쿼리의 검색어별 매칭 수와 실행 계획을 분석했습니다.
- 원문 검색어와 번역 검색어가 같은 경우에도 기존 쿼리가 중복 OR MATCH를 생성해 MySQL이 FULLTEXT 인덱스 대신 published_at 인덱스 역방향 스캔을 선택하는 케이스를 확인했습니다.
- text와 translatedText가 trim/case-insensitive 기준으로 같으면 단일 MATCH 쿼리를 사용하도록 최적화했습니다.
- 원문/번역어가 다른 다국어 검색 케이스는 기존 OR MATCH 쿼리를 유지합니다.
- 분석 결과와 한계를 docs/backend-improvement/search-fulltext-analysis.md에 기록하고 WORK_PROGRESS.md를 갱신했습니다.

## Issue
- Closes #133

## Findings
- API smoke: /api/search?text=war, economy, technology, 대구 모두 200
- local article rows: 9853
- FULLTEXT match counts: war=404, technology=82, economy=39, 대구 OR daegu=0
- single MATCH war: FULLTEXT index ft_article_title_description 사용, EXPLAIN ANALYZE 약 10.7ms
- duplicated OR MATCH war: idx_article_published_at reverse scan 선택, EXPLAIN ANALYZE 약 27.1ms
- 대구 -> daegu는 현재 로컬 데이터에서 FULLTEXT match 0건

## Change
- Added a single-MATCH repository query for same original/translated search text.
- SearchArticlesService now chooses:
  - single MATCH when text and translatedText are effectively same
  - existing OR MATCH when they differ

## Test
- ./gradlew.bat test
- git diff --check
- /api/search?text=war -> 200
- /api/search?text=대구 -> 200
- MySQL EXPLAIN / EXPLAIN ANALYZE

## Notes
- Current running local server was used for API smoke, but compile/test validates the branch code change.
- API response structure is unchanged.
- Korean morphology, multilingual ranking, Elasticsearch/vector search, and broader search quality improvements are follow-up topics.