### PR TITLE
[DOCS/#144] AI Reviewer MERGE_READY 이후 merge 흐름 문서화

### DIFF
--- a/docs/ai-workflow/README.md
+++ b/docs/ai-workflow/README.md
@@ -14,7 +14,7 @@ AI를 단순 코드 생성 도구가 아니라 조사, 계획, 구현, 검토를
 Reviewer 세션을 별도로 운영하는 경우에는 GitHub PR comment를 중심으로 리뷰 결과와 반영 내역을 기록한다.
 자세한 흐름은 [AI Reviewer PR Comment Workflow](./reviewer-comment-workflow.md)를 따른다.
 
-AI Reviewer가 `MERGE_READY`를 반환하고 사용자가 merge 진행을 승인한 경우, Implementer는 PR을 merge한 뒤 `WORK_PROGRESS.md`에 merge 결과와 다음 상태를 기록한다.
+AI Reviewer가 `MERGE_READY`를 반환하고 사용자가 해당 PR에 대해 명시적으로 merge 진행을 승인한 경우, Implementer는 PR을 merge한 뒤 `WORK_PROGRESS.md`에 merge 결과와 다음 상태를 기록한다.
 새 Issue/PR을 만든 경우에는 Reviewer Agent에게 전달할 검토 요청 예시도 사용자에게 함께 안내한다.
 
 ## 역할 분리

--- a/docs/ai-workflow/README.md
+++ b/docs/ai-workflow/README.md
@@ -14,6 +14,9 @@ AI를 단순 코드 생성 도구가 아니라 조사, 계획, 구현, 검토를
 Reviewer 세션을 별도로 운영하는 경우에는 GitHub PR comment를 중심으로 리뷰 결과와 반영 내역을 기록한다.
 자세한 흐름은 [AI Reviewer PR Comment Workflow](./reviewer-comment-workflow.md)를 따른다.
 
+AI Reviewer가 `MERGE_READY`를 반환하고 사용자가 merge 진행을 승인한 경우, Implementer는 PR을 merge한 뒤 `WORK_PROGRESS.md`에 merge 결과와 다음 상태를 기록한다.
+새 Issue/PR을 만든 경우에는 Reviewer Agent에게 전달할 검토 요청 예시도 사용자에게 함께 안내한다.
+
 ## 역할 분리
 
 | 역할 | 책임 | 코드 수정 권한 |
@@ -48,6 +51,7 @@ Reviewer 세션을 별도로 운영하는 경우에는 GitHub PR comment를 중�
 | AI Reviewer 검토 결과와 반영 내역 | PR comment |
 | 중요한 기술 선택과 대안 | `docs/adr/` |
 | 개선 후보와 우선순위 | `docs/backend-improvement/BACKLOG.md` |
+| merge 결과와 다음 작업 상태 | `docs/backend-improvement/WORK_PROGRESS.md` |
 
 PR은 해당 Issue를 `Closes #번호`로 연결한다.
 

--- a/docs/ai-workflow/reviewer-comment-workflow.md
+++ b/docs/ai-workflow/reviewer-comment-workflow.md
@@ -139,9 +139,9 @@ PR #<PR_NUMBER>의 AI Reviewer comment를 읽고 수정 계획을 세워줘.
 `scripts/ai-workflow/check-review-blocking.ps1` 또는 동일한 수동 확인으로 최신 `## AI Reviewer 검토 결과` comment의 결정이 `MERGE_READY`이고 Blocking이 없음을 확인하면, Implementer는 아래 기준에 따라 merge를 진행한다.
 
 1. PR이 승인된 Issue 범위 안에 머문다.
-2. Reviewer comment 이후 추가 변경이 없다. 추가 변경이 있다면 필요한 경우 재검토를 요청한다.
+2. Reviewer comment 이후 PR diff에 추가 변경이 없다. 추가 변경이 있다면 최신 diff 기준으로 Reviewer 재검토를 받아야 한다.
 3. PR이 GitHub 기준 mergeable 상태다.
-4. 사용자가 해당 PR 또는 앞으로의 동일 흐름에 대해 merge 진행을 승인했다.
+4. 사용자가 해당 PR에 대해 명시적으로 merge 진행을 승인했다.
 
 위 조건이 충족되면 Implementer는 별도 대기 없이 PR을 merge할 수 있다.
 merge 후에는 로컬 `develop`을 최신화하고 `WORK_PROGRESS.md`에 PR 상태, Reviewer 결정, merge 시각, 다음 작업 상태를 기록한다.

--- a/docs/ai-workflow/reviewer-comment-workflow.md
+++ b/docs/ai-workflow/reviewer-comment-workflow.md
@@ -49,6 +49,7 @@ Issue 생성
 → 필요 시 Reviewer 재검토
 → Blocking 없음 확인
 → 사용자 승인 후 merge
+→ merge 결과와 다음 상태를 WORK_PROGRESS.md에 기록
 ```
 
 ## Reviewer comment 형식
@@ -119,6 +120,9 @@ Issue: #<ISSUE_NUMBER>
 - 리뷰 결과만 PR comment로 기록
 ```
 
+Implementer는 새 Issue/PR을 생성한 뒤 사용자에게 Reviewer 세션에 전달할 검토 요청 예시를 함께 안내한다.
+검토 요청 예시는 PR URL, Issue 번호, 이번 PR의 핵심 검토 관점, Reviewer 제약, `## AI Reviewer 검토 결과` comment 작성 요구를 포함한다.
+
 ## Implementer 세션 표준 프롬프트
 
 ```text
@@ -130,12 +134,26 @@ PR #<PR_NUMBER>의 AI Reviewer comment를 읽고 수정 계획을 세워줘.
 - 코드 변경 전 사용자 승인을 먼저 받는다.
 ```
 
+## MERGE_READY 이후 처리
+
+`scripts/ai-workflow/check-review-blocking.ps1` 또는 동일한 수동 확인으로 최신 `## AI Reviewer 검토 결과` comment의 결정이 `MERGE_READY`이고 Blocking이 없음을 확인하면, Implementer는 아래 기준에 따라 merge를 진행한다.
+
+1. PR이 승인된 Issue 범위 안에 머문다.
+2. Reviewer comment 이후 추가 변경이 없다. 추가 변경이 있다면 필요한 경우 재검토를 요청한다.
+3. PR이 GitHub 기준 mergeable 상태다.
+4. 사용자가 해당 PR 또는 앞으로의 동일 흐름에 대해 merge 진행을 승인했다.
+
+위 조건이 충족되면 Implementer는 별도 대기 없이 PR을 merge할 수 있다.
+merge 후에는 로컬 `develop`을 최신화하고 `WORK_PROGRESS.md`에 PR 상태, Reviewer 결정, merge 시각, 다음 작업 상태를 기록한다.
+
 ## 기록 기준
 
 - Reviewer 검토 결과는 PR comment에 남긴다.
 - Implementer 반영 계획과 반영 완료 내역도 PR comment에 남긴다.
 - 최종 Reviewer 확인 결과는 “Blocking 없음” comment로 남긴다.
-- merge는 사용자의 명시적 승인 후에만 수행한다.
+- merge는 `MERGE_READY`와 사용자 승인 기준을 충족한 뒤 수행한다.
+- 새 Issue/PR 생성 후에는 Reviewer Agent에게 전달할 검토 요청 예시를 사용자에게 안내한다.
+- merge 완료 후에는 `WORK_PROGRESS.md`를 기준 문서로 갱신한다.
 
 ## 후속 자동화 후보
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -38,7 +38,7 @@ Issue 생성
 Reviewer는 코드 수정, 커밋, push, merge를 하지 않는다.
 Reviewer는 `## AI Reviewer 검토 결과` 제목으로 GitHub PR comment를 남긴다.
 Implementer는 새 Issue/PR을 만든 뒤 Reviewer Agent에게 전달할 검토 요청 예시를 사용자에게 함께 안내한다.
-최신 Reviewer comment가 `MERGE_READY`이고 사용자가 merge 진행을 승인한 경우, Implementer는 PR을 merge한 뒤 이 문서에 merge 상태와 다음 작업 상태를 기록한다.
+최신 Reviewer comment가 `MERGE_READY`이고 사용자가 해당 PR에 대해 명시적으로 merge 진행을 승인한 경우, Implementer는 PR을 merge한 뒤 이 문서에 merge 상태와 다음 작업 상태를 기록한다.
 
 ### 커밋 메시지 규칙
 
@@ -83,7 +83,7 @@ Blocking 예시:
 - #137/#138에서 기사 원문 크롤링 timeout/fallback과 외부 I/O 트랜잭션 분리를 개선했다.
 - #140/#141에서 Perspectives API 캐시 hit/miss, Redis 실패, 번역 fallback 흐름을 회귀 테스트로 고정했다.
 - #142/#143에서 Perspectives 다국어 이슈 매칭 품질 기준선을 정의해, Elasticsearch/Vector DB/RAG 같은 기술 도입 전에 현재 FULLTEXT 기반 매칭의 한계를 측정 가능하게 만들었다.
-- #144에서는 Reviewer `MERGE_READY` 이후 사용자 승인에 따라 바로 merge하고, Issue/PR 생성 시 Reviewer 요청 예시를 함께 안내하는 운영 흐름을 문서화한다.
+- #144에서는 Reviewer `MERGE_READY` 이후 PR별 명시 승인에 따라 바로 merge하고, Issue/PR 생성 시 Reviewer 요청 예시를 함께 안내하는 운영 흐름을 문서화한다.
 - 현재 반복 성능/안정성 기본기 흐름의 주요 후보(#123, #127, #129, #131, #133, #137, #140, #142)는 merge 완료 상태다.
 
 ### #113 / PR #114 - 백엔드 개선 Backlog 및 AI 작업 운영 규칙 수립
@@ -677,7 +677,8 @@ Reviewer 결과:
 
 목표:
 
-- Reviewer comment에서 `MERGE_READY`와 Blocking 없음이 확인되고 사용자가 merge 진행을 승인한 경우, Implementer가 바로 merge까지 수행하는 흐름을 문서화한다.
+- Reviewer comment에서 `MERGE_READY`와 Blocking 없음이 확인되고 사용자가 해당 PR에 대해 명시적으로 merge 진행을 승인한 경우, Implementer가 바로 merge까지 수행하는 흐름을 문서화한다.
+- Reviewer comment 이후 PR diff에 추가 변경이 있으면 최신 diff 기준으로 재검토를 받아야 한다는 기준을 명확히 한다.
 - 새 Issue/PR 생성 후에는 Reviewer Agent에게 전달할 검토 요청 예시를 사용자에게 함께 안내하는 규칙을 추가한다.
 - merge 후 `WORK_PROGRESS.md`에 PR 상태, Reviewer 결정, merge 결과, 다음 작업 상태를 남겨 새 Implementer 세션이 흐름을 복원할 수 있게 한다.
 
@@ -686,6 +687,7 @@ Reviewer 결과:
 - `reviewer-comment-workflow.md`에 MERGE_READY 이후 처리 기준을 추가한다.
 - `docs/ai-workflow/README.md`에 merge 결과와 다음 작업 상태 기록 위치를 추가한다.
 - `WORK_PROGRESS.md`에 #142/#143 merge 완료 상태와 #144 진행 상태를 기록한다.
+- AI Reviewer Blocking 반영으로 merge 승인을 PR별 명시 승인으로 좁히고, Reviewer comment 이후 diff 변경 시 재검토 필수 기준을 추가한다.
 
 검증:
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -667,6 +667,7 @@ Reviewer 결과:
 ### #144 - AI Reviewer MERGE_READY 이후 merge 흐름 문서화
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/144
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/145
 - 상태: In Progress
 - 작업 브랜치: `docs/#144-merge-ready-flow`
 - 주요 파일:

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -22,6 +22,7 @@ Issue 생성
 → Blocking 반영
 → 최종 Blocking 없음 확인
 → 사용자 승인 후 merge
+→ WORK_PROGRESS.md 상태 갱신
 ```
 
 ### 역할 분리
@@ -36,6 +37,8 @@ Issue 생성
 
 Reviewer는 코드 수정, 커밋, push, merge를 하지 않는다.
 Reviewer는 `## AI Reviewer 검토 결과` 제목으로 GitHub PR comment를 남긴다.
+Implementer는 새 Issue/PR을 만든 뒤 Reviewer Agent에게 전달할 검토 요청 예시를 사용자에게 함께 안내한다.
+최신 Reviewer comment가 `MERGE_READY`이고 사용자가 merge 진행을 승인한 경우, Implementer는 PR을 merge한 뒤 이 문서에 merge 상태와 다음 작업 상태를 기록한다.
 
 ### 커밋 메시지 규칙
 
@@ -79,8 +82,9 @@ Blocking 예시:
 - #133/#134에서 검색 API FULLTEXT 실행 계획을 분석하고, 원문/번역 검색어가 같은 경우 중복 `OR MATCH`를 제거해 FULLTEXT 인덱스를 사용하도록 개선했다.
 - #137/#138에서 기사 원문 크롤링 timeout/fallback과 외부 I/O 트랜잭션 분리를 개선했다.
 - #140/#141에서 Perspectives API 캐시 hit/miss, Redis 실패, 번역 fallback 흐름을 회귀 테스트로 고정했다.
-- 현재 반복 성능/안정성 기본기 흐름의 주요 후보(#123, #127, #129, #131, #133, #137, #140)는 merge 완료 상태다.
-- #142에서는 Perspectives 다국어 이슈 매칭 품질 기준선을 정의해, Elasticsearch/Vector DB/RAG 같은 기술 도입 전에 현재 FULLTEXT 기반 매칭의 한계를 측정 가능하게 만든다.
+- #142/#143에서 Perspectives 다국어 이슈 매칭 품질 기준선을 정의해, Elasticsearch/Vector DB/RAG 같은 기술 도입 전에 현재 FULLTEXT 기반 매칭의 한계를 측정 가능하게 만들었다.
+- #144에서는 Reviewer `MERGE_READY` 이후 사용자 승인에 따라 바로 merge하고, Issue/PR 생성 시 Reviewer 요청 예시를 함께 안내하는 운영 흐름을 문서화한다.
+- 현재 반복 성능/안정성 기본기 흐름의 주요 후보(#123, #127, #129, #131, #133, #137, #140, #142)는 merge 완료 상태다.
 
 ### #113 / PR #114 - 백엔드 개선 Backlog 및 AI 작업 운영 규칙 수립
 
@@ -618,7 +622,7 @@ git diff --check
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/142
 - PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/143
-- 상태: In Progress
+- 상태: merged
 - 작업 브랜치: `perf/#142-perspectives-matching-baseline`
 - 주요 파일:
   - `docs/backend-improvement/perspectives-matching-quality-baseline.md`
@@ -644,6 +648,43 @@ git diff --check
 - API 동작, DB 스키마, 검색 엔진, 캐시 정책은 변경하지 않는다.
 - 현재 매칭 흐름, 알려진 한계, 대표 샘플 선정 기준, 측정 절차, 결과 기록 템플릿을 문서화한다.
 - 기술 도입 후보는 기준선 측정 이후 ADR 또는 후속 이슈로 분리한다.
+
+검증:
+
+```text
+git diff --check
+```
+
+Reviewer 결과:
+
+- `## AI Reviewer 검토 결과` 제목의 Reviewer comment 기준 Blocking 없음.
+- Non-blocking 없음.
+- `check-review-blocking.ps1 -PrNumber 143` 결과 `MERGE_READY`를 확인했다.
+- 2026-07-03 기준 PR #143은 merge 완료되었고, Issue #142는 closed 상태다.
+
+---
+
+### #144 - AI Reviewer MERGE_READY 이후 merge 흐름 문서화
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/144
+- 상태: In Progress
+- 작업 브랜치: `docs/#144-merge-ready-flow`
+- 주요 파일:
+  - `docs/ai-workflow/reviewer-comment-workflow.md`
+  - `docs/ai-workflow/README.md`
+  - `docs/backend-improvement/WORK_PROGRESS.md`
+
+목표:
+
+- Reviewer comment에서 `MERGE_READY`와 Blocking 없음이 확인되고 사용자가 merge 진행을 승인한 경우, Implementer가 바로 merge까지 수행하는 흐름을 문서화한다.
+- 새 Issue/PR 생성 후에는 Reviewer Agent에게 전달할 검토 요청 예시를 사용자에게 함께 안내하는 규칙을 추가한다.
+- merge 후 `WORK_PROGRESS.md`에 PR 상태, Reviewer 결정, merge 결과, 다음 작업 상태를 남겨 새 Implementer 세션이 흐름을 복원할 수 있게 한다.
+
+수정 방향:
+
+- `reviewer-comment-workflow.md`에 MERGE_READY 이후 처리 기준을 추가한다.
+- `docs/ai-workflow/README.md`에 merge 결과와 다음 작업 상태 기록 위치를 추가한다.
+- `WORK_PROGRESS.md`에 #142/#143 merge 완료 상태와 #144 진행 상태를 기록한다.
 
 검증:
 


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #144

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)


## 📝 작업 내용
- AI Reviewer가 `MERGE_READY`를 반환하고 사용자가 merge 진행을 승인한 경우 Implementer가 바로 merge할 수 있는 기준을 문서화했습니다.
- 새 Issue/PR 생성 후 Reviewer Agent에게 전달할 검토 요청 예시를 사용자에게 함께 안내하는 규칙을 추가했습니다.
- merge 후 `WORK_PROGRESS.md`에 PR 상태, Reviewer 결정, merge 결과, 다음 작업 상태를 기록하는 흐름을 추가했습니다.
- PR #143 merge 결과와 #142 완료 상태를 `WORK_PROGRESS.md`에 반영했습니다.

## 🔍 기술적 배경
- 기존 흐름은 `Blocking 없음 확인 → 사용자 승인 후 merge`까지는 있었지만, `MERGE_READY` 이후 바로 merge해도 되는 조건과 merge 후 기준 문서 갱신 책임이 명시적으로 분리되어 있지 않았습니다.
- 새 Implementer 세션이 이전 작업을 복원하려면 Issue/PR 생성, Reviewer 요청 예시, Reviewer 결정, merge 결과가 `WORK_PROGRESS.md`에 이어져 있어야 합니다.
- 이번 PR은 자동화 흐름 문서화만 포함하며 코드, DB, API 동작은 변경하지 않습니다.


## 🧪 테스트/검증 (필수)
- [x] `git diff --check`로 문서 diff 공백 오류가 없음을 확인했습니다.
- [x] 코드 변경이 없는 문서 작업이므로 `./gradlew.bat test`는 실행하지 않았습니다.


## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?


## 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
- Reviewer는 `MERGE_READY` 이후 merge 기준이 기존 승인 게이트를 약화하지 않고, 사용자 승인과 Reviewer comment 확인을 전제로 하는지 확인해주세요.
- 새 Issue/PR 생성 후 Reviewer 요청 예시를 안내하는 규칙이 실제 작업 흐름에 충분히 명확한지 확인해주세요.


## ➕ 추후 계획(선택)
- 반복이 더 쌓이면 PR comment 조회, Blocking 추출, merge readiness 판단, WORK_PROGRESS 갱신 후보를 MCP 또는 스크립트로 확장합니다.
