### PR TITLE
[TEST/#142] Perspectives 다국어 이슈 매칭 품질 기준선 정의

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -50,7 +50,7 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## P3. 다국어 이슈 매칭 품질 개선
 
-- 상태: `Backlog`
+- 상태: `In Progress` ([#142](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/142))
 - AS-IS: 기사 제목의 키워드와 영어 번역 키워드를 MySQL FULLTEXT 검색에 사용하므로, 표현이 다른 동일 이슈 또는 비영어권 기사 간 매칭이 누락될 수 있다.
 - TO-BE: 기존 후보 검색을 유지하면서 이슈 유사도와 국가 다양성 기준으로 결과를 재정렬하는 정책을 검증한다.
 - 성공 기준:
@@ -60,7 +60,7 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## P4. 핵심 API 회귀 테스트 기반 마련
 
-- 상태: `In Progress` ([#140](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/140))
+- 상태: `Done` ([#140](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/140), [PR #141](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/141))
 - AS-IS: 핵심 수집, 검색, Perspectives 경로의 정상·실패 동작을 자동 검증하는 테스트 기반이 부족하다.
 - TO-BE: 외부 API를 격리한 서비스 단위 테스트와 핵심 API 통합 테스트를 단계적으로 도입한다.
 - 성공 기준:

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -78,7 +78,9 @@ Blocking 예시:
 - #131/#132에서 Perspectives FULLTEXT 쿼리의 `EXPLAIN`/`EXPLAIN ANALYZE`를 기록했고, 현재 데이터 규모에서는 FULLTEXT 인덱스 사용을 확인했다.
 - #133/#134에서 검색 API FULLTEXT 실행 계획을 분석하고, 원문/번역 검색어가 같은 경우 중복 `OR MATCH`를 제거해 FULLTEXT 인덱스를 사용하도록 개선했다.
 - #137/#138에서 기사 원문 크롤링 timeout/fallback과 외부 I/O 트랜잭션 분리를 개선했다.
-- 현재 반복 성능/안정성 기본기 흐름의 주요 후보(#123, #127, #129, #131, #133, #137)는 merge 완료 상태다.
+- #140/#141에서 Perspectives API 캐시 hit/miss, Redis 실패, 번역 fallback 흐름을 회귀 테스트로 고정했다.
+- 현재 반복 성능/안정성 기본기 흐름의 주요 후보(#123, #127, #129, #131, #133, #137, #140)는 merge 완료 상태다.
+- #142에서는 Perspectives 다국어 이슈 매칭 품질 기준선을 정의해, Elasticsearch/Vector DB/RAG 같은 기술 도입 전에 현재 FULLTEXT 기반 매칭의 한계를 측정 가능하게 만든다.
 
 ### #113 / PR #114 - 백엔드 개선 Backlog 및 AI 작업 운영 규칙 수립
 
@@ -568,7 +570,8 @@ Reviewer 결과:
 ### #140 - Perspectives API 캐시/실패 회귀 테스트 기반 마련
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/140
-- 상태: In Progress
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/141
+- 상태: merged
 - 작업 브랜치: `test/#140-perspectives-regression-tests`
 - 주요 파일:
   - `src/main/java/com/example/globalTimes_be/domain/detail/service/PerspectivesService.java`
@@ -607,6 +610,45 @@ git diff --check
 - 캐시 JSON 테스트에서 `LocalDateTime` 직렬화를 위해 테스트 `ObjectMapper`에 JavaTime module 등록이 필요했다.
 - 비영어 번역 실패 테스트는 `KeywordExtractor`의 실제 plain/boolean keyword 추출 결과를 기준으로 기대값을 맞췄다.
 - 서비스 코드는 변경하지 않고 테스트 코드의 fixture/기대값만 실제 동작에 맞게 조정했다.
+- 2026-07-03 기준 PR #141은 merge 완료되었고, Issue #140은 closed 상태다.
+
+---
+
+### #142 - Perspectives 다국어 이슈 매칭 품질 기준선 정의
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/142
+- 상태: In Progress
+- 작업 브랜치: `perf/#142-perspectives-matching-baseline`
+- 주요 파일:
+  - `docs/backend-improvement/perspectives-matching-quality-baseline.md`
+  - `docs/backend-improvement/BACKLOG.md`
+  - `docs/backend-improvement/WORK_PROGRESS.md`
+
+목표:
+
+- Perspectives API가 현재 제목 키워드, 영어 번역, MySQL FULLTEXT 검색으로 다국어 이슈를 어떻게 매칭하는지 기준선을 정의한다.
+- Elasticsearch, Vector DB, RAG, issue clustering 같은 기술 도입 전에 대표 샘플 기준으로 현재 매칭 품질과 한계를 측정할 수 있게 만든다.
+- #110의 장기 troubleshooting 내용은 직접 구현하지 않고, 그중 P3 다국어 이슈 매칭 품질 개선의 첫 측정 단계만 분리해 진행한다.
+
+조사 결과:
+
+- `PerspectivesService`는 기준 기사 제목에서 `KeywordExtractor.extractPlain()`과 `KeywordExtractor.extract()`로 평문/BOOLEAN MODE 키워드를 만든다.
+- 기준 기사 언어가 영어가 아니면 평문 키워드를 영어로 번역한 뒤 다시 BOOLEAN MODE 키워드로 변환해 검색한다.
+- 번역 키워드와 원문 키워드가 다르면 `findPerspectives`를 한 번 더 호출해 결과를 병합한다.
+- `ArticleRepository.findPerspectives`는 `MATCH(title, description) AGAINST(:keywords IN BOOLEAN MODE)`와 `ORDER BY published_at DESC LIMIT 50`을 사용한다.
+- 결과는 국가별로 그룹핑되고 국가당 최대 3개 기사로 제한된다.
+
+수정 방향:
+
+- API 동작, DB 스키마, 검색 엔진, 캐시 정책은 변경하지 않는다.
+- 현재 매칭 흐름, 알려진 한계, 대표 샘플 선정 기준, 측정 절차, 결과 기록 템플릿을 문서화한다.
+- 기술 도입 후보는 기준선 측정 이후 ADR 또는 후속 이슈로 분리한다.
+
+검증:
+
+```text
+git diff --check
+```
 
 ## 4. 이후 개선 로드맵
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -617,6 +617,7 @@ git diff --check
 ### #142 - Perspectives 다국어 이슈 매칭 품질 기준선 정의
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/142
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/143
 - 상태: In Progress
 - 작업 브랜치: `perf/#142-perspectives-matching-baseline`
 - 주요 파일:

--- a/docs/backend-improvement/perspectives-matching-quality-baseline.md
+++ b/docs/backend-improvement/perspectives-matching-quality-baseline.md
@@ -1,0 +1,135 @@
+# Perspectives matching quality baseline
+
+## Purpose
+
+`GET /api/news/{id}/perspectives` is intended to show articles from multiple countries about a similar issue.
+The current implementation uses title keywords, optional English translation, and MySQL FULLTEXT search.
+
+This document defines a small baseline for measuring the current matching quality before introducing heavier search layers such as Elasticsearch, vector search, RAG, or issue clustering.
+
+## Current Flow
+
+```text
+PerspectivesService.getPerspectives(articleId)
+-> ArticleRepository.findById(articleId)
+-> KeywordExtractor.extractPlain(base.title)
+-> KeywordExtractor.extract(base.title)
+-> if base.language != en, TranslationService.translateToEnglish(plainKeyword)
+-> ArticleRepository.findPerspectives(articleId, translatedOrOriginalBooleanKeyword)
+-> if translated keyword differs from original keyword, run original keyword search too
+-> merge duplicate articles
+-> group by country
+-> limit each country to 3 articles
+-> cache response in Redis
+```
+
+## Current Search Shape
+
+`ArticleRepository.findPerspectives` uses the following FULLTEXT query:
+
+```sql
+SELECT *
+FROM article
+WHERE article_id != :excludeId
+  AND MATCH(title, description) AGAINST(:keywords IN BOOLEAN MODE)
+ORDER BY published_at DESC
+LIMIT 50;
+```
+
+Known behavior:
+
+- The query uses the `ft_article_title_description(title, description)` FULLTEXT index on the local development dataset.
+- Results are ordered by `published_at DESC`, not by semantic similarity.
+- `KeywordExtractor` keeps at most 4 title tokens and makes the first 2 required terms in BOOLEAN MODE.
+- Non-English base articles are searched once with translated English keywords and, when different, once with original keywords.
+- The response groups the retrieved articles by country and keeps up to 3 articles per country.
+
+## Known Limits
+
+- Similar issues can be missed when titles use different expressions, entities, or languages.
+- FULLTEXT matching does not guarantee that articles describe the same event.
+- Search results can be recent but weakly related because the final ordering is recency-based.
+- The current model has no stable `issue_id` or article cluster identity.
+- Translating only the extracted base keywords to English favors English matching and does not fully cover all article languages.
+
+## Sample Selection Criteria
+
+Use representative article samples instead of cherry-picking only successful matches.
+
+Recommended sample set:
+
+| Sample type | Minimum count | Why |
+| --- | ---: | --- |
+| English global issue | 2 | Checks common high-volume FULLTEXT behavior. |
+| Korean or other non-English base article | 2 | Checks translation plus original keyword fallback. |
+| Low-match or zero-match issue | 2 | Exposes recall gaps. |
+| Multi-country breaking/news topic | 2 | Checks whether different country sources appear. |
+| Broad category term issue | 1 | Exposes noisy matches and recency bias. |
+
+For each sample, record the base article ID, title, country, language, category, extracted keywords, and observed result summary.
+Do not include private data, API keys, or full external API responses.
+
+## Measurement Procedure
+
+1. Clear the Redis key for the sample article when measuring the cold path:
+
+```text
+perspectives:article:{articleId}
+```
+
+2. Call the API:
+
+```http
+GET /api/news/{articleId}/perspectives
+```
+
+3. Capture the response summary and service log fields:
+
+```text
+keywordLength
+translationRequested
+translationFallback
+translationMs
+translatedSearchMs
+originalSearchMs
+countriesFound
+totalArticles
+totalMs
+```
+
+4. Review the returned country groups manually and classify each sample:
+
+| Classification | Meaning |
+| --- | --- |
+| `good_match` | Most returned articles appear to describe the same issue. |
+| `partial_match` | Some useful related articles appear, but important countries or articles are missing. |
+| `weak_match` | Results are mostly broad-topic matches rather than the same issue. |
+| `no_match` | The API returns no useful related articles. |
+
+## Baseline Result Template
+
+| Article ID | Base country | Language | Category | Keyword | countriesFound | totalArticles | Classification | Notes |
+| --- | --- | --- | --- | --- | ---: | ---: | --- | --- |
+| TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+
+Country breakdown template:
+
+| Article ID | Country | Returned count | Match notes |
+| --- | --- | ---: | --- |
+| TBD | TBD | TBD | TBD |
+
+## Decision Boundary
+
+This baseline does not introduce Elasticsearch, vector search, RAG, Kafka, or a new schema.
+Those options should be considered only after the baseline shows concrete quality gaps that cannot be addressed with small FULLTEXT or keyword improvements.
+
+Potential follow-up decisions:
+
+| Option | Consider when |
+| --- | --- |
+| FULLTEXT query tuning | Good keywords exist but query shape or ordering loses useful results. |
+| Better keyword extraction | Current title tokens are too noisy or miss entities. |
+| Multilingual query expansion | Non-English article recall is consistently poor. |
+| Vector search or embeddings | Same-issue articles use different wording and FULLTEXT misses them. |
+| Issue clustering / `issue_id` | The product needs stable event-level grouping across article ingestion. |
+| Elasticsearch | Keyword search, filtering, ranking, and multilingual analysis need a dedicated search layer. |


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #142

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)


## 📝 작업 내용
- `#140`/PR `#141` merge 상태를 `WORK_PROGRESS.md`, `BACKLOG.md`에 반영했습니다.
- Perspectives 다국어 이슈 매칭 품질 기준선 문서를 추가했습니다.
- 현재 `PerspectivesService`의 제목 키워드 추출, 영어 번역, MySQL FULLTEXT 검색, 국가별 그룹핑 흐름과 한계를 정리했습니다.
- 대표 articleId/이슈 샘플 선정 기준, 측정 절차, 결과 기록 템플릿을 추가했습니다.

## 🔍 기술적 배경
- 현재 Perspectives API는 같은 이슈를 의미 단위로 식별하는 `issue_id`나 클러스터링 계층 없이 제목 키워드와 FULLTEXT 검색으로 관련 기사를 탐색합니다.
- Elasticsearch, Vector DB, RAG 같은 기술을 바로 도입하기보다, 먼저 현재 FULLTEXT 기반 매칭의 품질 한계를 대표 샘플로 측정할 기준선이 필요합니다.
- 이번 PR은 API 동작, DB 스키마, 검색 엔진, 캐시 정책을 변경하지 않고 후속 기술 선택의 판단 근거를 문서화합니다.


## 🧪 테스트/검증 (필수)
- [x] `git diff --check`로 문서 diff 공백 오류가 없음을 확인했습니다.
- [x] 코드 변경이 없는 문서 작업이므로 `./gradlew.bat test`는 실행하지 않았습니다.


## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?


## 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
- 이번 PR은 구현 변경 없이 문서/기준선 정리만 포함합니다.
- Reviewer는 기준선 문서가 #110의 장기 troubleshooting을 직접 구현하지 않고, #142 범위의 측정 기준 정의에 머무르는지 확인해주세요.


## ➕ 추후 계획(선택)
- 대표 articleId 샘플을 선정해 현재 Perspectives API 결과를 기록합니다.
- 기준선에서 구체적인 품질 격차가 확인되면 FULLTEXT 튜닝, 키워드 개선, Vector DB/Elasticsearch/issue clustering ADR을 별도 이슈로 분리합니다.
