### PR TITLE
[FIX/#150] KeywordExtractor BOOLEAN MODE 검색어 포맷 정규화

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -50,7 +50,7 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## P3. 다국어 이슈 매칭 품질 개선
 
-- 상태: `Backlog` (최근 완료: [#142](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/142), [#146](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/146), [#148](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/148))
+- 상태: `In Progress` ([#150](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/150), 최근 완료: [#142](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/142), [#146](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/146), [#148](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/148))
 - AS-IS: 기사 제목의 키워드와 영어 번역 키워드를 MySQL FULLTEXT 검색에 사용하므로, 표현이 다른 동일 이슈 또는 비영어권 기사 간 매칭이 누락될 수 있다.
 - TO-BE: 기존 후보 검색을 유지하면서 이슈 유사도와 국가 다양성 기준으로 결과를 재정렬하는 정책을 검증한다.
 - 성공 기준:

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -86,6 +86,7 @@ Blocking 예시:
 - #144/#145에서 Reviewer `MERGE_READY` 이후 PR별 명시 승인에 따라 바로 merge하고, Issue/PR 생성 시 Reviewer 요청 예시를 함께 안내하는 운영 흐름을 문서화했다.
 - #146/#147에서 #142 기준선에 이어 로컬 개발 DB의 대표 샘플 후보와 MySQL FULLTEXT 매칭 스냅샷을 기록했다.
 - #148/#149에서 `KeywordExtractor` 현행 정책을 회귀 테스트로 고정하고, 의미 유사도 개선이 아니라 키워드 후보 탐색 정책임을 명확히 남겼다.
+- #150에서는 `KeywordExtractor.extract()`의 MySQL FULLTEXT BOOLEAN MODE 검색어 공백 포맷을 정규화한다.
 - 현재 반복 성능/안정성 기본기 흐름의 주요 후보(#123, #127, #129, #131, #133, #137, #140, #142, #146)와 AI workflow 보강(#144)은 merge 완료 상태다.
 
 ### #113 / PR #114 - 백엔드 개선 Backlog 및 AI 작업 운영 규칙 수립
@@ -794,6 +795,44 @@ Reviewer 결과:
 - Non-blocking 없음.
 - `check-review-blocking.ps1 -PrNumber 149` 결과 `MERGE_READY`를 확인했다.
 - 2026-07-03 기준 PR #149는 merge 완료되었고, Issue #148은 closed 상태다.
+
+---
+
+### #150 - KeywordExtractor BOOLEAN MODE 검색어 포맷 정규화
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/150
+- PR: TBD
+- 상태: In Progress
+- 작업 브랜치: `fix/#150-keyword-boolean-format`
+- 주요 파일:
+  - `src/main/java/com/example/globalTimes_be/domain/detail/util/KeywordExtractor.java`
+  - `src/test/java/com/example/globalTimes_be/domain/detail/util/KeywordExtractorTest.java`
+  - `docs/backend-improvement/BACKLOG.md`
+  - `docs/backend-improvement/WORK_PROGRESS.md`
+
+목표:
+
+- #148 회귀 테스트에서 드러난 `+First+round  Iran  talks` 형태의 불규칙한 BOOLEAN MODE 검색어 포맷을 `+First +round Iran talks`처럼 토큰 사이 공백이 명확한 형태로 정규화한다.
+- 일반 토큰 필터링, entity-aware 추출, ranking 정책은 변경하지 않고 검색어 문자열 조립 결함만 좁게 수정한다.
+- 이후 일반 토큰 필터링 개선을 검토할 때 비교 기준이 흔들리지 않도록 한다.
+
+수정 방향:
+
+- `KeywordExtractor.extract()`가 첫 2개 토큰에는 `+`를 붙이고, 모든 토큰은 단일 공백으로 join하도록 단순화한다.
+- `extractPlain()`은 변경하지 않는다.
+- 기존 회귀 테스트 기대값을 정규화된 BOOLEAN MODE 문자열로 갱신한다.
+
+검증 예정:
+
+```text
+./gradlew.bat test
+git diff --check
+```
+
+구현 메모:
+
+- `KeywordExtractor.extract()`의 토큰 추출 정책은 유지하고, BOOLEAN MODE 문자열 조립만 `+first +second third fourth` 형태로 단일 공백 join하도록 변경했다.
+- 기존 깨진 한글 fixture는 읽을 수 있는 한국어 Unicode ellipsis 샘플로 정리해, 토큰화 한계는 유지하되 테스트 의도를 명확히 했다.
 
 ## 4. 이후 개선 로드맵
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -801,7 +801,7 @@ Reviewer 결과:
 ### #150 - KeywordExtractor BOOLEAN MODE 검색어 포맷 정규화
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/150
-- PR: TBD
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/151
 - 상태: In Progress
 - 작업 브랜치: `fix/#150-keyword-boolean-format`
 - 주요 파일:

--- a/docs/backend-improvement/perspectives-matching-sample-snapshot.md
+++ b/docs/backend-improvement/perspectives-matching-sample-snapshot.md
@@ -130,7 +130,8 @@ This is a useful partial-match sample for evaluating future ranking or entity fi
 - Some `language='zh'` rows contain English titles, so the `language` field alone does not fully describe search text language.
 - The manual keyword examples in this snapshot are measurement aids, not a replacement for the Java policy.
   `KeywordExtractorTest` fixes the current Java behavior before any token policy changes are attempted.
-- The regression tests also expose current formatting/tokenization quirks, such as compacted `+first+second` BOOLEAN MODE output and Korean tokens joined by the Unicode ellipsis character.
+- The regression tests exposed formatting/tokenization quirks, such as compacted `+first+second` BOOLEAN MODE output and Korean tokens joined by the Unicode ellipsis character.
+  The compacted BOOLEAN MODE formatting is normalized in #150; token policy changes remain separate follow-up work.
 
 ## Follow-up Candidates
 

--- a/src/main/java/com/example/globalTimes_be/domain/detail/util/KeywordExtractor.java
+++ b/src/main/java/com/example/globalTimes_be/domain/detail/util/KeywordExtractor.java
@@ -41,14 +41,7 @@ public class KeywordExtractor {
         if (keywords.isEmpty()) return title;
 
         // 첫 2개는 필수(+), 나머지는 선택 → FULLTEXT 정확도 향상
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < keywords.size(); i++) {
-            if (i < 2) sb.append("+").append(keywords.get(i));
-            else sb.append(" ").append(keywords.get(i));
-            if (i < keywords.size() - 1 && i >= 1) sb.append(" ");
-        }
-
-        return sb.toString().trim();
+        return formatBooleanModeKeywords(keywords);
     }
 
     // 로깅/응답용 평문 키워드 (+ 기호 없이)
@@ -60,6 +53,12 @@ public class KeywordExtractor {
                 .filter(word -> !STOP_WORDS.contains(word.toLowerCase()))
                 .distinct()
                 .limit(MAX_KEYWORDS)
+                .collect(Collectors.joining(" "));
+    }
+
+    private static String formatBooleanModeKeywords(List<String> keywords) {
+        return java.util.stream.IntStream.range(0, keywords.size())
+                .mapToObj(i -> i < 2 ? "+" + keywords.get(i) : keywords.get(i))
                 .collect(Collectors.joining(" "));
     }
 }

--- a/src/test/java/com/example/globalTimes_be/domain/detail/util/KeywordExtractorTest.java
+++ b/src/test/java/com/example/globalTimes_be/domain/detail/util/KeywordExtractorTest.java
@@ -7,13 +7,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 class KeywordExtractorTest {
 
     @Test
-    void extract_keepsCurrentLeadingTokenPolicyForGenericEnglishWords() {
+    void extract_keepsLeadingTokenPolicyForGenericEnglishWords() {
         String title = "First round of US-Iran talks ends with encouraging progress";
 
         assertThat(KeywordExtractor.extractPlain(title))
                 .isEqualTo("First round Iran talks");
         assertThat(KeywordExtractor.extract(title))
-                .isEqualTo("+First+round  Iran  talks");
+                .isEqualTo("+First +round Iran talks");
     }
 
     @Test
@@ -23,7 +23,7 @@ class KeywordExtractorTest {
         assertThat(KeywordExtractor.extractPlain(title))
                 .isEqualTo("BTS fans losing thousands");
         assertThat(KeywordExtractor.extract(title))
-                .isEqualTo("+BTS+fans  losing  thousands");
+                .isEqualTo("+BTS +fans losing thousands");
     }
 
     @Test
@@ -33,17 +33,17 @@ class KeywordExtractorTest {
         assertThat(KeywordExtractor.extractPlain(title))
                 .isEqualTo("Trump backed political outsider");
         assertThat(KeywordExtractor.extract(title))
-                .isEqualTo("+Trump+backed  political  outsider");
+                .isEqualTo("+Trump +backed political outsider");
     }
 
     @Test
     void extract_keepsKoreanTokenJoinedByUnicodeEllipsis() {
-        String title = "AI 반도체 붐에 車 디스플레이칩도 쑥쑥…대만 하이맥스 약진";
+        String title = "AI 반도체…대만 하이맥스 급등";
 
         assertThat(KeywordExtractor.extractPlain(title))
-                .isEqualTo("반도체 디스플레이칩도 쑥쑥…대만 하이맥스");
+                .isEqualTo("반도체…대만 하이맥스");
         assertThat(KeywordExtractor.extract(title))
-                .isEqualTo("+반도체+디스플레이칩도  쑥쑥…대만  하이맥스");
+                .isEqualTo("+반도체…대만 +하이맥스");
     }
 
     @Test
@@ -53,7 +53,7 @@ class KeywordExtractorTest {
         assertThat(KeywordExtractor.extractPlain(title))
                 .isEqualTo("Entre Meloni Trump divorce");
         assertThat(KeywordExtractor.extract(title))
-                .isEqualTo("+Entre+Meloni  Trump  divorce");
+                .isEqualTo("+Entre +Meloni Trump divorce");
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
- closed #150

## 변경 타입
- [ ] 기능 추가 (FEAT)
- [x] 버그 수정 (FIX)
- [ ] 리팩토링 (REFACTOR)
- [x] 테스트/문서 (TEST/CHORE)

## 작업 내용
- `KeywordExtractor.extract()`의 MySQL FULLTEXT BOOLEAN MODE 검색어 조립을 단일 공백 join 방식으로 정규화했습니다.
- 기존 정책인 “앞의 2개 토큰은 required(`+`), 이후 토큰은 optional”은 유지했습니다.
- `KeywordExtractorTest`의 기대값을 `+First +round Iran talks`, `+BTS +fans losing thousands`처럼 정규화된 포맷으로 갱신했습니다.
- 깨진 한글 fixture를 읽을 수 있는 Unicode ellipsis 한국어 샘플로 정리해 테스트 의도를 명확히 했습니다.
- `WORK_PROGRESS.md`, `BACKLOG.md`, `perspectives-matching-sample-snapshot.md`에 #150 진행 맥락과 후속 분리 기준을 기록했습니다.

## 기술적 배경
- #148 회귀 테스트에서 기존 `extract()`가 `+First+round  Iran  talks`처럼 토큰 사이 공백이 불규칙한 BOOLEAN MODE 문자열을 생성하는 것이 확인되었습니다.
- 일반 토큰 필터링이나 entity-aware keyword extraction을 적용하기 전에, 검색어 포맷부터 안정화해야 후속 품질 개선의 비교 기준이 흔들리지 않습니다.
- 이번 PR은 검색 정책 자체를 바꾸지 않고, 문자열 조립 결함만 좁게 수정합니다.

## 테스트/검증
- [x] `./gradlew.bat test`
- [x] `git diff --check`

## 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop` 대상 PR)
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않는가?
- [x] (리팩토링/수정의 경우) 기존 동작/응답의 변경 범위를 명확히 확인했는가?

## 스크린샷
- 해당 없음

## 리뷰 요구사항
- `KeywordExtractor.extract()`가 BOOLEAN MODE 검색어를 `+first +second third fourth` 형태로 정규화하면서 기존 토큰 추출 정책을 유지하는지 확인 부탁드립니다.
- 이번 PR이 일반 토큰 필터링, entity-aware 추출, ranking 정책 변경을 포함하지 않고 포맷 정규화와 테스트/문서 갱신에 머무르는지 확인 부탁드립니다.

## 추후 계획
- 일반 토큰 필터링 개선은 이번 포맷 정규화가 merge된 뒤 별도 Issue로 분리해 진행합니다.
