### PR TITLE
[FIX] 기사 원문 크롤링 timeout 및 실패 처리 개선

### DIFF
--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -77,7 +77,7 @@ Blocking 예시:
 - #129/#130에서 Perspectives Redis cache key/TTL/fallback/stale 허용 기준을 문서화했다.
 - #131/#132에서 Perspectives FULLTEXT 쿼리의 `EXPLAIN`/`EXPLAIN ANALYZE`를 기록했고, 현재 데이터 규모에서는 FULLTEXT 인덱스 사용을 확인했다.
 - #133/#134에서 검색 API FULLTEXT 실행 계획을 분석하고, 원문/번역 검색어가 같은 경우 중복 `OR MATCH`를 제거해 FULLTEXT 인덱스를 사용하도록 개선했다.
-- 다음 우선 후보는 외부 I/O 기본기와 연결되는 `[FIX] 기사 원문 크롤링 timeout 및 실패 처리 개선`이다. Jsoup timeout, 본문 없음 fallback, 차단 응답 처리, 트랜잭션 내 외부 I/O 여부를 조사하는 흐름이 자연스럽다.
+- 현재 #137에서 외부 I/O 기본기와 연결되는 `[FIX] 기사 원문 크롤링 timeout 및 실패 처리 개선`을 진행 중이다. Jsoup timeout, 본문 없음 fallback, 차단 응답 처리, 트랜잭션 내 외부 I/O 여부를 중심으로 개선한다.
 
 ### #113 / PR #114 - 백엔드 개선 Backlog 및 AI 작업 운영 규칙 수립
 
@@ -513,6 +513,39 @@ Reviewer 결과:
 - Blocking 없음.
 - Non-blocking으로 지적된 `EXPLAIN` 예시의 필터 조건 범위 설명은 같은 PR에서 보강했다.
 - 2026-07-03 기준 PR #134는 merge 완료되었다.
+
+---
+
+### #137 - 기사 원문 크롤링 timeout 및 실패 처리 개선
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/137
+- 상태: In Progress
+- 작업 브랜치: `fix/#137-crawling-timeout-fallback`
+- 주요 파일:
+  - `src/main/java/com/example/globalTimes_be/global/crawler/ArticleCrawler.java`
+  - `src/main/java/com/example/globalTimes_be/domain/detail/service/DetailService.java`
+  - `src/main/java/com/example/globalTimes_be/domain/detail/service/ArticleCrawlContentService.java`
+  - `src/main/java/com/example/globalTimes_be/domain/trend/service/TrendCrawledService.java`
+
+목표:
+
+- AI 요약/질의응답 경로에서 외부 언론사 페이지 크롤링이 사용자 요청을 오래 붙잡지 않도록 timeout을 명시한다.
+- 크롤링 실패 또는 본문 추출 실패 시 API별 기존 fallback/에러 정책이 예측 가능하게 동작하도록 한다.
+- DB 조회/저장 트랜잭션과 외부 네트워크 I/O를 분리한다.
+
+조사 결과:
+
+- `DetailService#getArticleCrawledContent()`는 `@Transactional(readOnly = true)` 안에서 외부 크롤링과 `articleRepository.save()`를 함께 수행하고 있었다.
+- `DetailService`와 `TrendCrawledService` 모두 `Jsoup.connect(...).get()`에 timeout/user-agent 설정이 없었다.
+- `AiController#summarizeArticle()`에는 크롤링 실패 시 기사 서두를 제공하는 fallback 분기가 있었지만, 기존 서비스가 예외를 던져 해당 분기가 사실상 도달하기 어려웠다.
+
+수정 방향:
+
+- `ArticleCrawler` 공통 컴포넌트로 Jsoup timeout/user-agent/본문 추출을 모은다.
+- `DetailService`는 크롤링 실패 시 `null`을 반환해 일반 summary API의 기존 fallback 분기를 살린다.
+- SSE summary와 ask API는 기존처럼 `DetailErrorStatus._CRAWLER_ERROR`를 유지한다.
+- `ArticleCrawlContentService`를 별도 서비스로 분리해 DB 조회/저장 트랜잭션이 Spring 프록시를 타도록 한다.
+- 비동기/Kafka는 이번 PR 범위에서 제외하고, 동기 요청 경로의 timeout/fallback을 먼저 안정화한다.
 
 ## 4. 이후 개선 로드맵
 

--- a/src/main/java/com/example/globalTimes_be/domain/detail/service/ArticleCrawlContentService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/detail/service/ArticleCrawlContentService.java
@@ -1,0 +1,36 @@
+package com.example.globalTimes_be.domain.detail.service;
+
+import com.example.globalTimes_be.domain.article.entity.Article;
+import com.example.globalTimes_be.domain.article.repository.ArticleRepository;
+import com.example.globalTimes_be.domain.detail.exception.DetailErrorStatus;
+import com.example.globalTimes_be.global.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class ArticleCrawlContentService {
+
+    private final ArticleRepository articleRepository;
+
+    @Transactional(readOnly = true)
+    public ArticleCrawlTarget getCrawlTarget(Long id) {
+        Article article = articleRepository.findById(id)
+                .orElseThrow(() -> new BaseException(DetailErrorStatus._EMPTY_NEWS_DATA.getResponse()));
+
+        return new ArticleCrawlTarget(article.getUrl(), article.getCrawledContent());
+    }
+
+    @Transactional
+    public void saveCrawledContent(Long id, String crawledContent) {
+        Article article = articleRepository.findById(id)
+                .orElseThrow(() -> new BaseException(DetailErrorStatus._EMPTY_NEWS_DATA.getResponse()));
+
+        article.updateCrawledContent(crawledContent);
+        articleRepository.save(article);
+    }
+
+    public record ArticleCrawlTarget(String url, String crawledContent) {
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/domain/detail/service/DetailService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/detail/service/DetailService.java
@@ -6,24 +6,20 @@ import com.example.globalTimes_be.domain.detail.dto.response.DetailResDTO;
 import com.example.globalTimes_be.domain.detail.dto.response.DetailResponseDTO;
 import com.example.globalTimes_be.domain.detail.dto.response.RecentArticleDTO;
 import com.example.globalTimes_be.domain.detail.exception.DetailErrorStatus;
+import com.example.globalTimes_be.global.crawler.ArticleCrawler;
 import com.example.globalTimes_be.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.IOException;
 import java.util.List;
 
-@Slf4j
 @RequiredArgsConstructor
 @Service
 public class DetailService {
     private final ArticleRepository articleRepository;
+    private final ArticleCrawler articleCrawler;
+    private final ArticleCrawlContentService articleCrawlContentService;
 
     @Transactional
     public DetailResDTO getNewsDetail(Long id) {
@@ -79,7 +75,7 @@ public class DetailService {
     }
 
     // GPT 요약 결과를 DB에 저장
-    @org.springframework.transaction.annotation.Transactional
+    @Transactional
     public void saveArticleSummary(Long id, String summary) {
         Article article = articleRepository.findById(id)
                 .orElseThrow(() -> new BaseException(DetailErrorStatus._EMPTY_NEWS_DATA.getResponse()));
@@ -88,43 +84,20 @@ public class DetailService {
         articleRepository.save(article);
     }
 
-    // 크롤링(네트워크 I/O)은 트랜잭션 밖에서 실행하되, DB 조회 부분만 readOnly 트랜잭션으로 처리
-    @Transactional(readOnly = true)
+    // 크롤링(네트워크 I/O)은 트랜잭션 밖에서 실행하고, DB 조회/저장은 별도 트랜잭션에서 처리한다.
     public String getArticleCrawledContent(Long id) {
-        Article article = articleRepository.findById(id)
-                .orElseThrow(() -> new BaseException(DetailErrorStatus._EMPTY_NEWS_DATA.getResponse()));
-
-        String crawledContent = article.getCrawledContent();
-
-        if (crawledContent != null) {
-            return crawledContent;
+        ArticleCrawlContentService.ArticleCrawlTarget target = articleCrawlContentService.getCrawlTarget(id);
+        if (target.crawledContent() != null && !target.crawledContent().isBlank()) {
+            return target.crawledContent();
         }
 
-        crawledContent = getCrawlerUrl(article.getUrl());
-
+        String crawledContent = articleCrawler.crawlParagraphs(target.url())
+                .orElse(null);
         if (crawledContent == null) {
-            throw new BaseException(DetailErrorStatus._CRAWLER_ERROR.getResponse());
-        }
-
-        article.updateCrawledContent(crawledContent);
-        articleRepository.save(article);
-
-        return crawledContent;
-    }
-
-    private String getCrawlerUrl(String crawlerUrl) {
-        try {
-            Document doc = Jsoup.connect(crawlerUrl).get();
-            Elements paragraphs = doc.select("p");
-
-            return paragraphs.stream()
-                    .map(Element::text)
-                    .reduce((p1, p2) -> p1 + "\n" + p2)
-                    .orElse(null);
-
-        } catch (IOException e) {
-            log.error("크롤링에 실패했습니다. \n{}", e.getMessage());
             return null;
         }
+
+        articleCrawlContentService.saveCrawledContent(id, crawledContent);
+        return crawledContent;
     }
 }

--- a/src/main/java/com/example/globalTimes_be/domain/trend/service/TrendCrawledService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/trend/service/TrendCrawledService.java
@@ -1,40 +1,20 @@
 package com.example.globalTimes_be.domain.trend.service;
 
 import com.example.globalTimes_be.domain.trend.exception.TrendErrorStatus;
+import com.example.globalTimes_be.global.crawler.ArticleCrawler;
 import com.example.globalTimes_be.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
-
-@Slf4j
 @RequiredArgsConstructor
 @Service
 public class TrendCrawledService {
 
+    private final ArticleCrawler articleCrawler;
+
     //url 본문 기사 크롤링
     public String getArticleCrawledContent(String url){
-        try {
-            // URL에서 HTML 문서 가져오기
-            Document doc = Jsoup.connect(url).get();
-
-            // 모든 <p> 태그 가져오기
-            Elements paragraphs = doc.select("p");
-
-            // 텍스트만 추출해서 하나의 문자열로 반환 (줄바꿈 포함)
-            return paragraphs.stream()
-                    .map(Element::text)
-                    .reduce((p1, p2) -> p1 + "\n" + p2) // 문장마다 줄바꿈 추가
-                    .orElse(null);
-
-        } catch (IOException e) {
-            log.error("크롤링에 실패했습니다. \n{}", e.getMessage());
-            throw new BaseException(TrendErrorStatus._CRAWLER_ERROR.getResponse());
-        }
+        return articleCrawler.crawlParagraphs(url)
+                .orElseThrow(() -> new BaseException(TrendErrorStatus._CRAWLER_ERROR.getResponse()));
     }
 }

--- a/src/main/java/com/example/globalTimes_be/global/crawler/ArticleCrawler.java
+++ b/src/main/java/com/example/globalTimes_be/global/crawler/ArticleCrawler.java
@@ -1,0 +1,61 @@
+package com.example.globalTimes_be.global.crawler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@Slf4j
+@Component
+public class ArticleCrawler {
+
+    private final int timeoutMs;
+    private final String userAgent;
+
+    public ArticleCrawler(
+            @Value("${crawler.timeout-ms:5000}") int timeoutMs,
+            @Value("${crawler.user-agent:Mozilla/5.0 (compatible; GlobalTimesBot/1.0)}") String userAgent
+    ) {
+        this.timeoutMs = timeoutMs;
+        this.userAgent = userAgent;
+    }
+
+    public Optional<String> crawlParagraphs(String url) {
+        if (url == null || url.isBlank()) {
+            return Optional.empty();
+        }
+
+        try {
+            Document doc = Jsoup.connect(url)
+                    .userAgent(userAgent)
+                    .timeout(timeoutMs)
+                    .get();
+
+            String content = extractParagraphs(doc);
+            if (content == null || content.isBlank()) {
+                log.warn("[Crawler] 본문 추출 실패: paragraphs empty url={}", url);
+                return Optional.empty();
+            }
+
+            return Optional.of(content);
+        } catch (IOException | IllegalArgumentException e) {
+            log.warn("[Crawler] 크롤링 실패: url={}, message={}", url, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    String extractParagraphs(Document doc) {
+        Elements paragraphs = doc.select("p");
+        return paragraphs.stream()
+                .map(Element::text)
+                .filter(text -> !text.isBlank())
+                .reduce((p1, p2) -> p1 + "\n" + p2)
+                .orElse(null);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,8 @@
 spring.application.name=globalTimes_be
 
+# 기사 원문 크롤링 timeout. 외부 언론사 응답 지연이 사용자 요청을 오래 붙잡지 않도록 제한한다.
+crawler.timeout-ms=5000
+crawler.user-agent=Mozilla/5.0 (compatible; GlobalTimesBot/1.0)
+
 # 비로그인 기사 채팅 Redis TTL (초). 기본 7일.
 ai.anonymous-chat.ttl-seconds=604800

--- a/src/test/java/com/example/globalTimes_be/domain/detail/service/DetailServiceTest.java
+++ b/src/test/java/com/example/globalTimes_be/domain/detail/service/DetailServiceTest.java
@@ -1,0 +1,63 @@
+package com.example.globalTimes_be.domain.detail.service;
+
+import com.example.globalTimes_be.domain.article.repository.ArticleRepository;
+import com.example.globalTimes_be.global.crawler.ArticleCrawler;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DetailServiceTest {
+
+    private final ArticleRepository articleRepository = mock(ArticleRepository.class);
+    private final ArticleCrawler articleCrawler = mock(ArticleCrawler.class);
+    private final ArticleCrawlContentService articleCrawlContentService = mock(ArticleCrawlContentService.class);
+    private final DetailService detailService = new DetailService(
+            articleRepository,
+            articleCrawler,
+            articleCrawlContentService
+    );
+
+    @Test
+    void getArticleCrawledContent_returnsCachedContentWithoutCrawling() {
+        when(articleCrawlContentService.getCrawlTarget(1L))
+                .thenReturn(new ArticleCrawlContentService.ArticleCrawlTarget("https://news.example/1", "cached"));
+
+        String result = detailService.getArticleCrawledContent(1L);
+
+        assertThat(result).isEqualTo("cached");
+        verify(articleCrawler, never()).crawlParagraphs("https://news.example/1");
+        verify(articleCrawlContentService, never()).saveCrawledContent(1L, "cached");
+    }
+
+    @Test
+    void getArticleCrawledContent_returnsNullAndDoesNotSaveWhenCrawlingFails() {
+        when(articleCrawlContentService.getCrawlTarget(1L))
+                .thenReturn(new ArticleCrawlContentService.ArticleCrawlTarget("https://news.example/1", null));
+        when(articleCrawler.crawlParagraphs("https://news.example/1"))
+                .thenReturn(Optional.empty());
+
+        String result = detailService.getArticleCrawledContent(1L);
+
+        assertThat(result).isNull();
+        verify(articleCrawlContentService, never()).saveCrawledContent(1L, "crawled");
+    }
+
+    @Test
+    void getArticleCrawledContent_savesAndReturnsCrawledContent() {
+        when(articleCrawlContentService.getCrawlTarget(1L))
+                .thenReturn(new ArticleCrawlContentService.ArticleCrawlTarget("https://news.example/1", null));
+        when(articleCrawler.crawlParagraphs("https://news.example/1"))
+                .thenReturn(Optional.of("crawled"));
+
+        String result = detailService.getArticleCrawledContent(1L);
+
+        assertThat(result).isEqualTo("crawled");
+        verify(articleCrawlContentService).saveCrawledContent(1L, "crawled");
+    }
+}

--- a/src/test/java/com/example/globalTimes_be/global/crawler/ArticleCrawlerTest.java
+++ b/src/test/java/com/example/globalTimes_be/global/crawler/ArticleCrawlerTest.java
@@ -1,0 +1,38 @@
+package com.example.globalTimes_be.global.crawler;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ArticleCrawlerTest {
+
+    private final ArticleCrawler articleCrawler = new ArticleCrawler(5000, "test-agent");
+
+    @Test
+    void extractParagraphs_joinsNonBlankParagraphs() {
+        Document doc = Jsoup.parse("""
+                <html>
+                    <body>
+                        <p>first paragraph</p>
+                        <p>   </p>
+                        <p>second paragraph</p>
+                    </body>
+                </html>
+                """);
+
+        String result = articleCrawler.extractParagraphs(doc);
+
+        assertThat(result).isEqualTo("first paragraph\nsecond paragraph");
+    }
+
+    @Test
+    void extractParagraphs_returnsNullWhenParagraphsAreMissing() {
+        Document doc = Jsoup.parse("<html><body><div>no article body</div></body></html>");
+
+        String result = articleCrawler.extractParagraphs(doc);
+
+        assertThat(result).isNull();
+    }
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #137

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [x] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- 기사 원문 크롤링을 `ArticleCrawler` 공통 컴포넌트로 분리했습니다.
- Jsoup 크롤링에 `crawler.timeout-ms=5000`과 user-agent 설정을 명시했습니다.
- `DetailService`의 외부 크롤링 I/O를 DB 조회/저장 트랜잭션과 분리했습니다.
- 일반 AI summary API는 크롤링 실패 시 기사 서두 fallback을 사용하도록 하고, SSE/ask/trend summary의 기존 크롤링 불가 에러 정책은 유지했습니다.
- `ArticleCrawler`와 `DetailService` 핵심 분기 단위 테스트를 추가했습니다.
- `WORK_PROGRESS.md`에 #137 진행 상황을 기록했습니다.

## 🧪 테스트/검증 (필수)
- [x] `./gradlew.bat test`로 컴파일 및 단위 테스트 통과 확인
- [x] `git diff --check`로 공백/patch 오류 없음 확인

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop` branch 대상)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 외부 동작/응답 정책이 의도대로 유지되는가? 일반 summary fallback은 복구하고, SSE/ask/trend summary 에러 정책은 유지

## 📸 스크린샷 (선택)
- 해당 없음

## 💬 리뷰 요구사항(선택)
- `ArticleCrawler` timeout/user-agent 설정이 외부 언론사 응답 지연 제한에 충분한지 확인해주세요.
- `DetailService`에서 외부 I/O와 DB 트랜잭션 분리가 실제로 의도대로 되었는지 확인해주세요.
- summary fallback과 SSE/ask/trend summary 에러 정책이 기존 API 의도와 충돌하지 않는지 확인해주세요.

## ➕ 추후 계획(선택)
- 실제 서버 smoke test가 필요하면 `/api/ai/{id}/summary`, `/api/ai/{id}/summary/sse`, `/api/ai/{id}/ask`, `/api/trend/summary` 경로에서 추가 확인합니다.
