### PR TITLE
📝 [DOCS/#158] backend-improvement 다음 세션 handoff 문서 정리

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -53,6 +53,7 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 - 상태: `Backlog` (최근 완료: [#142](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/142), [#146](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/146), [#148](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/148), [#150](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/150), [#152](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/152), [#154](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/154), [#156](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/156))
 - AS-IS: 기사 제목의 키워드와 영어 번역 키워드를 MySQL FULLTEXT 검색에 사용하므로, 표현이 다른 동일 이슈 또는 비영어권 기사 간 매칭이 누락될 수 있다.
 - TO-BE: 기존 후보 검색을 유지하면서 이슈 유사도와 국가 다양성 기준으로 결과를 재정렬하는 정책을 검증한다.
+- 다음 추천 후보: #156에서 8146 샘플의 keyword 품질은 개선됐지만 최신순 정렬 때문에 Lebanon/ceasefire 같은 인접 노이즈가 남았다. 따라서 다음 단계는 `[PERF] Perspectives FULLTEXT relevance-first/hybrid ordering 비교`로, 현재 `ORDER BY published_at DESC`와 FULLTEXT score 기반 정렬 또는 hybrid 정렬을 같은 샘플에서 비교하는 것이다.
 - 성공 기준:
   - 대표 이슈 샘플과 기대 국가를 정의한다.
   - 개선 전후의 국가별 관련 기사 노출 수와 매칭 근거를 비교한다.

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -1,0 +1,121 @@
+# Backend Improvement Next Agent Brief
+
+이 문서는 새 Codex 세션이 `WORK_PROGRESS.md` 전체를 읽기 전에 현재 상태를 빠르게 복원하기 위한 짧은 handoff 문서다.
+상세한 이력과 근거는 `WORK_PROGRESS.md`, `BACKLOG.md`, 개별 측정 문서를 기준으로 확인한다.
+
+## Read Order
+
+1. `docs/backend-improvement/NEXT_AGENT_BRIEF.md`
+2. `docs/backend-improvement/WORK_PROGRESS.md`
+3. `docs/backend-improvement/BACKLOG.md`
+4. 현재 후보와 직접 관련된 측정/설계 문서
+
+## Workflow
+
+모든 작업은 아래 순서로 진행한다.
+
+```text
+Issue
+→ Branch
+→ 조사
+→ 계획
+→ 승인
+→ 구현
+→ 테스트
+→ PR
+→ AI Reviewer comment
+→ Blocking 확인
+→ merge
+→ WORK_PROGRESS.md 갱신
+```
+
+바로 구현하지 말고, 먼저 develop 최신화, 열린 Issue/PR 확인, `WORK_PROGRESS.md`와 `BACKLOG.md` 조사를 수행한다.
+새 Issue/PR 본문은 repository template을 읽고 반드시 `--body-file` 방식으로 작성한다.
+
+## Current Snapshot
+
+- Repo: `SKU-GlobalTimes/GlobalTimes_BeSide`
+- Base branch: `develop`
+- Long-running open issue: #110 `[Troubleshooting] 서비스 설계의 근본적 한계`
+- #110은 사용자가 별도로 지시하기 전까지 구현하거나 정리하지 않는다.
+- 최근 열린 PR은 없는 상태에서 #158 문서화 작업을 시작했다.
+
+## Recent Completed Work
+
+- #148/#149: `KeywordExtractor` 현행 정책을 회귀 테스트로 고정하고, 현재 정책이 의미 유사도 검색이 아니라 제목 토큰 기반 후보 탐색임을 명확히 했다.
+- #150/#151: MySQL FULLTEXT BOOLEAN MODE 검색어 포맷을 `+first +second third` 형태의 단일 공백 조립으로 정규화했다.
+- #152/#153: `First`, `round`, `Entre` 같은 샘플 기반 일반 토큰을 필터링해 weak keyword 후보를 줄였다.
+- #154/#155: RSS/News API 수집 편차와 source coverage 한계가 FULLTEXT/향후 연관도 측정 해석에 주는 영향을 별도 LOG로 남겼다.
+- #156/#157: #152 전후 DB-level FULLTEXT 결과 변화를 측정했다.
+
+## Why #156 Matters
+
+#156에서 대표 샘플 8146은 키워드가 `+First +round Iran talks`에서 `+Iran +talks ends encouraging`로 바뀌며 상위 결과가 스포츠/라운드 노이즈에서 Iran/US talks 중심으로 이동했다.
+다만 현재 쿼리는 여전히 `ORDER BY published_at DESC` 최신순이라 Lebanon/ceasefire 같은 인접 노이즈가 남는다.
+
+이 때문에 다음 P3 후보는 keyword extractor를 더 넓게 만지는 것보다, 동일 후보군에서 정렬 기준을 비교하는 작업이 자연스럽다.
+
+## Recommended Next Backend Issue
+
+추천 후보:
+
+```text
+[PERF] Perspectives FULLTEXT relevance-first/hybrid ordering 비교
+```
+
+목표:
+
+- 현재 latest-first 정렬과 `MATCH(title, description) AGAINST(...)` score 기반 relevance-first 정렬을 비교한다.
+- 필요하면 relevance score와 `published_at`을 함께 쓰는 hybrid ordering 후보를 비교한다.
+- 8146, 9440, 8147, 8149 같은 기존 대표 샘플을 우선 사용한다.
+- API 동작을 바로 변경하기보다 DB-level 측정 문서부터 만든다.
+
+판단 기준:
+
+- 관련성 높은 기사들이 상위에 더 안정적으로 올라오는가?
+- 국가/언어 다양성이 과하게 무너지지 않는가?
+- 최신성 요구와 relevance 요구의 trade-off가 설명 가능한가?
+- source coverage 한계 때문에 생기는 누락을 ranking 문제로 오판하지 않는가?
+
+참고 문서:
+
+- `docs/backend-improvement/perspectives-fulltext-generic-token-filter-result.md`
+- `docs/backend-improvement/perspectives-matching-sample-snapshot.md`
+- `docs/backend-improvement/perspectives-source-coverage-limit-log.md`
+- `docs/backend-improvement/perspectives-matching-quality-baseline.md`
+
+## Handoff Design Note
+
+긴 `WORK_PROGRESS.md`는 전체 audit log 역할을 하므로 유지한다.
+이 문서는 새 세션의 context 비용을 줄이기 위한 index 역할만 한다.
+
+다음 에이전트가 더 적은 context로도 진행도를 놓치지 않게 하려면 다음 원칙을 지킨다.
+
+- 이 문서에는 최신 상태와 다음 판단만 남긴다.
+- 세부 측정값, Reviewer 결과, merge 이력은 `WORK_PROGRESS.md`와 개별 문서에 남긴다.
+- 새 작업을 시작하거나 merge할 때 이 문서의 `Current Snapshot`과 `Recommended Next Backend Issue`를 갱신한다.
+- 의사결정 근거를 압축하되, 근거 문서 링크는 반드시 남긴다.
+
+## Reviewer Agent Prompt Template
+
+```text
+너는 Reviewer Agent다.
+코드 수정은 하지 말고 PR diff만 검토해줘.
+
+Repo: SKU-GlobalTimes/GlobalTimes_BeSide
+PR: <PR URL>
+Issue: #<ISSUE NUMBER>
+
+검토 관점:
+1. 이번 PR이 문서/handoff 구조 정리 범위에 머무르는가?
+2. NEXT_AGENT_BRIEF.md가 새 세션이 현재 workflow, 최근 완료 작업, #110 제외 조건, 다음 추천 후보를 빠르게 파악하기에 충분한가?
+3. WORK_PROGRESS.md와 BACKLOG.md가 Issue 목적과 진행 상태를 정확히 반영하는가?
+4. #156 이후 다음 후보로 FULLTEXT relevance-first/hybrid ordering 비교를 제안하는 근거가 기존 측정 문서와 일치하는가?
+5. 민감 정보가 포함되어 있지 않은가?
+6. 새 Blocking이 있는가?
+
+제약:
+- 코드 직접 수정 금지
+- 커밋, push, merge 금지
+- 리뷰 결과는 ## AI Reviewer 검토 결과 제목으로 GitHub PR comment에 직접 남겨줘.
+```

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -981,7 +981,7 @@ Reviewer 결과:
 ### #158 - backend-improvement 다음 세션 handoff 문서 정리
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/158
-- PR: 생성 예정
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/159
 - 상태: In Progress
 - 작업 브랜치: `docs/#158-next-agent-brief`
 - 주요 파일:

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -90,6 +90,7 @@ Blocking 예시:
 - #152/#153에서 `First`, `round`, `Entre` 같은 샘플 기반 일반 토큰을 필터링해 Perspectives 후보 검색어 품질을 개선했다.
 - #154/#155에서 RSS/News API 수집 편차와 갱신 주기가 FULLTEXT/향후 연관도 측정 해석에 주는 한계를 별도 LOG로 남겼다.
 - #156/#157에서 #152 전후 키워드로 대표 샘플의 MySQL FULLTEXT 결과 변화를 측정했다.
+- #158에서 긴 `WORK_PROGRESS.md`를 보완하기 위한 다음 세션 handoff 문서를 정리 중이다.
 - 현재 반복 성능/안정성 기본기 흐름의 주요 후보(#123, #127, #129, #131, #133, #137, #140, #142, #146)와 AI workflow 보강(#144)은 merge 완료 상태다.
 
 ### #113 / PR #114 - 백엔드 개선 Backlog 및 AI 작업 운영 규칙 수립
@@ -975,6 +976,37 @@ Reviewer 결과:
 - `check-review-blocking.ps1 -PrNumber 157` 결과 `MERGE_READY`를 확인했다.
 - 2026-07-04 기준 PR #157은 merge 완료되었고, Issue #156은 closed 상태다.
 
+---
+
+### #158 - backend-improvement 다음 세션 handoff 문서 정리
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/158
+- PR: 생성 예정
+- 상태: In Progress
+- 작업 브랜치: `docs/#158-next-agent-brief`
+- 주요 파일:
+  - `docs/backend-improvement/NEXT_AGENT_BRIEF.md`
+  - `docs/backend-improvement/BACKLOG.md`
+  - `docs/backend-improvement/WORK_PROGRESS.md`
+
+목표:
+
+- `WORK_PROGRESS.md`가 장기 audit log로 길어지는 것은 유지하되, 새 Codex 세션이 먼저 읽을 짧은 handoff 문서를 추가한다.
+- 다음 세션이 workflow, 최근 완료 작업, #110 제외 조건, 다음 추천 후보를 빠르게 파악할 수 있게 한다.
+- #156 결과에서 드러난 최신순 정렬의 한계를 바탕으로 다음 추천 후보를 `Perspectives FULLTEXT relevance-first/hybrid ordering 비교`로 명시한다.
+
+수정 방향:
+
+- `NEXT_AGENT_BRIEF.md`를 추가해 읽는 순서, 현재 snapshot, 최근 완료 작업, 다음 추천 이슈, Reviewer 요청 템플릿을 정리한다.
+- `BACKLOG.md`의 P3에 #156 이후 다음 후보와 판단 기준을 추가한다.
+- 코드, DB schema, API 동작, crawler/RSS feed, Redis 정책은 변경하지 않는다.
+
+검증 예정:
+
+```text
+git diff --check
+```
+
 ## 4. 이후 개선 로드맵
 
 ### A. #123 이후 바로 할 수 있는 성능 개선
@@ -1161,7 +1193,8 @@ PR comment 조회
 
 ## 5. 다음 세션에서 바로 이어가기 위한 시작 프롬프트
 
-새 Codex 세션에서 이어갈 때 아래 내용을 전달하면 된다.
+새 Codex 세션에서 이어갈 때는 먼저 `docs/backend-improvement/NEXT_AGENT_BRIEF.md`를 읽고, 더 자세한 이력이 필요할 때 이 문서를 읽는다.
+아래 내용은 간단한 시작 프롬프트로 사용할 수 있다.
 
 ```text
 GlobalTimes_BeSide 백엔드 개선 작업을 이어서 진행하려고 합니다.


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #158

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)


## 📝 작업 내용
- `docs/backend-improvement/NEXT_AGENT_BRIEF.md`를 추가해 새 Codex 세션이 먼저 읽을 짧은 handoff 문서를 마련했습니다.
- `WORK_PROGRESS.md`에 #158 In Progress 상태와 handoff 문서 사용 방식을 기록했습니다.
- `BACKLOG.md`의 P3에 #156 이후 다음 추천 후보로 FULLTEXT relevance-first/hybrid ordering 비교를 명시했습니다.

## 🔍 기술적 배경
- `WORK_PROGRESS.md`는 장기 audit log 역할을 하므로 계속 상세하게 유지하되, 새 세션이 매번 전체 이력을 읽기 전에 현재 상태와 다음 판단을 빠르게 복원할 수 있는 index 문서가 필요했습니다.
- #156 측정에서 8146 샘플의 keyword 품질은 개선됐지만, `ORDER BY published_at DESC` 최신순 정렬 때문에 Lebanon/ceasefire 같은 인접 노이즈가 남았습니다.
- 따라서 다음 개선 후보는 keyword extractor 확장보다 동일 FULLTEXT 후보군에서 relevance-first 또는 hybrid ordering을 비교하는 작업이 자연스럽다고 정리했습니다.


## 🧪 테스트/검증 (필수)
- [x] `git diff --check`로 문서 diff 공백 오류가 없음을 확인했습니다.
- [x] 코드, DB schema, API 동작, crawler/RSS feed, Redis 정책 변경이 없고 문서 변경 범위임을 확인했습니다.


## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?


## 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
- `NEXT_AGENT_BRIEF.md`가 다음 Implementer Agent에게 필요한 workflow, 최근 완료 작업, #110 제외 조건, 다음 추천 후보를 충분히 전달하는지 봐주세요.
- #156 이후 다음 후보로 FULLTEXT relevance-first/hybrid ordering 비교를 제안한 근거가 기존 측정 문서와 충돌하지 않는지 봐주세요.


## ➕ 추후 계획(선택)
- 다음 백엔드 개선 후보로 `[PERF] Perspectives FULLTEXT relevance-first/hybrid ordering 비교` 이슈를 생성해 DB-level 측정부터 진행할 예정입니다.
