### PR TITLE
[PERF/#152] Perspectives KeywordExtractor 일반 토큰 필터링 개선

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -50,7 +50,7 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## P3. 다국어 이슈 매칭 품질 개선
 
-- 상태: `Backlog` (최근 완료: [#142](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/142), [#146](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/146), [#148](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/148), [#150](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/150))
+- 상태: `In Progress` ([#152](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/152), 최근 완료: [#142](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/142), [#146](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/146), [#148](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/148), [#150](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/150))
 - AS-IS: 기사 제목의 키워드와 영어 번역 키워드를 MySQL FULLTEXT 검색에 사용하므로, 표현이 다른 동일 이슈 또는 비영어권 기사 간 매칭이 누락될 수 있다.
 - TO-BE: 기존 후보 검색을 유지하면서 이슈 유사도와 국가 다양성 기준으로 결과를 재정렬하는 정책을 검증한다.
 - 성공 기준:

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -87,6 +87,7 @@ Blocking 예시:
 - #146/#147에서 #142 기준선에 이어 로컬 개발 DB의 대표 샘플 후보와 MySQL FULLTEXT 매칭 스냅샷을 기록했다.
 - #148/#149에서 `KeywordExtractor` 현행 정책을 회귀 테스트로 고정하고, 의미 유사도 개선이 아니라 키워드 후보 탐색 정책임을 명확히 남겼다.
 - #150/#151에서 `KeywordExtractor.extract()`의 MySQL FULLTEXT BOOLEAN MODE 검색어 공백 포맷을 정규화했다.
+- #152에서는 `First`, `round`, `Entre` 같은 샘플 기반 일반 토큰을 필터링해 Perspectives 후보 검색어 품질을 개선한다.
 - 현재 반복 성능/안정성 기본기 흐름의 주요 후보(#123, #127, #129, #131, #133, #137, #140, #142, #146)와 AI workflow 보강(#144)은 merge 완료 상태다.
 
 ### #113 / PR #114 - 백엔드 개선 Backlog 및 AI 작업 운영 규칙 수립
@@ -840,6 +841,47 @@ Reviewer 결과:
 - Non-blocking: `WORK_PROGRESS.md`의 `검증 예정` 표현을 완료 상태와 맞추는 문서 정정 제안이 있었고, merge 후 후처리에서 `검증`으로 정리했다.
 - `check-review-blocking.ps1 -PrNumber 151` 결과 `MERGE_READY`를 확인했다.
 - 2026-07-03 기준 PR #151은 merge 완료되었고, Issue #150은 closed 상태다.
+
+---
+
+### #152 - Perspectives KeywordExtractor 일반 토큰 필터링 개선
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/152
+- PR: TBD
+- 상태: In Progress
+- 작업 브랜치: `perf/#152-keyword-generic-token-filtering`
+- 주요 파일:
+  - `src/main/java/com/example/globalTimes_be/domain/detail/util/KeywordExtractor.java`
+  - `src/test/java/com/example/globalTimes_be/domain/detail/util/KeywordExtractorTest.java`
+  - `docs/backend-improvement/perspectives-matching-sample-snapshot.md`
+  - `docs/backend-improvement/BACKLOG.md`
+  - `docs/backend-improvement/WORK_PROGRESS.md`
+
+목표:
+
+- #146 스냅샷에서 드러난 `First`, `round`, `Entre` 같은 일반 토큰이 required token으로 잡히는 문제를 샘플 기반 최소 필터링으로 줄인다.
+- #150에서 정규화한 BOOLEAN MODE 포맷 위에서 검색어 후보 품질을 개선한다.
+- ranking, entity-aware extraction, translation, DB query, Redis 정책은 변경하지 않는다.
+
+수정 방향:
+
+- `KeywordExtractor`에 기존 stop words와 별도로 샘플 기반 약한 토큰 필터를 둔다.
+- `extract()`와 `extractPlain()`이 같은 토큰 후보 추출 정책을 공유하도록 정리한다.
+- `BTS`, `Trump`, `Iran`, `Meloni` 같은 핵심 entity 토큰이 유지되는지 테스트로 확인한다.
+
+검증:
+
+```text
+./gradlew.bat test
+git diff --check
+```
+
+구현 메모:
+
+- `KeywordExtractor`의 토큰 후보 추출을 `extractKeywords()`로 모아 `extract()`와 `extractPlain()`이 같은 필터링 정책을 공유하게 했다.
+- 샘플 기반 일반 토큰으로 `first`, `round`, `entre`를 분리했다.
+- `First round of US-Iran...` 샘플은 `Iran talks...`, `Entre Meloni...` 샘플은 `Meloni Trump...` 중심의 검색어를 생성하도록 테스트 기대값을 갱신했다.
+- DB-level FULLTEXT 결과 변화는 이번 PR에서 직접 측정하지 않고, `perspectives-matching-sample-snapshot.md`에 후속 측정 후보로 남겼다.
 
 ## 4. 이후 개선 로드맵
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -847,7 +847,7 @@ Reviewer 결과:
 ### #152 - Perspectives KeywordExtractor 일반 토큰 필터링 개선
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/152
-- PR: TBD
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/153
 - 상태: In Progress
 - 작업 브랜치: `perf/#152-keyword-generic-token-filtering`
 - 주요 파일:

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -881,6 +881,7 @@ git diff --check
 - `KeywordExtractor`의 토큰 후보 추출을 `extractKeywords()`로 모아 `extract()`와 `extractPlain()`이 같은 필터링 정책을 공유하게 했다.
 - 샘플 기반 일반 토큰으로 `first`, `round`, `entre`를 분리했다.
 - `First round of US-Iran...` 샘플은 `Iran talks...`, `Entre Meloni...` 샘플은 `Meloni Trump...` 중심의 검색어를 생성하도록 테스트 기대값을 갱신했다.
+- Reviewer Blocking 반영으로 일반 토큰 필터링 후 후보가 비는 경우 `extract()`와 `extractPlain()` 모두 빈 문자열을 반환하도록 정책을 맞췄다.
 - DB-level FULLTEXT 결과 변화는 이번 PR에서 직접 측정하지 않고, `perspectives-matching-sample-snapshot.md`에 후속 측정 후보로 남겼다.
 
 ## 4. 이후 개선 로드맵

--- a/docs/backend-improvement/perspectives-matching-sample-snapshot.md
+++ b/docs/backend-improvement/perspectives-matching-sample-snapshot.md
@@ -133,11 +133,24 @@ This is a useful partial-match sample for evaluating future ranking or entity fi
 - The regression tests exposed formatting/tokenization quirks, such as compacted `+first+second` BOOLEAN MODE output and Korean tokens joined by the Unicode ellipsis character.
   The compacted BOOLEAN MODE formatting is normalized in #150; token policy changes remain separate follow-up work.
 
+## Java Policy Follow-up
+
+The snapshot table above preserves the original local measurement keywords and match counts.
+After #150 and #152, the Java `KeywordExtractor` policy changes the generated keywords for the weakest generic-token samples:
+
+| Base article ID | Previous keyword | #152 Java keyword | Reason |
+| --- | --- | --- | --- |
+| 8146 | `+First +round Iran talks` | `+Iran +talks ends encouraging` | `First` and `round` are filtered as sample-based generic tokens. |
+| 9440 | `+Entre +Meloni Trump divorce` | `+Meloni +Trump divorce italienne` | `Entre` is filtered as a sample-based generic token. |
+
+This section documents generated keyword changes only.
+It does not replace the original match counts, because DB-level FULLTEXT result quality should be measured separately after the code change is merged.
+
 ## Follow-up Candidates
 
 1. Measure the full API path for the same samples, including translation behavior, with external API usage explicitly approved.
-2. Add entity-aware keyword extraction or a better stop-word/token policy only after comparing against the fixed regression tests.
-3. Normalize BOOLEAN MODE keyword formatting only after confirming it does not change query semantics unexpectedly.
+2. Measure DB-level result changes for #152 generic-token filtering on the representative samples.
+3. Add entity-aware keyword extraction only after comparing against the fixed regression tests.
 4. Compare the current recency ordering with a relevance-first or hybrid ranking strategy.
 5. Define expected countries per sample before trying vector search or Elasticsearch.
 6. Keep `issue_id` or clustering as an ADR-level option until concrete sample failures justify the added model.

--- a/docs/backend-improvement/perspectives-matching-sample-snapshot.md
+++ b/docs/backend-improvement/perspectives-matching-sample-snapshot.md
@@ -145,6 +145,7 @@ After #150 and #152, the Java `KeywordExtractor` policy changes the generated ke
 
 This section documents generated keyword changes only.
 It does not replace the original match counts, because DB-level FULLTEXT result quality should be measured separately after the code change is merged.
+If all extracted candidates are removed by the generic-token filter, both `extract()` and `extractPlain()` return an empty string instead of falling back to the original title.
 
 ## Follow-up Candidates
 

--- a/src/main/java/com/example/globalTimes_be/domain/detail/util/KeywordExtractor.java
+++ b/src/main/java/com/example/globalTimes_be/domain/detail/util/KeywordExtractor.java
@@ -18,6 +18,9 @@ public class KeywordExtractor {
             "what", "how", "when", "where", "who", "which", "can", "do", "did",
             "he", "she", "we", "you", "his", "her", "our", "your"
     );
+    private static final Set<String> GENERIC_TOKENS = Set.of(
+            "first", "round", "entre"
+    );
 
     private static final int MAX_KEYWORDS = 4;
 
@@ -31,12 +34,7 @@ public class KeywordExtractor {
     public static String extract(String title) {
         if (title == null || title.isBlank()) return "";
 
-        List<String> keywords = Arrays.stream(title.split("[\\s\\p{Punct}]+"))
-                .filter(word -> word.length() > 2)
-                .filter(word -> !STOP_WORDS.contains(word.toLowerCase()))
-                .distinct()
-                .limit(MAX_KEYWORDS)
-                .collect(Collectors.toList());
+        List<String> keywords = extractKeywords(title);
 
         if (keywords.isEmpty()) return title;
 
@@ -48,12 +46,21 @@ public class KeywordExtractor {
     public static String extractPlain(String title) {
         if (title == null || title.isBlank()) return "";
 
+        return String.join(" ", extractKeywords(title));
+    }
+
+    private static List<String> extractKeywords(String title) {
         return Arrays.stream(title.split("[\\s\\p{Punct}]+"))
                 .filter(word -> word.length() > 2)
-                .filter(word -> !STOP_WORDS.contains(word.toLowerCase()))
+                .filter(KeywordExtractor::isSearchKeyword)
                 .distinct()
                 .limit(MAX_KEYWORDS)
-                .collect(Collectors.joining(" "));
+                .collect(Collectors.toList());
+    }
+
+    private static boolean isSearchKeyword(String word) {
+        String normalized = word.toLowerCase();
+        return !STOP_WORDS.contains(normalized) && !GENERIC_TOKENS.contains(normalized);
     }
 
     private static String formatBooleanModeKeywords(List<String> keywords) {

--- a/src/main/java/com/example/globalTimes_be/domain/detail/util/KeywordExtractor.java
+++ b/src/main/java/com/example/globalTimes_be/domain/detail/util/KeywordExtractor.java
@@ -36,7 +36,7 @@ public class KeywordExtractor {
 
         List<String> keywords = extractKeywords(title);
 
-        if (keywords.isEmpty()) return title;
+        if (keywords.isEmpty()) return "";
 
         // 첫 2개는 필수(+), 나머지는 선택 → FULLTEXT 정확도 향상
         return formatBooleanModeKeywords(keywords);

--- a/src/test/java/com/example/globalTimes_be/domain/detail/util/KeywordExtractorTest.java
+++ b/src/test/java/com/example/globalTimes_be/domain/detail/util/KeywordExtractorTest.java
@@ -7,13 +7,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 class KeywordExtractorTest {
 
     @Test
-    void extract_keepsLeadingTokenPolicyForGenericEnglishWords() {
+    void extract_filtersGenericLeadingTokensForIssueSearch() {
         String title = "First round of US-Iran talks ends with encouraging progress";
 
         assertThat(KeywordExtractor.extractPlain(title))
-                .isEqualTo("First round Iran talks");
+                .isEqualTo("Iran talks ends encouraging");
         assertThat(KeywordExtractor.extract(title))
-                .isEqualTo("+First +round Iran talks");
+                .isEqualTo("+Iran +talks ends encouraging");
     }
 
     @Test
@@ -47,13 +47,13 @@ class KeywordExtractorTest {
     }
 
     @Test
-    void extract_keepsFrenchGeneralTokenBecauseOnlyEnglishStopWordsExist() {
+    void extract_filtersFrenchGeneralTokenFromSample() {
         String title = "Entre Meloni et Trump, divorce a l'italienne";
 
         assertThat(KeywordExtractor.extractPlain(title))
-                .isEqualTo("Entre Meloni Trump divorce");
+                .isEqualTo("Meloni Trump divorce italienne");
         assertThat(KeywordExtractor.extract(title))
-                .isEqualTo("+Entre +Meloni Trump divorce");
+                .isEqualTo("+Meloni +Trump divorce italienne");
     }
 
     @Test

--- a/src/test/java/com/example/globalTimes_be/domain/detail/util/KeywordExtractorTest.java
+++ b/src/test/java/com/example/globalTimes_be/domain/detail/util/KeywordExtractorTest.java
@@ -57,6 +57,14 @@ class KeywordExtractorTest {
     }
 
     @Test
+    void extract_returnsEmptyStringWhenOnlyGenericTokensRemain() {
+        String title = "First round Entre";
+
+        assertThat(KeywordExtractor.extractPlain(title)).isEmpty();
+        assertThat(KeywordExtractor.extract(title)).isEmpty();
+    }
+
+    @Test
     void extract_returnsEmptyStringForNullOrBlankTitle() {
         assertThat(KeywordExtractor.extract(null)).isEmpty();
         assertThat(KeywordExtractor.extract("   ")).isEmpty();


### PR DESCRIPTION
## 관련 이슈
- closed #152

## 변경 타입
- [ ] 기능 추가 (FEAT)
- [ ] 버그 수정 (FIX)
- [ ] 리팩토링 (REFACTOR)
- [x] 테스트/문서 (TEST/CHORE)
- [x] 성능/품질 개선 (PERF)

## 작업 내용
- `KeywordExtractor`에 샘플 기반 일반 토큰 필터를 추가했습니다.
- `first`, `round`, `entre`가 검색어 후보에서 제외되도록 했습니다.
- `extract()`와 `extractPlain()`이 같은 토큰 후보 추출 정책을 공유하도록 `extractKeywords()`로 정리했습니다.
- `KeywordExtractorTest`에서 `First round of US-Iran...` 샘플이 `Iran talks...` 중심으로, `Entre Meloni...` 샘플이 `Meloni Trump...` 중심으로 검색어를 생성하는지 고정했습니다.
- `perspectives-matching-sample-snapshot.md`, `BACKLOG.md`, `WORK_PROGRESS.md`에 #152 진행 맥락과 후속 DB-level 측정 필요성을 기록했습니다.

## 기술적 배경
- #146 샘플 스냅샷에서 `First`, `round`, `Entre` 같은 일반 토큰이 MySQL FULLTEXT BOOLEAN MODE의 required token이 되어 약한 매칭 또는 no match를 만드는 사례가 확인되었습니다.
- #148에서 현행 정책을 테스트로 고정했고, #150에서 BOOLEAN MODE 문자열 포맷을 정규화했습니다.
- 이번 PR은 그 다음 단계로, ranking/entity-aware/translation/DB query 변경 없이 검색어 후보 필터링만 좁게 개선합니다.
- 실제 DB-level FULLTEXT 결과 품질 변화는 이번 PR에서 단정하지 않고 후속 측정 후보로 분리했습니다.

## 테스트/검증
- [x] `./gradlew.bat test`
- [x] `git diff --check`

## 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop` 대상 PR)
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않는가?
- [x] 기존 동작/응답의 변경 범위를 명확히 확인했는가?

## 스크린샷
- 해당 없음

## 리뷰 요구사항
- `KeywordExtractor`가 `first`, `round`, `entre`를 필터링하면서 `BTS`, `Trump`, `Iran`, `Meloni` 같은 핵심 entity 토큰은 유지하는지 확인 부탁드립니다.
- `extract()`와 `extractPlain()`이 같은 토큰 후보 추출 정책을 공유하도록 정리된 것이 과도한 구조 변경은 아닌지 확인 부탁드립니다.
- 이번 PR이 ranking, entity-aware extraction, translation, DB query, Redis cache 정책 변경 없이 검색어 후보 필터링과 테스트/문서 갱신에 머무르는지 확인 부탁드립니다.
- DB-level FULLTEXT 결과 개선을 이번 PR에서 단정하지 않고 후속 측정으로 분리한 문서화가 적절한지 확인 부탁드립니다.

## 추후 계획
- #152 merge 후 대표 샘플(8146, 9440 등)의 실제 DB-level FULLTEXT 결과 변화 측정을 별도 Issue로 분리합니다.
