### PR TITLE
[PERF/#156] Perspectives #152 이후 FULLTEXT 결과 변화 측정

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -50,7 +50,7 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## P3. 다국어 이슈 매칭 품질 개선
 
-- 상태: `Backlog` (최근 완료: [#142](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/142), [#146](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/146), [#148](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/148), [#150](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/150), [#152](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/152), [#154](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/154))
+- 상태: `In Progress` ([#156](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/156), 최근 완료: [#142](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/142), [#146](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/146), [#148](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/148), [#150](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/150), [#152](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/152), [#154](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/154))
 - AS-IS: 기사 제목의 키워드와 영어 번역 키워드를 MySQL FULLTEXT 검색에 사용하므로, 표현이 다른 동일 이슈 또는 비영어권 기사 간 매칭이 누락될 수 있다.
 - TO-BE: 기존 후보 검색을 유지하면서 이슈 유사도와 국가 다양성 기준으로 결과를 재정렬하는 정책을 검증한다.
 - 성공 기준:

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -89,6 +89,7 @@ Blocking 예시:
 - #150/#151에서 `KeywordExtractor.extract()`의 MySQL FULLTEXT BOOLEAN MODE 검색어 공백 포맷을 정규화했다.
 - #152/#153에서 `First`, `round`, `Entre` 같은 샘플 기반 일반 토큰을 필터링해 Perspectives 후보 검색어 품질을 개선했다.
 - #154/#155에서 RSS/News API 수집 편차와 갱신 주기가 FULLTEXT/향후 연관도 측정 해석에 주는 한계를 별도 LOG로 남겼다.
+- #156에서는 #152 전후 키워드로 대표 샘플의 MySQL FULLTEXT 결과 변화를 측정한다.
 - 현재 반복 성능/안정성 기본기 흐름의 주요 후보(#123, #127, #129, #131, #133, #137, #140, #142, #146)와 AI workflow 보강(#144)은 merge 완료 상태다.
 
 ### #113 / PR #114 - 백엔드 개선 Backlog 및 AI 작업 운영 규칙 수립
@@ -933,6 +934,39 @@ Reviewer 결과:
 - Non-blocking: `WORK_PROGRESS.md`의 `검증 예정` 표현을 완료 상태와 맞추는 문서 정정 제안이 있었고, merge 후 후처리에서 `검증`으로 정리했다.
 - `check-review-blocking.ps1 -PrNumber 155` 결과 `MERGE_READY`를 확인했다.
 - 2026-07-04 기준 PR #155는 merge 완료되었고, Issue #154는 closed 상태다.
+
+---
+
+### #156 - Perspectives #152 일반 토큰 필터링 FULLTEXT 결과 변화 측정
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/156
+- PR: TBD
+- 상태: In Progress
+- 작업 브랜치: `perf/#156-fulltext-after-generic-token-filter`
+- 주요 파일:
+  - `docs/backend-improvement/perspectives-fulltext-generic-token-filter-result.md`
+  - `docs/backend-improvement/perspectives-matching-sample-snapshot.md`
+  - `docs/backend-improvement/BACKLOG.md`
+  - `docs/backend-improvement/WORK_PROGRESS.md`
+
+목표:
+
+- #152에서 일반 토큰 필터링 후 생성 keyword가 바뀐 대표 샘플 8146, 9440의 실제 MySQL FULLTEXT 결과 변화를 측정한다.
+- match count, top 50 국가/언어 분포, 상위 반환 예시를 기록한다.
+- #154 source coverage LOG를 전제로 검색 품질 문제와 데이터 공급 한계를 구분해 해석한다.
+
+측정 결과:
+
+- 8146은 `+First +round Iran talks` 25건에서 `+Iran +talks ends encouraging` 27건으로 바뀌었고, 상위 결과가 스포츠/라운드 노이즈에서 Iran/US talks 중심으로 이동했다.
+- 9440은 `+Entre +Meloni Trump divorce` 0건에서 `+Meloni +Trump divorce italienne` 3건으로 바뀌어 Meloni/Trump 후보가 생겼다.
+- 운영 코드, DB schema, FULLTEXT query, ranking, crawler/RSS feed 정책은 변경하지 않았다.
+
+검증 예정:
+
+```text
+로컬 MySQL FULLTEXT 측정 쿼리
+git diff --check
+```
 
 ## 4. 이후 개선 로드맵
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -940,7 +940,7 @@ Reviewer 결과:
 ### #156 - Perspectives #152 일반 토큰 필터링 FULLTEXT 결과 변화 측정
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/156
-- PR: TBD
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/157
 - 상태: In Progress
 - 작업 브랜치: `perf/#156-fulltext-after-generic-token-filter`
 - 주요 파일:

--- a/docs/backend-improvement/perspectives-fulltext-generic-token-filter-result.md
+++ b/docs/backend-improvement/perspectives-fulltext-generic-token-filter-result.md
@@ -1,0 +1,212 @@
+# Perspectives FULLTEXT generic-token filter result
+
+## Purpose
+
+This document records the DB-level FULLTEXT result change after #152.
+
+#152 changed the Java `KeywordExtractor` policy by filtering sample-based generic tokens:
+
+- `first`
+- `round`
+- `entre`
+
+This measurement checks whether the generated keyword improvement also changes the local MySQL FULLTEXT candidates.
+It does not change API behavior, DB schema, Redis policy, crawler/RSS feeds, ranking, or the FULLTEXT query shape.
+
+Interpret this result together with `perspectives-source-coverage-limit-log.md`.
+The collected source data limits what FULLTEXT can return.
+
+## Environment
+
+| Item | Value |
+| --- | --- |
+| Date | 2026-07-04 |
+| Dataset | Local development MySQL via `docker-compose.dev.yml` |
+| Article rows | 9853 |
+| FULLTEXT index | `ft_article_title_description(title, description)` |
+| Query path | MySQL FULLTEXT query shaped like `ArticleRepository.findPerspectives` |
+| External translation API | Not called |
+| Redis cache | Not used |
+
+Sensitive local `.env` values and external API responses are intentionally excluded.
+
+## Query Shape
+
+```sql
+SELECT *
+FROM article
+WHERE article_id != :baseArticleId
+  AND MATCH(title, description) AGAINST(:keywords IN BOOLEAN MODE)
+ORDER BY published_at DESC
+LIMIT 50;
+```
+
+For this measurement, `match count` means the number of rows matching the FULLTEXT predicate before the `LIMIT 50`.
+Country/language spread and returned examples use the same latest-first ordering as `findPerspectives`.
+
+## Summary
+
+| Base article ID | Base title note | Before keyword | Before count | After keyword | After count | Initial interpretation |
+| --- | --- | --- | ---: | --- | ---: | --- |
+| 8146 | US-Iran talks | `+First +round Iran talks` | 25 | `+Iran +talks ends encouraging` | 27 | Improved: top results move from sports/broad `round` noise to Iran/US talks. |
+| 9440 | Meloni/Trump French sample | `+Entre +Meloni Trump divorce` | 0 | `+Meloni +Trump divorce italienne` | 3 | Improved recall, but still limited by available source coverage. |
+
+## 8146: US-Iran Talks
+
+Base title:
+
+```text
+First round of US-Iran talks ends with 'encouraging progress', mediators say
+```
+
+### Before #152
+
+Keyword:
+
+```text
++First +round Iran talks
+```
+
+Country/language spread:
+
+| Country | Language | Count |
+| --- | --- | ---: |
+| us | en | 14 |
+| us | null | 5 |
+| cn | zh | 4 |
+| gb | en | 2 |
+
+Top returned examples:
+
+| Article ID | Country | Language | Title note |
+| --- | --- | --- | --- |
+| 8413 | gb | en | Yamashita denies Woad third LPGA title in play-off |
+| 7845 | us | en | USMNT Round of 32 match price |
+| 9744 | cn | zh | China AI rivalry funding |
+| 6566 | gb | en | PGA Tour round |
+| 6247 | us | en | OSU stars and 1st round |
+| 7667 | cn | zh | New Zealand players facing Iran |
+| 6100 | cn | zh | Miami Open |
+| 4427 | us | en | March Madness second round |
+
+Interpretation:
+
+- `First` and `round` required broad sports and tournament-style matches.
+- The match count was non-zero, but the first returned examples were mostly weak matches.
+- This looked like a search-side keyword problem rather than only source coverage.
+
+### After #152
+
+Keyword:
+
+```text
++Iran +talks ends encouraging
+```
+
+Country/language spread:
+
+| Country | Language | Count |
+| --- | --- | ---: |
+| global | en | 13 |
+| cn | zh | 7 |
+| gb | en | 3 |
+| us | en | 2 |
+| de | en | 1 |
+| global | null | 1 |
+
+Top returned examples:
+
+| Article ID | Country | Language | Title note |
+| --- | --- | --- | --- |
+| 9652 | cn | zh | Blockade lifted, assets returned to Iran in Swiss talks |
+| 9667 | cn | zh | Iran-US talks continue |
+| 8086 | global | en | Iran war live and Switzerland |
+| 8091 | global | en | US-Iran talks to kick off Sunday |
+| 7939 | global | en | US-Iran talks begin in Switzerland |
+| 8114 | global | en | US envoy headed for Switzerland |
+| 8129 | global | en | Israel-Lebanon talks in Washington |
+| 8136 | global | en | Israel attacks Lebanon despite ceasefire |
+
+Interpretation:
+
+- The top results became much more centered on Iran/US talks and nearby Middle East diplomacy.
+- Some broader regional diplomacy/noise remains, which is expected because `ORDER BY published_at DESC` is still recency-based, not relevance-based.
+- This supports #152 as a useful keyword-side improvement for this sample.
+
+## 9440: Meloni/Trump French Sample
+
+Base title:
+
+```text
+Entre Meloni et Trump, divorce à l'italienne
+```
+
+### Before #152
+
+Keyword:
+
+```text
++Entre +Meloni Trump divorce
+```
+
+Result:
+
+| Metric | Value |
+| --- | ---: |
+| Match count | 0 |
+
+Interpretation:
+
+- `Entre` as a required token blocked recall for this sample.
+- Because the result was zero, we cannot tell from this query alone how much of the failure came from keyword choice versus source coverage.
+
+### After #152
+
+Keyword:
+
+```text
++Meloni +Trump divorce italienne
+```
+
+Country/language spread:
+
+| Country | Language | Count |
+| --- | --- | ---: |
+| global | en | 2 |
+| de | de | 1 |
+
+Top returned examples:
+
+| Article ID | Country | Language | Title note |
+| --- | --- | --- | --- |
+| 8096 | global | en | Trump says Italy's Meloni sought photos with him |
+| 8134 | global | en | Italy diplomat and Meloni/Trump fabricated story |
+| 9517 | de | de | German article about Meloni and Trump |
+
+Interpretation:
+
+- Filtering `Entre` produced a small but concrete recall improvement: `0` to `3`.
+- The available matches are related to Meloni/Trump, but the result set remains small.
+- Per `perspectives-source-coverage-limit-log.md`, this should be interpreted as mixed: keyword-side improvement plus likely source coverage/data availability limits.
+
+## Result Interpretation
+
+Observed improvement:
+
+- #152 improved generated keyword focus for the weak generic-token samples.
+- The DB-level result for 8146 moved away from sports/tournament noise and toward Iran/US talks.
+- The DB-level result for 9440 changed from no match to a small Meloni/Trump candidate set.
+
+Remaining limits:
+
+- Result ordering is still latest-first, not relevance-first.
+- FULLTEXT still requires enough textual overlap in collected `title`/`description`.
+- Missing or delayed RSS/News API source data cannot be recovered by keyword tuning.
+- The measurement does not call the full API path, translation API, or Redis.
+
+## Follow-Up Candidates
+
+1. Compare latest-first ordering with relevance-first or hybrid ordering for the same samples.
+2. Measure the full API path with translation enabled for non-English base articles, with external API usage explicitly approved.
+3. Add source coverage/freshness metrics for representative issues before choosing Elasticsearch, vector search, or issue clustering.
+4. Expand generic-token filtering only with additional measured samples, not as a broad stop-word list by intuition.

--- a/docs/backend-improvement/perspectives-matching-sample-snapshot.md
+++ b/docs/backend-improvement/perspectives-matching-sample-snapshot.md
@@ -148,6 +148,7 @@ After #150 and #152, the Java `KeywordExtractor` policy changes the generated ke
 This section documents generated keyword changes only.
 It does not replace the original match counts, because DB-level FULLTEXT result quality should be measured separately after the code change is merged.
 If all extracted candidates are removed by the generic-token filter, both `extract()` and `extractPlain()` return an empty string instead of falling back to the original title.
+The DB-level FULLTEXT result change after #152 is recorded in `perspectives-fulltext-generic-token-filter-result.md`.
 
 ## Follow-up Candidates
 


### PR DESCRIPTION
## 관련 이슈
- closed #156

## 변경 타입
- [ ] 기능 추가 (FEAT)
- [ ] 버그 수정 (FIX)
- [ ] 리팩토링 (REFACTOR)
- [x] 테스트/문서 (TEST/CHORE)
- [x] 성능/품질 측정 (PERF)

## 작업 내용
- `perspectives-fulltext-generic-token-filter-result.md`를 추가했습니다.
- #152 일반 토큰 필터링 전/후 keyword로 로컬 개발 MySQL FULLTEXT 결과를 비교했습니다.
- 대표 샘플 8146, 9440의 match count, top 50 국가/언어 분포, 상위 반환 예시를 기록했습니다.
- `perspectives-matching-sample-snapshot.md`에서 새 측정 문서를 참조하도록 연결했습니다.
- `WORK_PROGRESS.md`, `BACKLOG.md`에 #156 진행 상태를 기록했습니다.

## 측정 요약
- 8146 US-Iran talks:
  - Before: `+First +round Iran talks`, 25건, 상위 결과에 LPGA/PGA/March Madness 등 sports/round 노이즈가 섞임
  - After: `+Iran +talks ends encouraging`, 27건, 상위 결과가 Iran/US talks와 중동 외교 이슈 중심으로 이동
- 9440 Meloni/Trump French sample:
  - Before: `+Entre +Meloni Trump divorce`, 0건
  - After: `+Meloni +Trump divorce italienne`, 3건, Meloni/Trump 관련 후보가 생성됨

## 기술적 배경
- #152는 검색어 생성 정책을 개선했지만, 실제 MySQL FULLTEXT 후보 결과 변화는 별도로 측정해야 했습니다.
- #154 LOG에 따라 이번 결과는 검색 품질과 수집 데이터 커버리지 한계를 분리해 해석했습니다.
- 이번 PR은 DB-level 직접 측정이며, full API path, translation API, Redis cache는 측정하지 않았습니다.

## 테스트/검증
- [x] 로컬 개발 MySQL 컨테이너 확인: article 9853 rows, `ft_article_title_description(title, description)` FULLTEXT index 존재
- [x] #152 전/후 FULLTEXT query 실행
- [x] `git diff --check`

## 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop` 대상 PR)
- [x] 코드/DB schema/FULLTEXT query/crawler/RSS feed/ranking 정책 변경이 없는가?
- [x] match count만으로 품질을 단정하지 않고 반환 예시와 source coverage 한계를 함께 기록했는가?

## 스크린샷
- 해당 없음

## 리뷰 요구사항
- 측정 문서가 #152 전/후 FULLTEXT 결과 변화를 정확히 비교하는지 확인 부탁드립니다.
- 8146/9440 해석이 match count만으로 과장되지 않고 반환 예시와 #154 source coverage 한계를 함께 고려하는지 확인 부탁드립니다.
- 이번 PR이 코드, DB schema, FULLTEXT query, crawler/RSS feed, ranking 정책 변경 없이 문서/측정 범위에 머무르는지 확인 부탁드립니다.
- `WORK_PROGRESS.md`, `BACKLOG.md`, `perspectives-matching-sample-snapshot.md` 링크가 #156 진행 상태와 목적을 정확히 반영하는지 확인 부탁드립니다.

## 추후 계획
- 같은 샘플에서 relevance-first 또는 hybrid ordering 비교를 별도 Issue로 검토합니다.
- non-English full API path 측정은 translation API 사용 승인 후 별도 Issue로 분리합니다.
