### PR TITLE
📝 [DOCS/#166] PR 단위 문서 기록 기준 정리

### DIFF
--- a/docs/ai-workflow/README.md
+++ b/docs/ai-workflow/README.md
@@ -14,7 +14,8 @@ AI를 단순 코드 생성 도구가 아니라 조사, 계획, 구현, 검토를
 Reviewer 세션을 별도로 운영하는 경우에는 GitHub PR comment를 중심으로 리뷰 결과와 반영 내역을 기록한다.
 자세한 흐름은 [AI Reviewer PR Comment Workflow](./reviewer-comment-workflow.md)를 따른다.
 
-AI Reviewer가 `MERGE_READY`를 반환하고 사용자가 해당 PR에 대해 명시적으로 merge 진행을 승인한 경우, Implementer는 PR을 merge한 뒤 `WORK_PROGRESS.md`에 merge 결과와 다음 상태를 기록한다.
+AI Reviewer가 `MERGE_READY`를 반환하고 사용자가 해당 PR에 대해 명시적으로 merge 진행을 승인한 경우, Implementer는 PR을 merge한 뒤 GitHub PR/Issue 상태와 local `develop` 최신화로 merge 결과를 확인한다.
+`WORK_PROGRESS.md`, `NEXT_AGENT_BRIEF.md`, `BACKLOG.md` 갱신이 필요한 작업은 가능한 한 PR 본 작업 커밋에 함께 포함해 develop commit history를 이슈별 핵심 변경 중심으로 유지한다.
 새 Issue/PR을 만든 경우에는 Reviewer Agent에게 전달할 검토 요청 예시도 사용자에게 함께 안내한다.
 
 ## 역할 분리
@@ -51,7 +52,7 @@ AI Reviewer가 `MERGE_READY`를 반환하고 사용자가 해당 PR에 대해 �
 | AI Reviewer 검토 결과와 반영 내역 | PR comment |
 | 중요한 기술 선택과 대안 | `docs/adr/` |
 | 개선 후보와 우선순위 | `docs/backend-improvement/BACKLOG.md` |
-| merge 결과와 다음 작업 상태 | `docs/backend-improvement/WORK_PROGRESS.md` |
+| merge 결과와 다음 작업 상태 | PR 본문, GitHub PR/Issue 상태, 필요 시 `docs/backend-improvement/WORK_PROGRESS.md` |
 
 PR은 해당 Issue를 `Closes #번호`로 연결한다.
 

--- a/docs/ai-workflow/reviewer-comment-workflow.md
+++ b/docs/ai-workflow/reviewer-comment-workflow.md
@@ -49,7 +49,7 @@ Issue 생성
 → 필요 시 Reviewer 재검토
 → Blocking 없음 확인
 → 사용자 승인 후 merge
-→ merge 결과와 다음 상태를 WORK_PROGRESS.md에 기록
+→ GitHub PR/Issue 상태로 merge 결과 확인
 ```
 
 ## Reviewer comment 형식
@@ -144,7 +144,19 @@ PR #<PR_NUMBER>의 AI Reviewer comment를 읽고 수정 계획을 세워줘.
 4. 사용자가 해당 PR에 대해 명시적으로 merge 진행을 승인했다.
 
 위 조건이 충족되면 Implementer는 별도 대기 없이 PR을 merge할 수 있다.
-merge 후에는 로컬 `develop`을 최신화하고 `WORK_PROGRESS.md`에 PR 상태, Reviewer 결정, merge 시각, 다음 작업 상태를 기록한다.
+merge 후에는 로컬 `develop`을 최신화하고 GitHub PR/Issue 상태를 확인한다.
+
+develop commit history를 이슈별 핵심 변경 중심으로 유지하기 위해, merge 후 `WORK_PROGRESS.md`만 갱신하는 후처리 커밋은 기본값으로 만들지 않는다.
+작업 내용, 검증 결과, Reviewer 확인 방식, 다음 상태는 가능한 한 PR 본문과 PR에 포함된 문서 변경에 미리 기록한다.
+merge 시각, closed 상태처럼 merge 후에만 확정되는 정보는 GitHub PR/Issue 상태를 기준으로 확인한다.
+
+예외적으로 merge 후 문서 커밋을 만들 수 있는 경우는 다음과 같다.
+
+- PR에 포함된 문서가 실제 다음 세션을 잘못 안내하는 경우
+- Reviewer가 후처리 문서 갱신을 명시적으로 요구한 경우
+- merge 후 발견된 상태 불일치가 다음 작업 판단에 직접 영향을 주는 경우
+
+이 예외가 아니면 새 이슈의 작업 커밋 안에 관련 docs 기록을 함께 포함한다.
 
 ## 기록 기준
 
@@ -153,7 +165,8 @@ merge 후에는 로컬 `develop`을 최신화하고 `WORK_PROGRESS.md`에 PR 상
 - 최종 Reviewer 확인 결과는 “Blocking 없음” comment로 남긴다.
 - merge는 `MERGE_READY`와 사용자 승인 기준을 충족한 뒤 수행한다.
 - 새 Issue/PR 생성 후에는 Reviewer Agent에게 전달할 검토 요청 예시를 사용자에게 안내한다.
-- merge 완료 후에는 `WORK_PROGRESS.md`를 기준 문서로 갱신한다.
+- `WORK_PROGRESS.md`, `NEXT_AGENT_BRIEF.md`, `BACKLOG.md` 갱신이 필요한 작업은 PR 본 작업 커밋에 포함한다.
+- merge 후 상태 확인은 GitHub PR/Issue 상태와 local `develop` 최신화로 처리하고, 별도 후처리 커밋은 예외 상황에만 만든다.
 
 ## 후속 자동화 후보
 

--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -13,6 +13,8 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 - 성능 작업은 개선 전 기준값과 개선 후 결과를 같은 측정 조건에서 기록한다.
 - 새 이슈 후보를 고를 때마다 현재 프로젝트 단계, 데이터 규모, 신입 포트폴리오 설명 가능성을 기준으로 overengineering 여부를 먼저 판단한다.
 - 기술적으로 가능하더라도 근거가 부족하거나 복잡도 대비 효과가 작으면 구현 대신 측정 문서, 판단 기록, ADR, 후속 적용 기준 정리로 범위를 낮춘다.
+- 작업 내용, 검증 결과, docs 기록은 가능한 한 PR 본 작업 커밋에 함께 포함해 develop commit history를 이슈별 핵심 변경 중심으로 유지한다.
+- merge 후 `WORK_PROGRESS.md`만 갱신하는 후처리 커밋은 기본값으로 만들지 않고, GitHub PR/Issue 상태로 merge 결과를 확인한다.
 
 ## 상태 표기
 
@@ -24,7 +26,7 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## P0. AI 작업 운영 규칙 및 개선 Backlog 정립
 
-- 상태: `In Progress` ([#113](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/113))
+- 상태: `In Progress` ([#113](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/113), [#166](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/166))
 - AS-IS: 개선 작업의 계획, 승인, AI 검토 결과가 GitHub 흐름과 일관되게 연결되어 있지 않다.
 - TO-BE: 작업 계획과 승인 기준을 Issue, 브랜치, PR, 문서에 연결해 재현 가능한 작업 흐름을 만든다.
 - 성공 기준:

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -26,11 +26,13 @@ Issue
 → AI Reviewer comment
 → Blocking 확인
 → merge
-→ WORK_PROGRESS.md 갱신
+→ GitHub PR/Issue 상태 확인
 ```
 
 바로 구현하지 말고, 먼저 develop 최신화, 열린 Issue/PR 확인, `WORK_PROGRESS.md`와 `BACKLOG.md` 조사를 수행한다.
 새 Issue/PR 본문은 repository template을 읽고 반드시 `--body-file` 방식으로 작성한다.
+작업 내용과 관련 docs 기록은 가능한 한 PR 본 작업 커밋에 함께 포함한다.
+Reviewer 이후 diff 변경을 피하기 위해 merge 후 `WORK_PROGRESS.md`만 갱신하는 후처리 커밋은 기본값으로 만들지 않는다.
 
 ## Overengineering Guardrail
 
@@ -57,7 +59,7 @@ Issue
 - #160/#161에서 Perspectives FULLTEXT relevance-first/hybrid ordering 비교를 완료했다.
 - #162/#163에서 새 이슈 후보마다 overengineering 여부를 먼저 판단하는 guardrail을 추가했다.
 - #164/#165에서 hybrid ranking query variant를 바로 구현하지 않는 이유와 후속 적용 기준을 docs/ADR로 정리했다.
-- 현재 진행 중인 단기 작업은 없다. 다음 작업은 열린 Issue/PR과 `WORK_PROGRESS.md`, `BACKLOG.md`를 다시 확인한 뒤 선택한다.
+- #166에서 PR 단위 문서 기록과 develop 커밋 이력 정리 기준을 문서화하는 작업을 진행 중이다.
 
 ## Recent Completed Work
 
@@ -70,6 +72,7 @@ Issue
 - #160/#161: Perspectives FULLTEXT ordering을 latest-first, relevance-first, hybrid 후보로 비교했다.
 - #162/#163: 새 후보마다 overengineering 여부를 먼저 판단하는 guardrail을 추가했다.
 - #164/#165: Perspectives ranking policy 도입 보류와 hybrid 후보 적용 기준을 ADR로 정리했다.
+- #166: PR 본 작업 커밋에 docs 기록을 함께 포함하고 merge 후 후처리 커밋을 기본값으로 만들지 않는 기준을 정리 중이다.
 
 ## Why #160 Matters
 
@@ -81,11 +84,22 @@ pure relevance-first는 wrong-context 기사를 끌어올릴 수 있어 바로 �
 
 ## Recommended Next Backend Issue
 
-현재 확정된 다음 이슈는 없다.
-다음 세션에서는 먼저 develop 최신화, 열린 Issue/PR 확인, `WORK_PROGRESS.md`와 `BACKLOG.md` 확인을 다시 수행한다.
-#110은 사용자가 별도로 지시하기 전까지 다루지 않는다.
+현재 진행 중:
 
-후보를 고를 때는 #162 guardrail에 따라 "지금 구현하면 과한가?"를 먼저 판단한다.
+```text
+#166 [DOCS] PR 단위 문서 기록과 develop 커밋 이력 정리 기준 추가
+```
+
+목표:
+
+- merge 후 `WORK_PROGRESS.md`만 갱신하는 후처리 커밋을 기본값으로 만들지 않는다.
+- 작업 내용, 검증, docs 기록을 PR 본 작업 커밋에 함께 포함한다.
+- Reviewer 이후 diff 변경 금지와 재검토 기준을 유지한다.
+- merge 시각/closed 상태처럼 사후에만 확정되는 정보는 GitHub PR/Issue 상태로 대체한다.
+
+다음 세션에서 새 후보를 고를 때는 먼저 develop 최신화, 열린 Issue/PR 확인, `WORK_PROGRESS.md`와 `BACKLOG.md` 확인을 다시 수행한다.
+#110은 사용자가 별도로 지시하기 전까지 다루지 않는다.
+#162 guardrail에 따라 "지금 구현하면 과한가?"를 먼저 판단한다.
 #164 ADR 기준상 hybrid ranking code experiment는 아래 조건이 준비된 뒤 별도 Issue로 검토한다.
 
 ```text
@@ -119,7 +133,8 @@ pure relevance-first는 wrong-context 기사를 끌어올릴 수 있어 바로 �
 
 - 이 문서에는 최신 상태와 다음 판단만 남긴다.
 - 세부 측정값, Reviewer 결과, merge 이력은 `WORK_PROGRESS.md`와 개별 문서에 남긴다.
-- 새 작업을 시작하거나 merge할 때 이 문서의 `Current Snapshot`과 `Recommended Next Backend Issue`를 갱신한다.
+- 새 작업을 시작할 때 이 문서의 `Current Snapshot`과 `Recommended Next Backend Issue`를 갱신한다.
+- merge 후 상태 확인은 GitHub PR/Issue 상태를 기준으로 하고, 별도 후처리 커밋은 예외 상황에만 만든다.
 - 의사결정 근거를 압축하되, 근거 문서 링크는 반드시 남긴다.
 
 ## Reviewer Agent Prompt Template

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -22,7 +22,7 @@ Issue 생성
 → Blocking 반영
 → 최종 Blocking 없음 확인
 → 사용자 승인 후 merge
-→ WORK_PROGRESS.md 상태 갱신
+→ GitHub PR/Issue 상태 확인
 ```
 
 ### 역할 분리
@@ -38,7 +38,10 @@ Issue 생성
 Reviewer는 코드 수정, 커밋, push, merge를 하지 않는다.
 Reviewer는 `## AI Reviewer 검토 결과` 제목으로 GitHub PR comment를 남긴다.
 Implementer는 새 Issue/PR을 만든 뒤 Reviewer Agent에게 전달할 검토 요청 예시를 사용자에게 함께 안내한다.
-최신 Reviewer comment가 `MERGE_READY`이고 사용자가 해당 PR에 대해 명시적으로 merge 진행을 승인한 경우, Implementer는 PR을 merge한 뒤 이 문서에 merge 상태와 다음 작업 상태를 기록한다.
+최신 Reviewer comment가 `MERGE_READY`이고 사용자가 해당 PR에 대해 명시적으로 merge 진행을 승인한 경우, Implementer는 PR을 merge한 뒤 GitHub PR/Issue 상태와 local `develop` 최신화로 merge 결과를 확인한다.
+다만 develop commit history를 이슈별 핵심 변경 중심으로 유지하기 위해, 작업 내용과 관련 docs 기록은 가능한 한 PR 본 작업 커밋에 함께 포함한다.
+merge 후 `WORK_PROGRESS.md`만 갱신하는 후처리 커밋은 기본값으로 만들지 않고, GitHub PR/Issue 상태로 merge 결과를 확인한다.
+후처리 커밋은 PR에 포함된 문서가 다음 세션을 잘못 안내하거나 Reviewer가 명시적으로 요구한 경우처럼 필요한 때에만 만든다.
 
 ### 커밋 메시지 규칙
 
@@ -94,6 +97,7 @@ Blocking 예시:
 - #160/#161에서 Perspectives FULLTEXT 정렬 기준을 latest-first, relevance-first, hybrid ordering으로 비교했다.
 - #162/#163에서 새 이슈 후보마다 overengineering 여부를 먼저 판단하는 docs guardrail을 추가했다.
 - #164/#165에서 #160 측정 결과를 바탕으로 Perspectives ranking policy 도입 보류와 hybrid 후보 적용 기준을 docs/ADR로 정리했다.
+- #166에서 PR 본 작업 커밋에 docs 기록을 함께 포함하고 merge 후 후처리 커밋을 기본값으로 만들지 않는 기준을 정리 중이다.
 - 현재 반복 성능/안정성 기본기 흐름의 주요 후보(#123, #127, #129, #131, #133, #137, #140, #142, #146)와 AI workflow 보강(#144)은 merge 완료 상태다.
 
 ### #113 / PR #114 - 백엔드 개선 Backlog 및 AI 작업 운영 규칙 수립
@@ -690,7 +694,7 @@ Reviewer 결과:
 - Reviewer comment에서 `MERGE_READY`와 Blocking 없음이 확인되고 사용자가 해당 PR에 대해 명시적으로 merge 진행을 승인한 경우, Implementer가 바로 merge까지 수행하는 흐름을 문서화한다.
 - Reviewer comment 이후 PR diff에 추가 변경이 있으면 최신 diff 기준으로 재검토를 받아야 한다는 기준을 명확히 한다.
 - 새 Issue/PR 생성 후에는 Reviewer Agent에게 전달할 검토 요청 예시를 사용자에게 함께 안내하는 규칙을 추가한다.
-- merge 후 `WORK_PROGRESS.md`에 PR 상태, Reviewer 결정, merge 결과, 다음 작업 상태를 남겨 새 Implementer 세션이 흐름을 복원할 수 있게 한다.
+- 당시 기준으로는 merge 후 `WORK_PROGRESS.md`에 PR 상태, Reviewer 결정, merge 결과, 다음 작업 상태를 남기도록 했다. 이 기본값은 #166에서 PR 본 작업 커밋에 docs 기록을 포함하고 GitHub PR/Issue 상태로 merge 결과를 확인하는 방향으로 조정한다.
 
 수정 방향:
 
@@ -1157,6 +1161,46 @@ Reviewer 결과:
 - Non-blocking 없음.
 - `check-review-blocking.ps1 -PrNumber 165` 결과 `MERGE_READY`를 확인했다.
 - 2026-07-08 기준 PR #165는 merge 완료되었고, Issue #164는 closed 상태다.
+
+---
+
+### #166 - PR 단위 문서 기록과 develop 커밋 이력 정리 기준 추가
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/166
+- 상태: PR 기준 진행 기록
+- 작업 브랜치: `docs/#166-commit-history-policy`
+- 주요 파일:
+  - `docs/ai-workflow/reviewer-comment-workflow.md`
+  - `docs/ai-workflow/README.md`
+  - `docs/backend-improvement/NEXT_AGENT_BRIEF.md`
+  - `docs/backend-improvement/WORK_PROGRESS.md`
+  - `docs/backend-improvement/BACKLOG.md`
+
+목표:
+
+- merge 후 `WORK_PROGRESS.md`만 갱신하는 후처리 커밋이 반복되어 develop commit history가 잘게 쪼개지는 문제를 줄인다.
+- 작업 내용, 검증 결과, docs 기록을 PR 본 작업 커밋에 함께 포함하는 기준을 명확히 한다.
+- Reviewer 이후 diff 변경 금지와 최신 diff 기준 재검토 원칙을 유지한다.
+- merge 시각이나 closed 상태처럼 사후에만 확정되는 정보는 GitHub PR/Issue 상태로 확인한다.
+
+Overengineering 판단:
+
+- MCP 자동화나 스크립트 구현은 아직 과하다.
+- 현재 문제는 문서화된 workflow 기본값이 후처리 커밋을 유도하는 것이므로, 코드 변경 없이 문서 기준을 정리하는 것이 적절하다.
+- develop 이력을 깔끔하게 유지하는 기준은 포트폴리오 설명 가능성과 협업 재현성에 직접 도움이 된다.
+
+수정 방향:
+
+- `reviewer-comment-workflow.md`의 merge 후 처리 기준을 GitHub PR/Issue 상태 확인 중심으로 바꾼다.
+- `README.md`의 GitHub 기록 기준에서 merge 결과와 다음 상태의 위치를 PR 본문, GitHub PR/Issue 상태, 필요 시 `WORK_PROGRESS.md`로 조정한다.
+- `NEXT_AGENT_BRIEF.md`와 이 문서에 #166 진행 상태와 새 기본 원칙을 기록한다.
+- 이번 PR 자체도 작업 내용과 docs 기록을 한 커밋에 포함하고, merge 후 별도 기록 커밋을 만들지 않는 기준을 따른다.
+
+검증:
+
+```text
+git diff --check
+```
 
 ## 4. 이후 개선 로드맵
 


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #166

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)


## 📝 작업 내용
- merge 후 `WORK_PROGRESS.md`만 갱신하는 후처리 커밋을 기본값으로 만들지 않는 기준을 문서화했습니다.
- 작업 내용, 검증 결과, docs 기록을 PR 본 작업 커밋에 함께 포함하는 원칙을 정리했습니다.
- `docs/ai-workflow`와 `docs/backend-improvement` handoff 문서의 merge 후 처리 기준을 GitHub PR/Issue 상태 확인 중심으로 맞췄습니다.
- 이번 PR 자체도 관련 docs 기록을 단일 커밋에 포함했습니다.

## 🔍 기술적 배경
- #158/#160/#162/#164 이후 merge 결과 기록 커밋이 반복되면서 develop commit history가 이슈별 핵심 변경보다 잘게 쪼개지는 문제가 확인됐습니다.
- Reviewer 이후 PR diff를 바꾸면 재검토가 필요하므로, merge 후 후처리 커밋을 기본값으로 두는 대신 PR 본 작업 커밋에 필요한 docs 기록을 미리 포함하는 편이 더 안정적입니다.
- merge 시각과 closed 상태처럼 사후에만 확정되는 정보는 GitHub PR/Issue 상태를 기준으로 확인하도록 역할을 분리했습니다.


## 🧪 테스트/검증 (필수)
- [x] `git diff --check`로 문서 포맷 문제 없음 확인
- [x] workflow 문서 간 merge 후 처리 기준이 충돌하지 않는지 확인

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?


## 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
- #166 문서 범위에 머무르고 코드/API/DB/Redis/FULLTEXT query 변경이 없는지 확인해주세요.
- merge 후 후처리 커밋을 기본값으로 만들지 않는 새 기준이 Reviewer 재검토 원칙과 충돌하지 않는지 확인해주세요.
- `WORK_PROGRESS.md`, `NEXT_AGENT_BRIEF.md`, `BACKLOG.md`, `docs/ai-workflow` 문서의 기준이 서로 일관적인지 확인해주세요.


## ➕ 추후 계획(선택)
- 이후 이슈부터 작업 내용과 관련 docs 기록은 PR 본 작업 커밋에 함께 포함하고, merge 후 별도 기록 커밋은 예외 상황에서만 만듭니다.
