### PR TITLE
[DOCS/#154] Perspectives 수집 편차와 매칭 품질 해석 한계 LOG

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -50,7 +50,7 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## P3. 다국어 이슈 매칭 품질 개선
 
-- 상태: `Backlog` (최근 완료: [#142](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/142), [#146](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/146), [#148](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/148), [#150](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/150), [#152](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/152))
+- 상태: `In Progress` ([#154](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/154), 최근 완료: [#142](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/142), [#146](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/146), [#148](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/148), [#150](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/150), [#152](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/152))
 - AS-IS: 기사 제목의 키워드와 영어 번역 키워드를 MySQL FULLTEXT 검색에 사용하므로, 표현이 다른 동일 이슈 또는 비영어권 기사 간 매칭이 누락될 수 있다.
 - TO-BE: 기존 후보 검색을 유지하면서 이슈 유사도와 국가 다양성 기준으로 결과를 재정렬하는 정책을 검증한다.
 - 성공 기준:

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -88,6 +88,7 @@ Blocking 예시:
 - #148/#149에서 `KeywordExtractor` 현행 정책을 회귀 테스트로 고정하고, 의미 유사도 개선이 아니라 키워드 후보 탐색 정책임을 명확히 남겼다.
 - #150/#151에서 `KeywordExtractor.extract()`의 MySQL FULLTEXT BOOLEAN MODE 검색어 공백 포맷을 정규화했다.
 - #152/#153에서 `First`, `round`, `Entre` 같은 샘플 기반 일반 토큰을 필터링해 Perspectives 후보 검색어 품질을 개선했다.
+- #154에서는 RSS/News API 수집 편차와 갱신 주기가 FULLTEXT/향후 연관도 측정 해석에 주는 한계를 별도 LOG로 남긴다.
 - 현재 반복 성능/안정성 기본기 흐름의 주요 후보(#123, #127, #129, #131, #133, #137, #140, #142, #146)와 AI workflow 보강(#144)은 merge 완료 상태다.
 
 ### #113 / PR #114 - 백엔드 개선 Backlog 및 AI 작업 운영 규칙 수립
@@ -892,6 +893,39 @@ Reviewer 결과:
 - 재검토 결과 `MERGE_READY`, Blocking 없음, Non-blocking 없음으로 확인했다.
 - `check-review-blocking.ps1 -PrNumber 153` 결과 `MERGE_READY`를 확인했다.
 - 2026-07-04 기준 PR #153은 merge 완료되었고, Issue #152는 closed 상태다.
+
+---
+
+### #154 - Perspectives 데이터 수집 편차와 매칭 품질 해석 한계 LOG
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/154
+- PR: TBD
+- 상태: In Progress
+- 작업 브랜치: `docs/#154-perspectives-source-coverage-log`
+- 주요 파일:
+  - `docs/backend-improvement/perspectives-source-coverage-limit-log.md`
+  - `docs/backend-improvement/perspectives-matching-quality-baseline.md`
+  - `docs/backend-improvement/perspectives-matching-sample-snapshot.md`
+  - `docs/backend-improvement/BACKLOG.md`
+  - `docs/backend-improvement/WORK_PROGRESS.md`
+
+목표:
+
+- RSS/News API 수집 소스별 갱신 주기, 기사 선택 기준, 국가/언론사별 기사 수 편차가 Perspectives 매칭 품질 해석에 주는 영향을 별도 LOG로 남긴다.
+- FULLTEXT, Vector/Embedding, Issue clustering 같은 검색/연관도 기술이 해결할 수 있는 문제와 데이터 공급 문제를 분리한다.
+- #152 이후 DB-level FULLTEXT 결과 변화 측정에서 이 LOG를 해석 기준으로 참조하게 한다.
+
+수정 방향:
+
+- `perspectives-source-coverage-limit-log.md`를 추가한다.
+- 기존 matching quality baseline과 sample snapshot에서 이 LOG를 참조하도록 링크를 추가한다.
+- 코드, DB schema, RSS feed, FULLTEXT query, ranking 정책은 변경하지 않는다.
+
+검증 예정:
+
+```text
+git diff --check
+```
 
 ## 4. 이후 개선 로드맵
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -899,7 +899,7 @@ Reviewer 결과:
 ### #154 - Perspectives 데이터 수집 편차와 매칭 품질 해석 한계 LOG
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/154
-- PR: TBD
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/155
 - 상태: In Progress
 - 작업 브랜치: `docs/#154-perspectives-source-coverage-log`
 - 주요 파일:

--- a/docs/backend-improvement/perspectives-matching-quality-baseline.md
+++ b/docs/backend-improvement/perspectives-matching-quality-baseline.md
@@ -8,6 +8,7 @@ The current implementation uses title keywords, optional English translation, an
 This document defines a small baseline for measuring the current matching quality before introducing heavier search layers such as Elasticsearch, vector search, RAG, or issue clustering.
 
 The first local MySQL snapshot is recorded in `perspectives-matching-sample-snapshot.md`.
+When interpreting any snapshot, also apply `perspectives-source-coverage-limit-log.md` to separate search quality from source coverage and freshness limits.
 
 ## Current Flow
 
@@ -53,6 +54,7 @@ Known behavior:
 - Search results can be recent but weakly related because the final ordering is recency-based.
 - The current model has no stable `issue_id` or article cluster identity.
 - Translating only the extracted base keywords to English favors English matching and does not fully cover all article languages.
+- Matching quality is bounded by collected source coverage; missing or delayed RSS/News API articles cannot be recovered by FULLTEXT or semantic search alone.
 
 ## Sample Selection Criteria
 

--- a/docs/backend-improvement/perspectives-matching-sample-snapshot.md
+++ b/docs/backend-improvement/perspectives-matching-sample-snapshot.md
@@ -6,6 +6,7 @@ This document records a first local snapshot for the Perspectives matching quali
 It follows `perspectives-matching-quality-baseline.md` and uses the local development MySQL data to identify representative samples before introducing heavier search technology.
 
 This snapshot does not change API behavior, DB schema, Redis policy, or search logic.
+Interpret this snapshot together with `perspectives-source-coverage-limit-log.md`, because some low-match cases can be caused by source coverage or feed freshness rather than only FULLTEXT behavior.
 
 ## Environment
 
@@ -40,6 +41,7 @@ Top local article groups:
 | jp | ja | sports | 248 |
 
 The dataset is large enough to test English and non-English candidate behavior, but this snapshot is still a local development sample and should not be treated as production quality evidence.
+It also does not prove that every country/source had a comparable opportunity to publish and be collected for the same issue.
 
 ## Method
 

--- a/docs/backend-improvement/perspectives-source-coverage-limit-log.md
+++ b/docs/backend-improvement/perspectives-source-coverage-limit-log.md
@@ -1,0 +1,97 @@
+# Perspectives source coverage limit log
+
+## Purpose
+
+This log records a data-side limitation that must be considered when interpreting Perspectives matching quality.
+
+Perspectives matching is affected not only by keyword extraction, MySQL FULLTEXT, translation, ranking, or future semantic similarity.
+It is also constrained by the article data that has actually been collected from RSS and News API sources.
+
+This document is a measurement and ADR interpretation aid.
+It does not change crawler behavior, RSS feeds, DB schema, FULLTEXT query shape, ranking, or cache policy.
+
+## Background
+
+The project collects articles from multiple external sources.
+Those sources do not behave like a balanced event dataset:
+
+- each RSS feed can have a different update interval
+- each media source can choose different stories for its RSS feed
+- some countries, languages, or categories can have more collected articles than others
+- a same global issue can appear in one source earlier than another
+- some sources may publish a related article outside the categories or feeds currently collected
+- News API free-plan limitations and RSS feed coverage affect which articles enter the DB
+
+Therefore, Perspectives quality is bounded by both search quality and data coverage.
+
+## Interpretation Rule
+
+When measuring FULLTEXT, keyword, vector, embedding, or future issue-clustering quality, separate these two causes:
+
+| Observation | Search-side interpretation | Data-side interpretation |
+| --- | --- | --- |
+| `0` matches | Query terms, language, tokenization, or ranking may be poor. | Related articles may not exist in the collected DB yet. |
+| Low country diversity | Matching may over-focus on one language or source. | Some country feeds may not have supplied the issue. |
+| No related non-English result | Translation or multilingual search may be insufficient. | Non-English sources may not have published or been collected for that issue. |
+| Noisy matches | Keywords may be too broad or ordering may be recency-biased. | The DB may contain many broad-topic articles but few exact same-issue articles. |
+| Apparent improvement after query tuning | Search terms may be better. | The sample may simply have better available coverage than other issues. |
+
+## FULLTEXT-Specific Limit
+
+MySQL FULLTEXT can only search text that exists in the local `article` table.
+It cannot find:
+
+- articles that have not been collected yet
+- articles from feeds that do not expose the issue
+- articles from sources outside the configured RSS/News API list
+- same-issue articles written with words that do not overlap enough with the generated query
+
+For this reason, a FULLTEXT result change measurement should not conclude "the algorithm is bad" or "the algorithm is fixed" from match count alone.
+It should record returned examples and distinguish search failure from possible source coverage gaps.
+
+## ADR Implication
+
+Future ADRs for Elasticsearch, vector search, embeddings, RAG, or issue clustering should use this boundary:
+
+| Candidate | Can help with | Cannot solve by itself |
+| --- | --- | --- |
+| FULLTEXT tuning | Token/query shape, index use, simple keyword recall | Missing articles or uncollected sources |
+| Better keyword extraction | Noisy title tokens and weak required terms | Source update delay or feed selection bias |
+| Elasticsearch | Search analyzers, ranking, multilingual text handling | Lack of collected same-issue articles |
+| Vector/embedding search | Different wording for the same issue | Articles absent from the DB |
+| Issue clustering | Stable grouping of collected articles | External source coverage and freshness |
+| RAG | Explanation over retrieved content | Retrieval gaps caused by missing source data |
+
+If a representative issue is absent from the collected dataset, search-layer technology cannot recover it.
+The correct follow-up may be source coverage analysis, ingestion scheduling, feed expansion, or data freshness tracking rather than search ranking.
+
+## Measurement Guidance
+
+For every future Perspectives quality snapshot, record:
+
+- measurement date and local dataset size
+- sample article ID, country, language, category, source, and published time when available
+- generated keyword before and after the change
+- match count and returned country/language spread
+- a few returned title notes for manual quality review
+- whether `0` or low-diversity results may be caused by source coverage rather than search behavior
+
+Avoid using match count alone as the success metric.
+Prefer a short interpretation that says whether the result looks like:
+
+- search/query limitation
+- data coverage limitation
+- mixed limitation
+- insufficient evidence
+
+## Link To Current P3 Flow
+
+Current P3 work has already created:
+
+- a matching quality baseline
+- a local FULLTEXT sample snapshot
+- `KeywordExtractor` regression tests
+- BOOLEAN MODE formatting normalization
+- sample-based generic-token filtering
+
+The next DB-level FULLTEXT result measurement should use this log as an interpretation guardrail before deciding whether keyword tuning is enough or whether an ADR is needed.


### PR DESCRIPTION
## 관련 이슈
- closed #154

## 변경 타입
- [ ] 기능 추가 (FEAT)
- [ ] 버그 수정 (FIX)
- [ ] 리팩토링 (REFACTOR)
- [x] 테스트/문서 (TEST/CHORE)

## 작업 내용
- `perspectives-source-coverage-limit-log.md`를 추가했습니다.
- RSS/News API 수집 소스별 갱신 주기, 기사 선택 기준, 국가/언론사별 기사 수 편차가 Perspectives 매칭 품질 해석에 주는 영향을 정리했습니다.
- FULLTEXT, keyword extraction, Elasticsearch, Vector/Embedding, Issue clustering, RAG가 해결할 수 있는 문제와 데이터 공급 문제를 구분했습니다.
- `perspectives-matching-quality-baseline.md`와 `perspectives-matching-sample-snapshot.md`에서 새 LOG를 참조하도록 연결했습니다.
- `BACKLOG.md`, `WORK_PROGRESS.md`에 #154 진행 상태를 기록했습니다.

## 기술적 배경
- #152 이후 FULLTEXT 결과 변화 측정을 진행하기 전에, 검색 결과의 0건/국가 다양성 부족/노이즈가 항상 검색 알고리즘 문제만은 아니라는 해석 기준이 필요했습니다.
- RSS/News API 수집 데이터는 소스별 갱신 주기, 기사 선택 기준, 수집량이 다르기 때문에 같은 이슈라도 국가별/언론사별 기사 공급이 균등하지 않습니다.
- 이 제한사항은 FULLTEXT뿐 아니라 향후 Elasticsearch, Vector DB, Embedding, Issue clustering, RAG ADR 판단에도 영향을 줍니다.

## 테스트/검증
- [x] `git diff --check`

## 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop` 대상 PR)
- [x] 코드/DB schema/크롤러/RSS feed/FULLTEXT query/ranking 정책 변경이 없는가?
- [x] 문서가 #152 이후 DB-level FULLTEXT 결과 측정의 해석 기준으로 연결되는가?

## 스크린샷
- 해당 없음

## 리뷰 요구사항
- 새 LOG가 검색 알고리즘 문제와 수집 데이터 커버리지 문제를 명확히 구분하는지 확인 부탁드립니다.
- FULLTEXT/Vector/Embedding/ADR이 해결할 수 있는 범위와 해결할 수 없는 범위가 과장 없이 설명되었는지 확인 부탁드립니다.
- 기존 README의 구조적 한계 설명과 충돌하지 않고 backend-improvement 측정 문맥으로 보강되는지 확인 부탁드립니다.
- 코드, DB schema, crawler, RSS feed, FULLTEXT query, ranking 정책 변경이 없는지 확인 부탁드립니다.

## 추후 계획
- #154 LOG를 전제로 #152 이후 DB-level FULLTEXT 결과 변화 측정 Issue를 진행합니다.
