### PR TITLE
[TEST/#140] Perspectives API 캐시/실패 회귀 테스트 기반 마련

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -60,7 +60,7 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## P4. 핵심 API 회귀 테스트 기반 마련
 
-- 상태: `Backlog`
+- 상태: `In Progress` ([#140](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/140))
 - AS-IS: 핵심 수집, 검색, Perspectives 경로의 정상·실패 동작을 자동 검증하는 테스트 기반이 부족하다.
 - TO-BE: 외부 API를 격리한 서비스 단위 테스트와 핵심 API 통합 테스트를 단계적으로 도입한다.
 - 성공 기준:

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -563,6 +563,51 @@ Reviewer 결과:
 - Non-blocking: PR #136 merge 후 Issue #135가 open으로 남은 housekeeping 항목 확인.
 - 2026-07-03 기준 PR #138은 merge 완료되었고, Issue #137은 closed 상태다.
 
+---
+
+### #140 - Perspectives API 캐시/실패 회귀 테스트 기반 마련
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/140
+- 상태: In Progress
+- 작업 브랜치: `test/#140-perspectives-regression-tests`
+- 주요 파일:
+  - `src/main/java/com/example/globalTimes_be/domain/detail/service/PerspectivesService.java`
+  - `src/test/java/com/example/globalTimes_be/domain/detail/service/PerspectivesServiceTest.java`
+  - `docs/backend-improvement/BACKLOG.md`
+  - `docs/backend-improvement/WORK_PROGRESS.md`
+
+목표:
+
+- #127/#129/#131에서 측정/문서화한 Perspectives cache hit/miss, Redis 실패, 번역 fallback 흐름을 테스트로 고정한다.
+- 이후 Redis, 검색, 번역, 유사도 개선을 이어갈 때 기존 동작이 깨졌는지 자동으로 확인할 안전망을 만든다.
+
+조사 결과:
+
+- `PerspectivesService`는 cache hit 시 Redis JSON을 `PerspectivesResDTO`로 역직렬화해 즉시 반환한다.
+- Redis read 실패 또는 캐시 역직렬화 실패는 warn 로그 후 재계산한다.
+- cache miss 시 기준 기사 조회, 키워드 추출, 비영어 기사 번역, FULLTEXT 검색, 국가별 grouping, Redis 저장 순서로 동작한다.
+- 번역 실패는 원문 키워드 fallback으로 처리한다.
+- Redis write 실패는 warn 로그 후 API 응답을 정상 반환한다.
+
+수정 방향:
+
+- Spring context를 띄우지 않는 mock 기반 `PerspectivesServiceTest`를 추가한다.
+- cache hit, cache miss, Redis read 실패, 캐시 역직렬화 실패, Redis write 실패, 번역 실패 fallback 분기를 테스트로 고정한다.
+- API 응답 구조와 운영 코드는 변경하지 않고 회귀 테스트 안전망을 우선 확보한다.
+
+검증:
+
+```text
+./gradlew.bat test
+git diff --check
+```
+
+초기 테스트 실패와 조정:
+
+- 캐시 JSON 테스트에서 `LocalDateTime` 직렬화를 위해 테스트 `ObjectMapper`에 JavaTime module 등록이 필요했다.
+- 비영어 번역 실패 테스트는 `KeywordExtractor`의 실제 plain/boolean keyword 추출 결과를 기준으로 기대값을 맞췄다.
+- 서비스 코드는 변경하지 않고 테스트 코드의 fixture/기대값만 실제 동작에 맞게 조정했다.
+
 ## 4. 이후 개선 로드맵
 
 ### A. #123 이후 바로 할 수 있는 성능 개선

--- a/src/test/java/com/example/globalTimes_be/domain/detail/service/PerspectivesServiceTest.java
+++ b/src/test/java/com/example/globalTimes_be/domain/detail/service/PerspectivesServiceTest.java
@@ -1,0 +1,189 @@
+package com.example.globalTimes_be.domain.detail.service;
+
+import com.example.globalTimes_be.domain.article.entity.Article;
+import com.example.globalTimes_be.domain.article.repository.ArticleRepository;
+import com.example.globalTimes_be.domain.detail.dto.response.PerspectiveArticleDTO;
+import com.example.globalTimes_be.domain.detail.dto.response.PerspectivesResDTO;
+import com.example.globalTimes_be.domain.detail.util.KeywordExtractor;
+import com.example.globalTimes_be.domain.search.service.TranslationService;
+import com.example.globalTimes_be.domain.source.entity.Source;
+import com.example.globalTimes_be.global.redis.RedisUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PerspectivesServiceTest {
+
+    private static final long CACHE_TTL_SECONDS = 3600L;
+
+    private final ArticleRepository articleRepository = mock(ArticleRepository.class);
+    private final TranslationService translationService = mock(TranslationService.class);
+    private final RedisUtil redisUtil = mock(RedisUtil.class);
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+    private final PerspectivesService perspectivesService = new PerspectivesService(
+            articleRepository,
+            translationService,
+            redisUtil,
+            objectMapper
+    );
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(perspectivesService, "cacheTtlSeconds", CACHE_TTL_SECONDS);
+    }
+
+    @Test
+    void getPerspectives_returnsCachedResponseWithoutRepositoryLookup() throws Exception {
+        PerspectivesResDTO cachedResponse = PerspectivesResDTO.builder()
+                .keyword("cached keyword")
+                .perspectives(Map.of("us", List.of(cachedArticleDto())))
+                .countriesFound(1)
+                .totalArticles(1)
+                .build();
+        when(redisUtil.getData("perspectives:article:1"))
+                .thenReturn(objectMapper.writeValueAsString(cachedResponse));
+
+        PerspectivesResDTO result = perspectivesService.getPerspectives(1L);
+
+        assertThat(result.getKeyword()).isEqualTo("cached keyword");
+        assertThat(result.getCountriesFound()).isEqualTo(1);
+        assertThat(result.getTotalArticles()).isEqualTo(1);
+        verify(articleRepository, never()).findById(1L);
+        verify(articleRepository, never()).findPerspectives(eq(1L), anyString());
+        verify(translationService, never()).translateToEnglish(anyString());
+        verify(redisUtil, never()).setData(eq("perspectives:article:1"), anyString(), eq(CACHE_TTL_SECONDS));
+    }
+
+    @Test
+    void getPerspectives_recalculatesAndStoresCacheWhenCacheMisses() {
+        Article base = article(1L, "Global market shock hits banks", "us", "en");
+        Article koreanPerspective = article(2L, "Global market shock in Seoul", "kr", "en");
+        Article japanesePerspective = article(3L, "Global market shock in Tokyo", "jp", "en");
+        when(redisUtil.getData("perspectives:article:1")).thenReturn(null);
+        when(articleRepository.findById(1L)).thenReturn(Optional.of(base));
+        when(articleRepository.findPerspectives(eq(1L), anyString()))
+                .thenReturn(new java.util.ArrayList<>(List.of(koreanPerspective, japanesePerspective)));
+
+        PerspectivesResDTO result = perspectivesService.getPerspectives(1L);
+
+        assertThat(result.getKeyword()).isEqualTo("Global market shock hits");
+        assertThat(result.getCountriesFound()).isEqualTo(2);
+        assertThat(result.getTotalArticles()).isEqualTo(2);
+        assertThat(result.getPerspectives()).containsKeys("kr", "jp");
+        verify(translationService, never()).translateToEnglish(anyString());
+        verify(redisUtil).setData(eq("perspectives:article:1"), anyString(), eq(CACHE_TTL_SECONDS));
+    }
+
+    @Test
+    void getPerspectives_recalculatesWhenCacheReadFails() {
+        Article base = article(1L, "Global market shock hits banks", "us", "en");
+        when(redisUtil.getData("perspectives:article:1"))
+                .thenThrow(new RuntimeException("redis down"));
+        when(articleRepository.findById(1L)).thenReturn(Optional.of(base));
+        when(articleRepository.findPerspectives(eq(1L), anyString()))
+                .thenReturn(new java.util.ArrayList<>());
+
+        PerspectivesResDTO result = perspectivesService.getPerspectives(1L);
+
+        assertThat(result.getCountriesFound()).isZero();
+        assertThat(result.getTotalArticles()).isZero();
+        verify(articleRepository).findById(1L);
+    }
+
+    @Test
+    void getPerspectives_recalculatesWhenCachedJsonCannotBeDeserialized() {
+        Article base = article(1L, "Global market shock hits banks", "us", "en");
+        when(redisUtil.getData("perspectives:article:1")).thenReturn("{broken-json");
+        when(articleRepository.findById(1L)).thenReturn(Optional.of(base));
+        when(articleRepository.findPerspectives(eq(1L), anyString()))
+                .thenReturn(new java.util.ArrayList<>());
+
+        PerspectivesResDTO result = perspectivesService.getPerspectives(1L);
+
+        assertThat(result.getKeyword()).isEqualTo("Global market shock hits");
+        verify(articleRepository).findById(1L);
+    }
+
+    @Test
+    void getPerspectives_returnsResponseEvenWhenCacheWriteFails() {
+        Article base = article(1L, "Global market shock hits banks", "us", "en");
+        when(redisUtil.getData("perspectives:article:1")).thenReturn(null);
+        when(articleRepository.findById(1L)).thenReturn(Optional.of(base));
+        when(articleRepository.findPerspectives(eq(1L), anyString()))
+                .thenReturn(new java.util.ArrayList<>());
+        doThrow(new RuntimeException("redis write failed"))
+                .when(redisUtil).setData(eq("perspectives:article:1"), anyString(), eq(CACHE_TTL_SECONDS));
+
+        PerspectivesResDTO result = perspectivesService.getPerspectives(1L);
+
+        assertThat(result.getCountriesFound()).isZero();
+        assertThat(result.getTotalArticles()).isZero();
+    }
+
+    @Test
+    void getPerspectives_usesOriginalKeywordWhenTranslationFails() {
+        String title = "Korea economy crisis response";
+        Article base = article(1L, title, "kr", "ko");
+        String plainKeyword = KeywordExtractor.extractPlain(title);
+        String booleanKeyword = KeywordExtractor.extract(title);
+        when(redisUtil.getData("perspectives:article:1")).thenReturn(null);
+        when(articleRepository.findById(1L)).thenReturn(Optional.of(base));
+        when(translationService.translateToEnglish(plainKeyword))
+                .thenThrow(new RuntimeException("translation failed"));
+        when(articleRepository.findPerspectives(eq(1L), anyString()))
+                .thenReturn(new java.util.ArrayList<>());
+
+        PerspectivesResDTO result = perspectivesService.getPerspectives(1L);
+
+        assertThat(result.getKeyword()).isEqualTo(plainKeyword);
+        verify(translationService).translateToEnglish(plainKeyword);
+        verify(articleRepository).findPerspectives(1L, booleanKeyword);
+    }
+
+    private PerspectiveArticleDTO cachedArticleDto() {
+        return PerspectiveArticleDTO.builder()
+                .id(10L)
+                .country("us")
+                .language("en")
+                .source("Cached Source")
+                .title("Cached title")
+                .description("Cached description")
+                .urlToImage("https://image.example/cached.jpg")
+                .publishedAt(LocalDateTime.of(2026, 1, 1, 0, 0))
+                .build();
+    }
+
+    private Article article(Long id, String title, String country, String language) {
+        Source source = Source.createSource("Source " + country, null);
+        Article article = Article.createRssArticle(
+                source,
+                "Reporter",
+                title,
+                "Description " + title,
+                "Content " + title,
+                "https://news.example/" + id,
+                "https://image.example/" + id + ".jpg",
+                LocalDateTime.of(2026, 1, 1, 0, 0),
+                country,
+                "general",
+                language
+        );
+        ReflectionTestUtils.setField(article, "id", id);
+        return article;
+    }
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #140

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- `PerspectivesServiceTest`를 추가해 Perspectives API의 핵심 cache/fallback 분기를 단위 테스트로 고정했습니다.
- Redis cache hit 시 repository/translation/search를 호출하지 않는 동작을 검증했습니다.
- cache miss, Redis read 실패, 캐시 역직렬화 실패, Redis write 실패 시 재계산/응답 유지 동작을 검증했습니다.
- 비영어 기사 번역 실패 시 원문 키워드로 FULLTEXT 검색하는 fallback을 검증했습니다.
- `BACKLOG.md`와 `WORK_PROGRESS.md`에 #140 진행 상태와 검증 결과를 기록했습니다.

## 🔍 기술적 배경
- #127/#129/#131에서 Perspectives API의 Redis cache 효과와 FULLTEXT 실행 계획을 측정/문서화했지만, cache hit/miss와 외부 의존성 실패 분기는 자동 테스트로 고정되어 있지 않았습니다.
- 이번 PR은 기능을 추가하기보다, 이후 Redis/검색/번역/유사도 개선을 안전하게 이어가기 위한 회귀 테스트 기반을 마련합니다.
- Spring context를 띄우지 않는 mock 기반 서비스 단위 테스트로 Redis, TranslationService, Repository 의존성을 격리했습니다.

## 🧪 테스트/검증 (필수)
- [x] `./gradlew.bat test`로 컴파일 및 전체 테스트 통과 확인
- [x] `git diff --check`로 공백/patch 오류 없음 확인

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop` branch 대상)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 테스트/품질 PR이며 기존 API 응답 구조를 변경하지 않았는가?

## 📸 스크린샷 (선택)
- 해당 없음

## 💬 리뷰 요구사항(선택)
- `PerspectivesServiceTest`가 cache hit/miss, Redis 실패, 번역 실패 fallback의 핵심 회귀 지점을 충분히 고정하는지 확인해주세요.
- 테스트 fixture가 실제 `KeywordExtractor`, `Article`, `Source`, DTO 구조를 과하게 우회하지 않는지 확인해주세요.
- `WORK_PROGRESS.md`와 `BACKLOG.md`가 #140의 성격을 과장 없이 설명하는지 확인해주세요.

## ➕ 추후 계획(선택)
- 이후 필요하면 Controller 통합 테스트 또는 k6 smoke와 연결해 API 레벨 회귀 검증을 확장합니다.
