### PR TITLE
📝 [DOCS/#164] Perspectives ranking policy ADR 정리

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -52,11 +52,11 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## P3. 다국어 이슈 매칭 품질 개선
 
-- 상태: `Backlog` (최근 완료: [#142](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/142), [#146](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/146), [#148](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/148), [#150](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/150), [#152](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/152), [#154](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/154), [#156](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/156), [#160](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/160))
+- 상태: `In Progress` ([#164](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/164), 최근 완료: [#142](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/142), [#146](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/146), [#148](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/148), [#150](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/150), [#152](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/152), [#154](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/154), [#156](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/156), [#160](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/160))
 - AS-IS: 기사 제목의 키워드와 영어 번역 키워드를 MySQL FULLTEXT 검색에 사용하므로, 표현이 다른 동일 이슈 또는 비영어권 기사 간 매칭이 누락될 수 있다.
 - TO-BE: 기존 후보 검색을 유지하면서 이슈 유사도와 국가 다양성 기준으로 결과를 재정렬하는 정책을 검증한다.
 - 최근 측정: #160에서 `ORDER BY published_at DESC` latest-first, FULLTEXT score 기반 relevance-first, bounded recency signal을 더한 hybrid 후보를 비교했다. 측정상 pure relevance-first는 wrong-context 기사도 끌어올릴 수 있어, 후속 코드 변경은 hybrid 후보 중심으로 검토하는 것이 안전하다.
-- 다음 판단: hybrid ranking query variant를 바로 구현하기보다, 현재 단계에서 과한 구현인지 검토하고 도입 보류/적용 기준을 docs/ADR로 정리하는 것이 우선이다.
+- 다음 판단: #164에서 hybrid ranking query variant를 바로 구현하지 않는 이유와 후속 적용 기준을 docs/ADR로 정리한다. 코드 변경은 대표 샘플, 기대 top-result intent, 회귀 테스트, before/after 측정 기준이 준비된 뒤 별도 Issue로 검토한다.
 - 성공 기준:
   - 대표 이슈 샘플과 기대 국가를 정의한다.
   - 개선 전후의 국가별 관련 기사 노출 수와 매칭 근거를 비교한다.

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -56,7 +56,7 @@ Issue
 - #158/#159에서 다음 세션 handoff 문서 정리를 완료했다.
 - #160/#161에서 Perspectives FULLTEXT relevance-first/hybrid ordering 비교를 완료했다.
 - #162/#163에서 새 이슈 후보마다 overengineering 여부를 먼저 판단하는 guardrail을 추가했다.
-- 다음 후보는 hybrid ranking query variant를 바로 구현하기보다, #160 측정 결과를 바탕으로 적용 보류/도입 기준을 정리하는 docs/ADR 작업이다.
+- #164에서 hybrid ranking query variant를 바로 구현하지 않는 이유와 후속 적용 기준을 docs/ADR로 정리하는 작업을 진행 중이다.
 
 ## Recent Completed Work
 
@@ -66,20 +66,23 @@ Issue
 - #154/#155: RSS/News API 수집 편차와 source coverage 한계가 FULLTEXT/향후 연관도 측정 해석에 주는 영향을 별도 LOG로 남겼다.
 - #156/#157: #152 전후 DB-level FULLTEXT 결과 변화를 측정했다.
 - #158/#159: 긴 `WORK_PROGRESS.md`를 보완하기 위한 다음 세션 handoff 문서를 추가했다.
+- #160/#161: Perspectives FULLTEXT ordering을 latest-first, relevance-first, hybrid 후보로 비교했다.
+- #162/#163: 새 후보마다 overengineering 여부를 먼저 판단하는 guardrail을 추가했다.
 
-## Why #156 Matters
+## Why #160 Matters
 
 #156에서 대표 샘플 8146은 키워드가 `+First +round Iran talks`에서 `+Iran +talks ends encouraging`로 바뀌며 상위 결과가 스포츠/라운드 노이즈에서 Iran/US talks 중심으로 이동했다.
 다만 현재 쿼리는 여전히 `ORDER BY published_at DESC` 최신순이라 Lebanon/ceasefire 같은 인접 노이즈가 남는다.
 
-이 때문에 다음 P3 후보는 keyword extractor를 더 넓게 만지는 것보다, 동일 후보군에서 정렬 기준을 비교하는 작업이 자연스럽다.
+#160에서는 동일 후보군에서 latest-first, relevance-first, hybrid 후보를 비교했다.
+pure relevance-first는 wrong-context 기사를 끌어올릴 수 있어 바로 적용하기 위험하고, hybrid는 폐기하지 않되 후속 실험 기준이 필요한 후보로 남겼다.
 
-## Recommended Next Backend Issue
+## Current Backend Issue
 
-추천 후보:
+현재 진행 중:
 
 ```text
-[DOCS/ADR] Perspectives ranking policy 도입 보류와 hybrid 후보 적용 기준 정리
+#164 [DOCS/ADR] Perspectives ranking policy 도입 보류와 hybrid 후보 적용 기준 정리
 ```
 
 목표:
@@ -88,6 +91,7 @@ Issue
 - 현재 단계에서 query variant 구현이 과한지 판단하고, 바로 운영 응답을 바꾸지 않는 이유를 남긴다.
 - 나중에 코드 실험을 한다면 필요한 조건을 정의한다.
 - source coverage 한계와 ranking 개선 효과를 계속 분리해서 해석한다.
+- 코드, API 응답, DB schema, Redis 정책, FULLTEXT query는 변경하지 않는다.
 
 판단 기준:
 
@@ -100,6 +104,7 @@ Issue
 
 - `docs/backend-improvement/perspectives-fulltext-generic-token-filter-result.md`
 - `docs/backend-improvement/perspectives-fulltext-ordering-comparison.md`
+- `docs/backend-improvement/perspectives-ranking-policy-adr.md`
 - `docs/backend-improvement/perspectives-matching-sample-snapshot.md`
 - `docs/backend-improvement/perspectives-source-coverage-limit-log.md`
 - `docs/backend-improvement/perspectives-matching-quality-baseline.md`
@@ -124,15 +129,16 @@ Issue
 
 Repo: SKU-GlobalTimes/GlobalTimes_BeSide
 PR: <PR URL>
-Issue: #<ISSUE NUMBER>
+Issue: #164
 
 검토 관점:
-1. 이번 PR이 문서/handoff 구조 정리 범위에 머무르는가?
-2. NEXT_AGENT_BRIEF.md가 새 세션이 현재 workflow, 최근 완료 작업, #110 제외 조건, 다음 추천 후보를 빠르게 파악하기에 충분한가?
-3. WORK_PROGRESS.md와 BACKLOG.md가 Issue 목적과 진행 상태를 정확히 반영하는가?
-4. #156 이후 다음 후보로 FULLTEXT relevance-first/hybrid ordering 비교를 제안하는 근거가 기존 측정 문서와 일치하는가?
-5. 민감 정보가 포함되어 있지 않은가?
-6. 새 Blocking이 있는가?
+1. 이번 PR이 #164 문서/ADR 범위에 머무르고 코드, API 응답, DB schema, Redis 정책, FULLTEXT query를 변경하지 않는가?
+2. ADR이 #160 측정 결과를 근거로 pure relevance-first 직접 적용을 보류하는 이유를 명확히 설명하는가?
+3. hybrid ranking을 폐기하지 않고 후속 실험 조건으로 남기는 기준이 충분한가?
+4. source coverage 한계와 ranking 개선 효과를 분리해서 해석하고 있는가?
+5. NEXT_AGENT_BRIEF.md, WORK_PROGRESS.md, BACKLOG.md가 Issue 목적과 진행 상태를 정확히 반영하는가?
+6. 민감 정보가 포함되어 있지 않은가?
+7. 새 Blocking이 있는가?
 
 제약:
 - 코드 직접 수정 금지

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -93,6 +93,7 @@ Blocking 예시:
 - #158/#159에서 긴 `WORK_PROGRESS.md`를 보완하기 위한 다음 세션 handoff 문서를 정리했다.
 - #160/#161에서 Perspectives FULLTEXT 정렬 기준을 latest-first, relevance-first, hybrid ordering으로 비교했다.
 - #162/#163에서 새 이슈 후보마다 overengineering 여부를 먼저 판단하는 docs guardrail을 추가했다.
+- #164에서 #160 측정 결과를 바탕으로 Perspectives ranking policy 도입 보류와 hybrid 후보 적용 기준을 docs/ADR로 정리 중이다.
 - 현재 반복 성능/안정성 기본기 흐름의 주요 후보(#123, #127, #129, #131, #133, #137, #140, #142, #146)와 AI workflow 보강(#144)은 merge 완료 상태다.
 
 ### #113 / PR #114 - 백엔드 개선 Backlog 및 AI 작업 운영 규칙 수립
@@ -1108,6 +1109,46 @@ Reviewer 결과:
 - Non-blocking: `WORK_PROGRESS.md`의 `검증 예정` 표현을 완료 상태와 맞추는 문서 정정 제안이 있었고, merge 전 `검증`으로 정리했다.
 - `check-review-blocking.ps1 -PrNumber 163` 결과 `MERGE_READY`를 확인했다.
 - 2026-07-07 기준 PR #163은 merge 완료되었고, Issue #162는 closed 상태다.
+
+---
+
+### #164 - Perspectives ranking policy 도입 보류와 hybrid 후보 적용 기준 정리
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/164
+- 상태: In Progress
+- 작업 브랜치: `docs/#164-perspectives-ranking-policy-adr`
+- 주요 파일:
+  - `docs/backend-improvement/perspectives-ranking-policy-adr.md`
+  - `docs/backend-improvement/BACKLOG.md`
+  - `docs/backend-improvement/NEXT_AGENT_BRIEF.md`
+  - `docs/backend-improvement/WORK_PROGRESS.md`
+
+목표:
+
+- #160 측정 결과를 바탕으로 pure relevance-first를 현재 latest-first의 직접 대체안으로 적용하지 않는 이유를 정리한다.
+- hybrid ranking은 폐기하지 않고, 추후 code experiment 후보로 남기되 적용 조건을 명시한다.
+- source coverage 한계와 ranking 개선 효과를 분리해서 해석하는 기준을 ADR에 남긴다.
+- 신입 포트폴리오 관점에서 "구현하지 않는 판단"도 측정 근거와 함께 설명 가능하게 만든다.
+
+Overengineering 판단:
+
+- 지금 hybrid ranking query variant를 구현하면 운영 API 응답 순서가 바뀌지만, 대표 샘플과 회귀 기준이 아직 부족하다.
+- #160 측정은 candidate set이 모두 50건 미만인 조건에서 top ordering 차이를 비교한 것이므로 recall 개선 근거는 아니다.
+- pure relevance-first는 wrong-context 기사를 끌어올릴 수 있어 바로 적용하기 위험하다.
+- 현재 단계에서는 코드 변경 없이 ADR로 보류 판단과 후속 적용 기준을 남기는 편이 더 적절하다.
+
+수정 방향:
+
+- `perspectives-ranking-policy-adr.md`를 추가해 도입 보류 결정, 근거, 후속 hybrid 실험 조건, non-goals를 정리한다.
+- `BACKLOG.md`의 P3 상태를 #164 In Progress로 갱신하고 다음 판단을 ADR 작업 기준으로 좁힌다.
+- `NEXT_AGENT_BRIEF.md`가 새 세션에서 #164 진행 상태와 Reviewer 검토 관점을 바로 파악할 수 있게 갱신한다.
+- 코드, API 응답, DB schema, FULLTEXT query, Redis 정책은 변경하지 않는다.
+
+검증:
+
+```text
+git diff --check
+```
 
 ## 4. 이후 개선 로드맵
 

--- a/docs/backend-improvement/perspectives-ranking-policy-adr.md
+++ b/docs/backend-improvement/perspectives-ranking-policy-adr.md
@@ -1,0 +1,122 @@
+# ADR: Perspectives ranking policy 도입 보류와 hybrid 후보 적용 기준
+
+## Status
+
+- Date: 2026-07-08
+- Issue: [#164](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/164)
+- Decision: `ORDER BY published_at DESC`를 지금 바로 교체하지 않는다.
+- Scope: 문서/ADR 작업만 수행한다. 코드, API 응답, DB schema, Redis 정책, FULLTEXT query는 변경하지 않는다.
+
+## Context
+
+`GET /api/news/{id}/perspectives`는 기준 기사와 유사한 이슈의 다른 국가 기사를 보여주기 위한 API다.
+현재 구현은 기준 기사 제목에서 키워드를 추출하고, 필요하면 영어 번역 키워드를 추가한 뒤 MySQL FULLTEXT로 후보를 찾는다.
+
+현재 repository query shape는 다음과 같다.
+
+```sql
+WHERE article_id != :baseArticleId
+  AND MATCH(title, description) AGAINST(:keywords IN BOOLEAN MODE)
+ORDER BY published_at DESC
+LIMIT 50
+```
+
+#156에서는 #152의 generic-token filtering 이후 대표 샘플의 DB-level FULLTEXT 결과가 개선되는지 측정했다.
+8146 샘플은 `+First +round Iran talks`에서 `+Iran +talks ends encouraging`로 바뀌며 스포츠/라운드 노이즈가 줄고 Iran/US talks 중심 결과로 이동했다.
+다만 최신순 정렬 때문에 Lebanon/ceasefire 같은 인접 외교 노이즈가 여전히 상위에 남았다.
+
+#160에서는 같은 후보 predicate에서 세 가지 ordering을 비교했다.
+
+- latest-first: 현재 운영 방식인 `ORDER BY published_at DESC`
+- relevance-first: FULLTEXT score 중심 정렬
+- hybrid candidate: FULLTEXT score에 제한된 recency boost를 더한 후보
+
+측정 결과 pure relevance-first는 일부 샘플에서 잘 맞는 기사도 올리지만, 8147처럼 wrong-context Iran/Trump 기사를 1위로 올릴 수 있었다.
+hybrid 후보는 pure relevance-first보다 안전해 보였지만, 아직 운영 응답을 바꿀 만큼 충분한 샘플과 회귀 기준이 없다.
+
+또한 source coverage 한계가 있다.
+수집된 DB에 같은 이슈 기사가 없거나 특정 국가/source feed가 늦게 들어오면, ranking policy만으로는 결과를 복구할 수 없다.
+따라서 ranking 개선 효과와 RSS/News API 수집 편차를 분리해서 해석해야 한다.
+
+## Decision
+
+현재 단계에서는 Perspectives ranking policy를 구현으로 바꾸지 않고 보류한다.
+
+구체적으로는 다음을 결정한다.
+
+- pure relevance-first를 현재 latest-first의 직접 대체안으로 적용하지 않는다.
+- hybrid ranking은 폐기하지 않고, 후속 code experiment 후보로 남긴다.
+- 운영 API 응답 순서를 바꾸기 전에 대표 샘플, 기대 top intent, 회귀 테스트, before/after 측정 기준을 먼저 정의한다.
+- source coverage 문제를 ranking 실패로 단정하지 않는다.
+
+## Why Not Implement Now
+
+### 현재 데이터 규모와 사용자 흐름
+
+현재 측정은 local development MySQL 9,853 rows 기준이며, #160 샘플들은 모두 candidate set이 50건 미만이었다.
+즉 이번 비교는 recall 개선이 아니라 같은 후보군 안에서 top ordering이 어떻게 달라지는지를 본 것이다.
+
+이 정도 근거만으로 운영 API 응답 순서를 바꾸면, 일부 샘플에서는 좋아 보이지만 다른 샘플에서는 wrong-context 기사가 더 위로 올라갈 수 있다.
+
+### 포트폴리오 설명 가능성
+
+신입 백엔드 포트폴리오 관점에서는 "복잡한 ranking query를 넣었다"보다 "측정 결과 pure relevance-first의 위험을 확인했고, hybrid 적용 기준을 ADR로 남겼다"가 더 설명 가능하다.
+구현하지 않는 판단도 근거가 있으면 좋은 엔지니어링 결과다.
+
+### 더 단순한 대안
+
+지금은 코드 변경 없이 다음을 먼저 정리하는 편이 적절하다.
+
+- 대표 샘플과 기대 top-result intent
+- source coverage 한계와 ranking 한계의 구분
+- hybrid 실험이 필요한 조건
+- API 응답 변경 전 필요한 회귀 테스트
+
+## Future Hybrid Experiment Criteria
+
+다음 조건이 충족되면 hybrid ranking code experiment를 별도 Issue로 분리해 검토한다.
+
+1. 대표 샘플을 최소 6개 이상 정의한다.
+   - good-match control
+   - partial-match sample
+   - noisy recency-biased sample
+   - non-English base article
+   - low-match or zero-match sample
+   - multi-country breaking/news topic
+2. 각 샘플에 기대 top-result intent를 적는다.
+   - 특정 article ID 고정보다 "같은 사건", "같은 인물/국가/이슈", "wrong-context 제외"처럼 설명 가능한 기준을 우선한다.
+3. latest-first, relevance-first, hybrid의 top 5 결과를 같은 local dataset에서 비교한다.
+4. API response order 변경이 필요한지 service-level 테스트 또는 repository-level 테스트로 고정한다.
+5. source coverage 한계로 인한 실패를 ranking 실패와 분리해서 기록한다.
+6. hybrid formula의 recency window와 boost weight를 임의값으로 숨기지 않고 문서화한다.
+
+## Non-Goals
+
+- Elasticsearch, vector DB, RAG, issue clustering 도입을 결정하지 않는다.
+- `ArticleRepository.findPerspectives` query를 변경하지 않는다.
+- Redis cache key, TTL, stale policy를 변경하지 않는다.
+- crawler/RSS feed 수집 정책을 변경하지 않는다.
+- #110 장기 troubleshooting 이슈를 정리하거나 구현하지 않는다.
+
+## Consequences
+
+좋은 점:
+
+- 운영 API 응답 순서를 성급하게 바꾸지 않는다.
+- #160 측정에서 드러난 pure relevance-first 위험을 후속 작업자가 빠르게 이해할 수 있다.
+- hybrid ranking을 폐기하지 않고, 적용 조건을 가진 후보로 보존한다.
+- source coverage와 ranking 품질을 분리해서 해석하는 기준이 남는다.
+
+감수하는 점:
+
+- 최신순 정렬의 알려진 노이즈는 당장 해결하지 않는다.
+- 일부 good-match 샘플에서 relevance-first/hybrid가 더 나은 top ordering을 보였더라도, 사용자는 아직 그 개선을 체감하지 못한다.
+- 후속 실험 전까지 ranking policy는 보수적으로 유지된다.
+
+## References
+
+- `docs/backend-improvement/perspectives-matching-quality-baseline.md`
+- `docs/backend-improvement/perspectives-matching-sample-snapshot.md`
+- `docs/backend-improvement/perspectives-fulltext-generic-token-filter-result.md`
+- `docs/backend-improvement/perspectives-fulltext-ordering-comparison.md`
+- `docs/backend-improvement/perspectives-source-coverage-limit-log.md`


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #164

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)


## 📝 작업 내용
- `perspectives-ranking-policy-adr.md`를 추가해 #160 ordering 비교 이후 ranking policy 도입 보류 결정을 정리했습니다.
- `BACKLOG.md`, `WORK_PROGRESS.md`, `NEXT_AGENT_BRIEF.md`에 #164 진행 상태와 후속 hybrid 적용 기준을 반영했습니다.
- 코드, API 응답, DB schema, Redis 정책, FULLTEXT query는 변경하지 않았습니다.

## 🔍 기술적 배경
- #160 측정에서 pure relevance-first는 일부 샘플에서 wrong-context 기사를 상위로 올릴 수 있음이 확인됐습니다.
- hybrid ranking 후보는 폐기하지 않되, 운영 API 응답 순서를 바꾸기 전 대표 샘플, 기대 top-result intent, 회귀 테스트, before/after 측정 기준이 필요합니다.
- source coverage 한계는 ranking 개선 효과와 분리해서 해석해야 하므로, 이번 작업은 구현 대신 ADR로 판단 기준을 남깁니다.


## 🧪 테스트/검증 (필수)
- [x] `git diff --check`로 문서 포맷 문제 없음 확인
- [x] 관련 문서 링크, Issue 번호, 상태 표기가 #164 기준으로 이어지는지 확인

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?


## 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
- #164 문서/ADR 범위에 머무르며 코드/API/DB/Redis/FULLTEXT query 변경이 없는지 확인해주세요.
- pure relevance-first 보류와 hybrid 후속 적용 기준이 #160 측정 결과와 일치하는지 확인해주세요.
- source coverage 한계와 ranking 개선 효과를 분리해서 설명하는지 확인해주세요.


## ➕ 추후 계획(선택)
- 대표 샘플, 기대 top-result intent, 회귀 테스트, before/after 측정 기준이 준비되면 hybrid ranking code experiment를 별도 Issue로 검토합니다.
