### PR TITLE
📊 [PERF/#160] Perspectives FULLTEXT 정렬 기준 비교

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -53,7 +53,7 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 - 상태: `In Progress` ([#160](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/160), 최근 완료: [#142](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/142), [#146](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/146), [#148](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/148), [#150](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/150), [#152](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/152), [#154](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/154), [#156](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/156))
 - AS-IS: 기사 제목의 키워드와 영어 번역 키워드를 MySQL FULLTEXT 검색에 사용하므로, 표현이 다른 동일 이슈 또는 비영어권 기사 간 매칭이 누락될 수 있다.
 - TO-BE: 기존 후보 검색을 유지하면서 이슈 유사도와 국가 다양성 기준으로 결과를 재정렬하는 정책을 검증한다.
-- 다음 추천 후보: #156에서 8146 샘플의 keyword 품질은 개선됐지만 최신순 정렬 때문에 Lebanon/ceasefire 같은 인접 노이즈가 남았다. 따라서 다음 단계는 `[PERF] Perspectives FULLTEXT relevance-first/hybrid ordering 비교`로, 현재 `ORDER BY published_at DESC`와 FULLTEXT score 기반 정렬 또는 hybrid 정렬을 같은 샘플에서 비교하는 것이다.
+- 현재 측정: #160에서 `ORDER BY published_at DESC` latest-first, FULLTEXT score 기반 relevance-first, bounded recency signal을 더한 hybrid 후보를 비교한다. 초기 측정상 pure relevance-first는 wrong-context 기사도 끌어올릴 수 있어, 후속 코드 변경은 hybrid 후보 중심으로 검토하는 것이 안전하다.
 - 성공 기준:
   - 대표 이슈 샘플과 기대 국가를 정의한다.
   - 개선 전후의 국가별 관련 기사 노출 수와 매칭 근거를 비교한다.

--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -50,7 +50,7 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## P3. 다국어 이슈 매칭 품질 개선
 
-- 상태: `Backlog` (최근 완료: [#142](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/142), [#146](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/146), [#148](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/148), [#150](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/150), [#152](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/152), [#154](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/154), [#156](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/156))
+- 상태: `In Progress` ([#160](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/160), 최근 완료: [#142](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/142), [#146](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/146), [#148](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/148), [#150](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/150), [#152](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/152), [#154](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/154), [#156](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/156))
 - AS-IS: 기사 제목의 키워드와 영어 번역 키워드를 MySQL FULLTEXT 검색에 사용하므로, 표현이 다른 동일 이슈 또는 비영어권 기사 간 매칭이 누락될 수 있다.
 - TO-BE: 기존 후보 검색을 유지하면서 이슈 유사도와 국가 다양성 기준으로 결과를 재정렬하는 정책을 검증한다.
 - 다음 추천 후보: #156에서 8146 샘플의 keyword 품질은 개선됐지만 최신순 정렬 때문에 Lebanon/ceasefire 같은 인접 노이즈가 남았다. 따라서 다음 단계는 `[PERF] Perspectives FULLTEXT relevance-first/hybrid ordering 비교`로, 현재 `ORDER BY published_at DESC`와 FULLTEXT score 기반 정렬 또는 hybrid 정렬을 같은 샘플에서 비교하는 것이다.

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -71,6 +71,7 @@ Issue
 - 필요하면 relevance score와 `published_at`을 함께 쓰는 hybrid ordering 후보를 비교한다.
 - 8146, 9440, 8147, 8149 같은 기존 대표 샘플을 우선 사용한다.
 - API 동작을 바로 변경하기보다 DB-level 측정 문서부터 만든다.
+- #160 측정 문서는 `docs/backend-improvement/perspectives-fulltext-ordering-comparison.md`에 기록한다.
 
 판단 기준:
 
@@ -78,10 +79,12 @@ Issue
 - 국가/언어 다양성이 과하게 무너지지 않는가?
 - 최신성 요구와 relevance 요구의 trade-off가 설명 가능한가?
 - source coverage 한계 때문에 생기는 누락을 ranking 문제로 오판하지 않는가?
+- pure relevance-first가 wrong-context 기사를 과하게 올리지 않는가?
 
 참고 문서:
 
 - `docs/backend-improvement/perspectives-fulltext-generic-token-filter-result.md`
+- `docs/backend-improvement/perspectives-fulltext-ordering-comparison.md`
 - `docs/backend-improvement/perspectives-matching-sample-snapshot.md`
 - `docs/backend-improvement/perspectives-source-coverage-limit-log.md`
 - `docs/backend-improvement/perspectives-matching-quality-baseline.md`

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -39,7 +39,7 @@ Issue
 - Long-running open issue: #110 `[Troubleshooting] 서비스 설계의 근본적 한계`
 - #110은 사용자가 별도로 지시하기 전까지 구현하거나 정리하지 않는다.
 - #158/#159에서 다음 세션 handoff 문서 정리를 완료했다.
-- 다음 추천 후보는 Perspectives FULLTEXT relevance-first/hybrid ordering 비교다.
+- 현재 진행 후보는 #160 Perspectives FULLTEXT relevance-first/hybrid ordering 비교다.
 
 ## Recent Completed Work
 
@@ -62,7 +62,7 @@ Issue
 추천 후보:
 
 ```text
-[PERF] Perspectives FULLTEXT relevance-first/hybrid ordering 비교
+[PERF] Perspectives FULLTEXT relevance-first/hybrid ordering 비교 (#160)
 ```
 
 목표:

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -91,6 +91,7 @@ Blocking 예시:
 - #154/#155에서 RSS/News API 수집 편차와 갱신 주기가 FULLTEXT/향후 연관도 측정 해석에 주는 한계를 별도 LOG로 남겼다.
 - #156/#157에서 #152 전후 키워드로 대표 샘플의 MySQL FULLTEXT 결과 변화를 측정했다.
 - #158/#159에서 긴 `WORK_PROGRESS.md`를 보완하기 위한 다음 세션 handoff 문서를 정리했다.
+- #160에서 Perspectives FULLTEXT 정렬 기준을 latest-first, relevance-first, hybrid ordering으로 비교하는 작업을 시작했다.
 - 현재 반복 성능/안정성 기본기 흐름의 주요 후보(#123, #127, #129, #131, #133, #137, #140, #142, #146)와 AI workflow 보강(#144)은 merge 완료 상태다.
 
 ### #113 / PR #114 - 백엔드 개선 Backlog 및 AI 작업 운영 규칙 수립
@@ -1013,6 +1014,38 @@ Reviewer 결과:
 - Non-blocking: `WORK_PROGRESS.md`의 `검증 예정` 표현을 완료 상태와 맞추는 문서 정정 제안이 있었고, merge 후 후처리에서 `검증`으로 정리했다.
 - `check-review-blocking.ps1 -PrNumber 159` 결과 `MERGE_READY`를 확인했다.
 - 2026-07-07 기준 PR #159는 merge 완료되었고, Issue #158은 closed 상태다.
+
+---
+
+### #160 - Perspectives FULLTEXT relevance-first/hybrid ordering 비교
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/160
+- PR: 생성 예정
+- 상태: In Progress
+- 작업 브랜치: `perf/#160-perspectives-fulltext-ordering-comparison`
+- 주요 파일:
+  - `docs/backend-improvement/perspectives-fulltext-ordering-comparison.md` 예정
+  - `docs/backend-improvement/BACKLOG.md`
+  - `docs/backend-improvement/NEXT_AGENT_BRIEF.md`
+  - `docs/backend-improvement/WORK_PROGRESS.md`
+
+목표:
+
+- #156에서 keyword 품질 개선 후에도 남은 최신순 정렬 노이즈를 분리해 확인한다.
+- 현재 운영 쿼리와 같은 latest-first, FULLTEXT score 기반 relevance-first, relevance와 최신성을 함께 보는 hybrid ordering을 같은 샘플에서 비교한다.
+- API 동작을 바로 변경하지 않고 DB-level 측정 문서로 후속 코드 변경 판단 근거를 만든다.
+
+조사 메모:
+
+- `ArticleRepository.findPerspectives`는 `MATCH(title, description) AGAINST(:keywords IN BOOLEAN MODE)`로 후보를 찾고 `ORDER BY published_at DESC LIMIT 50`으로 정렬한다.
+- #156 문서 기준 8146은 keyword 개선 후 Iran/US talks 중심으로 좋아졌지만 Lebanon/ceasefire 같은 인접 노이즈가 최신순 상위에 남았다.
+- 2026-07-08 기준 Docker daemon이 실행 중이 아니어서 로컬 MySQL 측정은 Docker Desktop 또는 컨테이너 시작 후 진행해야 한다.
+
+계획:
+
+- 8146, 9440, 8147, 8149 샘플을 우선 대상으로 삼는다.
+- 각 샘플에서 latest-first, relevance-first, hybrid ordering의 top results와 score, 국가/언어 분포를 비교한다.
+- source coverage 한계로 인한 누락과 ranking 문제를 분리해 해석한다.
 
 ## 4. 이후 개선 로드맵
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -1024,7 +1024,7 @@ Reviewer 결과:
 - 상태: In Progress
 - 작업 브랜치: `perf/#160-perspectives-fulltext-ordering-comparison`
 - 주요 파일:
-  - `docs/backend-improvement/perspectives-fulltext-ordering-comparison.md` 예정
+  - `docs/backend-improvement/perspectives-fulltext-ordering-comparison.md`
   - `docs/backend-improvement/BACKLOG.md`
   - `docs/backend-improvement/NEXT_AGENT_BRIEF.md`
   - `docs/backend-improvement/WORK_PROGRESS.md`
@@ -1040,12 +1040,28 @@ Reviewer 결과:
 - `ArticleRepository.findPerspectives`는 `MATCH(title, description) AGAINST(:keywords IN BOOLEAN MODE)`로 후보를 찾고 `ORDER BY published_at DESC LIMIT 50`으로 정렬한다.
 - #156 문서 기준 8146은 keyword 개선 후 Iran/US talks 중심으로 좋아졌지만 Lebanon/ceasefire 같은 인접 노이즈가 최신순 상위에 남았다.
 - 2026-07-08 기준 Docker daemon이 실행 중이 아니어서 로컬 MySQL 측정은 Docker Desktop 또는 컨테이너 시작 후 진행해야 한다.
+- 이후 Docker 컨테이너 실행을 확인하고 local MySQL에서 측정을 진행했다.
 
 계획:
 
 - 8146, 9440, 8147, 8149 샘플을 우선 대상으로 삼는다.
 - 각 샘플에서 latest-first, relevance-first, hybrid ordering의 top results와 score, 국가/언어 분포를 비교한다.
 - source coverage 한계로 인한 누락과 ranking 문제를 분리해 해석한다.
+
+측정 결과:
+
+- 모든 측정 샘플은 match count가 50개 미만이므로 candidate set은 동일하고 top ordering만 달라진다.
+- 8146은 latest-first가 최신 Iran/US talks 흐름을 유지하지만 Lebanon/ceasefire 인접 노이즈를 상위에 남겼고, relevance-first는 오래된 March 기사와 broad token overlap을 끌어올렸다.
+- 8147은 pure relevance-first가 wrong-context Iran/Trump 기사를 1위로 올렸고, hybrid 후보는 Colombia election 기사를 1위로 유지했다.
+- 8149는 good-match control sample로, relevance-first/hybrid가 BTS comeback 관련 강한 score 기사를 더 위로 올렸다.
+- 따라서 pure relevance-first로 바로 바꾸기보다는 bounded recency signal을 함께 쓰는 hybrid 후보를 후속 코드 실험 대상으로 보는 것이 안전하다.
+
+검증:
+
+```text
+local MySQL FULLTEXT 측정 쿼리
+git diff --check
+```
 
 ## 4. 이후 개선 로드맵
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -1045,7 +1045,7 @@ Reviewer 결과:
 계획:
 
 - 8146, 9440, 8147, 8149 샘플을 우선 대상으로 삼는다.
-- 각 샘플에서 latest-first, relevance-first, hybrid ordering의 top results와 score, 국가/언어 분포를 비교한다.
+- 각 샘플에서 latest-first, relevance-first, hybrid ordering의 top results와 score 기반 ordering 차이, 국가/언어 분포를 비교한다.
 - source coverage 한계로 인한 누락과 ranking 문제를 분리해 해석한다.
 
 측정 결과:

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -1020,7 +1020,7 @@ Reviewer 결과:
 ### #160 - Perspectives FULLTEXT relevance-first/hybrid ordering 비교
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/160
-- PR: 생성 예정
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/161
 - 상태: In Progress
 - 작업 브랜치: `perf/#160-perspectives-fulltext-ordering-comparison`
 - 주요 파일:

--- a/docs/backend-improvement/perspectives-fulltext-ordering-comparison.md
+++ b/docs/backend-improvement/perspectives-fulltext-ordering-comparison.md
@@ -1,0 +1,204 @@
+# Perspectives FULLTEXT ordering comparison
+
+## Purpose
+
+This document compares ordering strategies for `ArticleRepository.findPerspectives`.
+
+#156 showed that #152 improved generated keyword quality for weak generic-token samples.
+However, sample 8146 still had nearby Middle East diplomacy noise near the top because current results are ordered by recency:
+
+```sql
+ORDER BY published_at DESC
+```
+
+This measurement checks whether the remaining noise is better explained as an ordering problem.
+It does not change API behavior, DB schema, Redis policy, crawler/RSS feeds, or `KeywordExtractor`.
+
+Interpret this result together with `perspectives-source-coverage-limit-log.md`.
+FULLTEXT can only rank articles that exist in the collected local dataset.
+
+## Environment
+
+| Item | Value |
+| --- | --- |
+| Date | 2026-07-08 |
+| Dataset | Local development MySQL via Docker |
+| MySQL | 8.0.45 |
+| Article rows | 9853 |
+| FULLTEXT index | `ft_article_title_description(title, description)` |
+| Query path | DB-level query shaped like `ArticleRepository.findPerspectives` |
+| External translation API | Not called |
+| Redis cache | Not used |
+
+Sensitive local `.env` values and external API responses are intentionally excluded.
+
+## Compared Ordering Strategies
+
+All strategies use the same candidate predicate:
+
+```sql
+WHERE article_id != :baseArticleId
+  AND MATCH(title, description) AGAINST(:keywords IN BOOLEAN MODE)
+LIMIT 50
+```
+
+### Latest-first
+
+Current production ordering:
+
+```sql
+ORDER BY published_at DESC
+```
+
+Meaning: prefer the newest matching articles.
+
+### Relevance-first
+
+FULLTEXT score ordering:
+
+```sql
+ORDER BY MATCH(title, description) AGAINST(:keywords IN BOOLEAN MODE) DESC,
+         article_id DESC
+```
+
+Meaning: prefer articles with stronger FULLTEXT keyword overlap.
+
+### Hybrid candidate
+
+Exploratory score plus bounded recency boost:
+
+```sql
+hybrid_score =
+  fulltext_score
+  + GREATEST(
+      0,
+      1 - TIMESTAMPDIFF(HOUR, published_at, max_matched_published_at) / (24 * 30)
+    ) * 5
+
+ORDER BY hybrid_score DESC,
+         published_at DESC
+```
+
+Meaning: prefer relevant articles, but give a limited boost to articles within 30 days of the newest matched article.
+This is a measurement candidate, not a final ranking policy.
+
+## Sample Summary
+
+Because all selected samples have fewer than 50 matches, each ordering strategy returns the same candidate set.
+This measurement therefore compares top order, not recall.
+
+| Base article ID | Keyword | Match count | Country/language spread |
+| --- | --- | ---: | --- |
+| 8146 | `+Iran +talks ends encouraging` | 27 | global/en 13, cn/zh 7, gb/en 3, us/en 2, de/en 1, global/null 1 |
+| 9440 | `+Meloni +Trump divorce italienne` | 3 | global/en 2, de/de 1 |
+| 8147 | `+Trump +backed political outsider` | 4 | cn/zh 2, gb/en 1, us/null 1 |
+| 8149 | `+BTS +fans losing thousands` | 8 | cn/zh 4, gb/en 2, fr/fr 1, us/en 1 |
+
+## 8146: US-Iran Talks
+
+Base title:
+
+```text
+First round of US-Iran talks ends with 'encouraging progress', mediators say
+```
+
+### Top Results
+
+| Ordering | Top returned examples |
+| --- | --- |
+| latest-first | 9652 Blockade/assets to Iran in Swiss talks; 9667 Iran-US talks continue; 8086 Iran war live and Lebanon; 8091 US-Iran talks to kick off; 7939 US-Iran talks begin |
+| relevance-first | 9667 Iran-US talks continue; 9652 Blockade/assets to Iran; 5219 Iran denies US talks; 1517 Ukraine peace talks amid Iran war; 4276 Iran World Cup |
+| hybrid | 9652 Blockade/assets to Iran; 9667 Iran-US talks continue; 8114 US envoy headed for Switzerland; 8129 Israel-Lebanon talks; 8086 Iran war live and Lebanon |
+
+### Interpretation
+
+- Latest-first keeps the newest Iran/US talks articles high, but also keeps recent Lebanon/ceasefire regional noise near the top.
+- Relevance-first raises strong `Iran`/`talks` overlaps, but it can promote older or broader matches such as Ukraine peace talks or Iran World Cup.
+- The hybrid candidate reduces the pure relevance-first drift toward older March articles while still using score to avoid pure recency ordering.
+- Remaining Lebanon/ceasefire results are not fully solved by ordering because the text overlaps with the same regional diplomacy context.
+
+## 9440: Meloni/Trump French Sample
+
+Base title:
+
+```text
+Entre Meloni et Trump, divorce à l'italienne
+```
+
+### Top Results
+
+| Ordering | Top returned examples |
+| --- | --- |
+| latest-first | 8096 Trump/Meloni photos; 8134 Meloni says Trump fabricated story; 9517 German Meloni/Trump article |
+| relevance-first | 9517 German Meloni/Trump article; 8134 Meloni says Trump fabricated story; 8096 Trump/Meloni photos |
+| hybrid | 9517 German Meloni/Trump article; 8134 Meloni says Trump fabricated story; 8096 Trump/Meloni photos |
+
+### Interpretation
+
+- The candidate set is only 3 rows, so ordering cannot solve source coverage limits.
+- Relevance-first and hybrid both move the highest FULLTEXT score article to the top.
+- This sample is useful for recall tracking after #152, but it is too small to justify a ranking policy alone.
+
+## 8147: Trump-backed Political Outsider
+
+Base title note:
+
+```text
+Trump-backed political outsider
+```
+
+### Top Results
+
+| Ordering | Top returned examples |
+| --- | --- |
+| latest-first | 9658 Trump-backed Colombia election; 4941 Iran awaits Trump threat; 3258 Trump-backed television merger; 778 Trump allies/Iran |
+| relevance-first | 4941 Iran awaits Trump threat; 9658 Trump-backed Colombia election; 778 Trump allies/Iran; 3258 Trump-backed television merger |
+| hybrid | 9658 Trump-backed Colombia election; 4941 Iran awaits Trump threat; 778 Trump allies/Iran; 3258 Trump-backed television merger |
+
+### Interpretation
+
+- Latest-first already puts the most likely same-issue article first because it is much newer.
+- Relevance-first over-promotes a higher-score but wrong-context Iran/Trump article.
+- Hybrid keeps the Colombia election article first while still preserving score as a ranking signal.
+- This sample argues against switching directly to pure relevance-first.
+
+## 8149: BTS Fans
+
+Base title note:
+
+```text
+BTS fans losing thousands
+```
+
+### Top Results
+
+| Ordering | Top returned examples |
+| --- | --- |
+| latest-first | 6014 BTS fans/Arirang credits; 4523 BTS agency shares; 4935 BTS comeback crowd; 3246 K-pop fans in Seoul; 3008 BTS comeback concert |
+| relevance-first | 3008 BTS comeback concert; 6014 BTS fans/Arirang credits; 3246 K-pop fans in Seoul; 2874 BTS first show; 4935 BTS comeback crowd |
+| hybrid | 3008 BTS comeback concert; 6014 BTS fans/Arirang credits; 3246 K-pop fans in Seoul; 2874 BTS first show; 4935 BTS comeback crowd |
+
+### Interpretation
+
+- This is a good-match control sample: most returned rows are BTS-related under all strategies.
+- Relevance-first and hybrid surface stronger BTS event matches than latest-first.
+- The result suggests ordering can improve top position quality when the candidate set is already coherent.
+
+## Findings
+
+- Pure latest-first is simple and freshness-friendly, but it can keep nearby topical noise high.
+- Pure relevance-first can improve exact keyword overlap, but it may over-promote older or wrong-context articles with strong token overlap.
+- The measured hybrid candidate looks safer than pure relevance-first for samples 8146 and 8147 because it keeps recency as a bounded signal.
+- Since all measured candidate sets are under 50 rows, this comparison does not evaluate recall. It evaluates top ordering only.
+- Source coverage remains a hard boundary. If the collected DB lacks same-issue articles, no ordering policy can recover them.
+
+## Recommendation
+
+Do not directly replace `ORDER BY published_at DESC` with pure relevance-first.
+
+If code changes are attempted later, prefer a small, explicit hybrid experiment with tests and before/after measurement:
+
+1. Select representative samples and expected top-result intent.
+2. Add a repository method or query variant for hybrid ranking.
+3. Compare API response order against this DB-level baseline.
+4. Keep source coverage limitations documented separately from ranking failures.


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #160

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)


## 📝 작업 내용
- `docs/backend-improvement/perspectives-fulltext-ordering-comparison.md`를 추가해 Perspectives FULLTEXT 정렬 전략을 비교했습니다.
- 8146, 9440, 8147, 8149 샘플에서 latest-first, relevance-first, hybrid 후보의 top result 변화를 기록했습니다.
- `WORK_PROGRESS.md`, `BACKLOG.md`, `NEXT_AGENT_BRIEF.md`에 #160 진행 상태와 측정 결과 요약을 반영했습니다.

## 🔍 기술적 배경
- 현재 `ArticleRepository.findPerspectives`는 FULLTEXT 후보를 찾은 뒤 `ORDER BY published_at DESC` 최신순으로 정렬합니다.
- #156에서 8146 샘플의 keyword 품질은 개선됐지만, 최신순 정렬 때문에 Lebanon/ceasefire 같은 인접 노이즈가 상위에 남았습니다.
- 이번 PR은 운영 쿼리를 바로 변경하지 않고, latest-first, FULLTEXT score 기반 relevance-first, score에 bounded recency signal을 더한 hybrid 후보를 DB-level로 비교해 후속 코드 변경 판단 근거를 남깁니다.


## 🧪 테스트/검증 (필수)
- [x] 로컬 Docker MySQL에서 article 9853건과 `ft_article_title_description(title, description)` FULLTEXT index를 확인했습니다.
- [x] 8146, 9440, 8147, 8149 샘플에 대해 latest-first, relevance-first, hybrid ordering 측정 쿼리를 실행했습니다.
- [x] `git diff --check`로 문서 diff 공백 오류가 없음을 확인했습니다.


## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?


## 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
- 이번 PR이 운영 코드 변경 없이 DB-level 측정/문서화 범위에 머무르는지 봐주세요.
- pure relevance-first가 wrong-context 기사를 올릴 수 있다는 해석과, 후속 코드 변경은 hybrid 후보 중심으로 검토하자는 결론이 측정 결과와 일치하는지 봐주세요.
- source coverage 한계와 ranking 문제를 과하게 섞어 해석하지 않았는지 봐주세요.


## ➕ 추후 계획(선택)
- 후속 이슈에서 hybrid ranking을 실제 `findPerspectives` 쿼리 또는 별도 query variant로 실험할지 검토할 예정입니다.
