### PR TITLE
[TEST/#148] KeywordExtractor 현행 정책 회귀 테스트 추가

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -50,7 +50,7 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## P3. 다국어 이슈 매칭 품질 개선
 
-- 상태: `In Progress` ([#146](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/146))
+- 상태: `In Progress` ([#148](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/148))
 - AS-IS: 기사 제목의 키워드와 영어 번역 키워드를 MySQL FULLTEXT 검색에 사용하므로, 표현이 다른 동일 이슈 또는 비영어권 기사 간 매칭이 누락될 수 있다.
 - TO-BE: 기존 후보 검색을 유지하면서 이슈 유사도와 국가 다양성 기준으로 결과를 재정렬하는 정책을 검증한다.
 - 성공 기준:

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -85,6 +85,7 @@ Blocking 예시:
 - #142/#143에서 Perspectives 다국어 이슈 매칭 품질 기준선을 정의해, Elasticsearch/Vector DB/RAG 같은 기술 도입 전에 현재 FULLTEXT 기반 매칭의 한계를 측정 가능하게 만들었다.
 - #144/#145에서 Reviewer `MERGE_READY` 이후 PR별 명시 승인에 따라 바로 merge하고, Issue/PR 생성 시 Reviewer 요청 예시를 함께 안내하는 운영 흐름을 문서화했다.
 - #146/#147에서 #142 기준선에 이어 로컬 개발 DB의 대표 샘플 후보와 MySQL FULLTEXT 매칭 스냅샷을 기록했다.
+- #148에서는 `KeywordExtractor` 현행 정책을 회귀 테스트로 고정하고, 의미 유사도 개선이 아니라 키워드 후보 탐색 정책임을 명확히 남긴다.
 - 현재 반복 성능/안정성 기본기 흐름의 주요 후보(#123, #127, #129, #131, #133, #137, #140, #142, #146)와 AI workflow 보강(#144)은 merge 완료 상태다.
 
 ### #113 / PR #114 - 백엔드 개선 Backlog 및 AI 작업 운영 규칙 수립
@@ -752,6 +753,39 @@ Reviewer 결과:
 - Non-blocking 없음.
 - `check-review-blocking.ps1 -PrNumber 147` 결과 `MERGE_READY`를 확인했다.
 - 2026-07-03 기준 PR #147은 merge 완료되었고, Issue #146은 closed 상태다.
+
+---
+
+### #148 - KeywordExtractor 현행 정책 회귀 테스트 및 한계 명시
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/148
+- 상태: In Progress
+- 작업 브랜치: `test/#148-keyword-extractor-regression`
+- 주요 파일:
+  - `src/test/java/com/example/globalTimes_be/domain/detail/util/KeywordExtractorTest.java`
+  - `docs/backend-improvement/perspectives-matching-sample-snapshot.md`
+  - `docs/backend-improvement/BACKLOG.md`
+  - `docs/backend-improvement/WORK_PROGRESS.md`
+
+목표:
+
+- #146 스냅샷에서 드러난 `First`, `round`, `Entre` 같은 일반 토큰 문제를 바로 수정하지 않고, 먼저 `KeywordExtractor`의 현재 정책을 테스트로 고정한다.
+- 현재 정책이 의미 유사도 검색이 아니라 제목 토큰 기반 후보 탐색임을 문서에 명확히 남긴다.
+- 이후 일반 토큰 필터링, entity-aware keyword extraction, ranking 개선을 검토할 때 비교 기준을 확보한다.
+
+수정 방향:
+
+- 운영 코드의 `KeywordExtractor` 정책은 변경하지 않는다.
+- `First round`, `BTS`, `Trump-backed`, 한국어, 프랑스어 제목 샘플을 단위 테스트로 고정한다.
+- 테스트 과정에서 현재 `extract()`의 BOOLEAN MODE 문자열 공백 형식과 Unicode ellipsis 기반 한국어 토큰 결합도 함께 드러난다.
+- #146 스냅샷 문서에 수동 키워드 예시는 측정 보조 자료이며, 실제 Java 정책은 테스트로 고정한다는 설명을 추가한다.
+
+검증:
+
+```text
+./gradlew.bat test
+git diff --check
+```
 
 ## 4. 이후 개선 로드맵
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -759,6 +759,7 @@ Reviewer 결과:
 ### #148 - KeywordExtractor 현행 정책 회귀 테스트 및 한계 명시
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/148
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/149
 - 상태: In Progress
 - 작업 브랜치: `test/#148-keyword-extractor-regression`
 - 주요 파일:

--- a/docs/backend-improvement/perspectives-matching-sample-snapshot.md
+++ b/docs/backend-improvement/perspectives-matching-sample-snapshot.md
@@ -128,11 +128,15 @@ This is a useful partial-match sample for evaluating future ranking or entity fi
 - BTS is a good positive sample because the extracted keyword is a strong entity.
 - Korean and French original keyword samples often return zero in this local query snapshot.
 - Some `language='zh'` rows contain English titles, so the `language` field alone does not fully describe search text language.
+- The manual keyword examples in this snapshot are measurement aids, not a replacement for the Java policy.
+  `KeywordExtractorTest` fixes the current Java behavior before any token policy changes are attempted.
+- The regression tests also expose current formatting/tokenization quirks, such as compacted `+first+second` BOOLEAN MODE output and Korean tokens joined by the Unicode ellipsis character.
 
 ## Follow-up Candidates
 
 1. Measure the full API path for the same samples, including translation behavior, with external API usage explicitly approved.
-2. Add entity-aware keyword extraction or a better stop-word/token policy before changing search engines.
-3. Compare the current recency ordering with a relevance-first or hybrid ranking strategy.
-4. Define expected countries per sample before trying vector search or Elasticsearch.
-5. Keep `issue_id` or clustering as an ADR-level option until concrete sample failures justify the added model.
+2. Add entity-aware keyword extraction or a better stop-word/token policy only after comparing against the fixed regression tests.
+3. Normalize BOOLEAN MODE keyword formatting only after confirming it does not change query semantics unexpectedly.
+4. Compare the current recency ordering with a relevance-first or hybrid ranking strategy.
+5. Define expected countries per sample before trying vector search or Elasticsearch.
+6. Keep `issue_id` or clustering as an ADR-level option until concrete sample failures justify the added model.

--- a/src/test/java/com/example/globalTimes_be/domain/detail/util/KeywordExtractorTest.java
+++ b/src/test/java/com/example/globalTimes_be/domain/detail/util/KeywordExtractorTest.java
@@ -1,0 +1,66 @@
+package com.example.globalTimes_be.domain.detail.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KeywordExtractorTest {
+
+    @Test
+    void extract_keepsCurrentLeadingTokenPolicyForGenericEnglishWords() {
+        String title = "First round of US-Iran talks ends with encouraging progress";
+
+        assertThat(KeywordExtractor.extractPlain(title))
+                .isEqualTo("First round Iran talks");
+        assertThat(KeywordExtractor.extract(title))
+                .isEqualTo("+First+round  Iran  talks");
+    }
+
+    @Test
+    void extract_keepsStrongEntityKeywordForBtsSample() {
+        String title = "The BTS fans losing thousands as scammers cash in on comeback tour ticket war";
+
+        assertThat(KeywordExtractor.extractPlain(title))
+                .isEqualTo("BTS fans losing thousands");
+        assertThat(KeywordExtractor.extract(title))
+                .isEqualTo("+BTS+fans  losing  thousands");
+    }
+
+    @Test
+    void extract_splitsHyphenatedEnglishWordsIntoSeparateTokens() {
+        String title = "Trump-backed political outsider wins Colombia election";
+
+        assertThat(KeywordExtractor.extractPlain(title))
+                .isEqualTo("Trump backed political outsider");
+        assertThat(KeywordExtractor.extract(title))
+                .isEqualTo("+Trump+backed  political  outsider");
+    }
+
+    @Test
+    void extract_keepsKoreanTokenJoinedByUnicodeEllipsis() {
+        String title = "AI 반도체 붐에 車 디스플레이칩도 쑥쑥…대만 하이맥스 약진";
+
+        assertThat(KeywordExtractor.extractPlain(title))
+                .isEqualTo("반도체 디스플레이칩도 쑥쑥…대만 하이맥스");
+        assertThat(KeywordExtractor.extract(title))
+                .isEqualTo("+반도체+디스플레이칩도  쑥쑥…대만  하이맥스");
+    }
+
+    @Test
+    void extract_keepsFrenchGeneralTokenBecauseOnlyEnglishStopWordsExist() {
+        String title = "Entre Meloni et Trump, divorce a l'italienne";
+
+        assertThat(KeywordExtractor.extractPlain(title))
+                .isEqualTo("Entre Meloni Trump divorce");
+        assertThat(KeywordExtractor.extract(title))
+                .isEqualTo("+Entre+Meloni  Trump  divorce");
+    }
+
+    @Test
+    void extract_returnsEmptyStringForNullOrBlankTitle() {
+        assertThat(KeywordExtractor.extract(null)).isEmpty();
+        assertThat(KeywordExtractor.extract("   ")).isEmpty();
+        assertThat(KeywordExtractor.extractPlain(null)).isEmpty();
+        assertThat(KeywordExtractor.extractPlain("   ")).isEmpty();
+    }
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #148

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)


## 📝 작업 내용
- `KeywordExtractor.extract()`와 `extractPlain()`의 현행 동작을 단위 테스트로 고정했습니다.
- #146 샘플에서 이어지는 `First round`, `BTS`, `Trump-backed`, 한국어, 프랑스어 제목 케이스를 테스트에 포함했습니다.
- 운영 코드의 키워드 정책은 변경하지 않았습니다.
- `perspectives-matching-sample-snapshot.md`, `BACKLOG.md`, `WORK_PROGRESS.md`에 #148 진행 맥락을 반영했습니다.

## 🔍 기술적 배경
- Perspectives 매칭은 의미 유사도 검색이 아니라 제목 토큰 기반 MySQL FULLTEXT 후보 탐색입니다.
- #146 스냅샷에서 `First`, `round`, `Entre` 같은 일반 토큰과 한국어 punctuation/tokenization 한계가 드러났지만, 바로 stop word나 필수 키워드 정책을 바꾸면 다른 샘플을 망칠 수 있습니다.
- 이번 PR은 개선 전 현재 정책을 회귀 테스트로 고정해, 후속 일반 토큰 필터링이나 키워드 정책 개선의 비교 기준을 마련합니다.


## 🧪 테스트/검증 (필수)
- [x] `./gradlew.bat test`로 전체 테스트 통과를 확인했습니다.
- [x] `git diff --check`로 diff 공백 오류가 없음을 확인했습니다.


## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?


## 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
- Reviewer는 이번 PR이 `KeywordExtractor` 운영 정책 변경 없이 현행 동작 회귀 테스트와 문서화 범위에 머무르는지 확인해주세요.
- `extract()`의 현재 BOOLEAN MODE 문자열 공백 형식과 Unicode ellipsis 토큰 결합을 “개선”하지 않고 테스트로 고정한 것이 #148 목적과 맞는지 확인해주세요.
- 이 PR이 의미 유사도 개선으로 과장되지 않고, 후속 개선 전 기준선 역할로 설명되어 있는지 확인해주세요.


## ➕ 추후 계획(선택)
- 일반 토큰 필터링, BOOLEAN MODE 문자열 정규화, entity-aware keyword extraction은 이 테스트를 기준으로 별도 이슈에서 비교합니다.
