### PR TITLE
📊 [PERF/#168] 검색 API FULLTEXT 기준선 수립

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -52,6 +52,16 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
   - 연결 지연, 읽기 지연, 본문 없음, 차단 응답의 처리 규칙이 문서화되고 검증된다.
   - 동일 기사 요청 시 불필요한 재크롤링을 줄이는 기준을 확인한다.
 
+## P2-1. 검색 API FULLTEXT 성능 기준선
+
+- 상태: `In Progress` ([#168](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/168))
+- AS-IS: #133/#134에서 검색 API FULLTEXT 실행 계획과 중복 `OR MATCH` 최적화는 확인했지만, 검색어 유형별 API p95, 실패율, 결과 수 기준선은 분리되어 있지 않다.
+- TO-BE: 영어/한국어/짧은 검색어/결과 적은 검색어를 같은 조건에서 측정하고, MySQL FULLTEXT 기반 검색의 안정성을 p95와 실패율로 설명한다.
+- 성공 기준:
+  - 검색어별 측정 스크립트가 있다.
+  - p95, 실패율, 결과 수를 기록할 수 있는 문서 템플릿이 있다.
+  - Elasticsearch 도입 여부는 결정하지 않고, 도입 검토 조건만 남긴다.
+
 ## P3. 다국어 이슈 매칭 품질 개선
 
 - 상태: `Backlog` (최근 완료: [#142](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/142), [#146](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/146), [#148](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/148), [#150](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/150), [#152](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/152), [#154](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/154), [#156](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/156), [#160](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/160), [#164](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/164))

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -59,7 +59,8 @@ Reviewer 이후 diff 변경을 피하기 위해 merge 후 `WORK_PROGRESS.md`만 
 - #160/#161에서 Perspectives FULLTEXT relevance-first/hybrid ordering 비교를 완료했다.
 - #162/#163에서 새 이슈 후보마다 overengineering 여부를 먼저 판단하는 guardrail을 추가했다.
 - #164/#165에서 hybrid ranking query variant를 바로 구현하지 않는 이유와 후속 적용 기준을 docs/ADR로 정리했다.
-- #166에서 PR 단위 문서 기록과 develop 커밋 이력 정리 기준을 문서화하는 작업을 진행 중이다.
+- #166/#167에서 PR 단위 문서 기록과 develop 커밋 이력 정리 기준을 문서화했다.
+- #168에서 검색 API FULLTEXT 검색어별 성능 기준선 수립을 진행 중이다.
 
 ## Recent Completed Work
 
@@ -72,7 +73,7 @@ Reviewer 이후 diff 변경을 피하기 위해 merge 후 `WORK_PROGRESS.md`만 
 - #160/#161: Perspectives FULLTEXT ordering을 latest-first, relevance-first, hybrid 후보로 비교했다.
 - #162/#163: 새 후보마다 overengineering 여부를 먼저 판단하는 guardrail을 추가했다.
 - #164/#165: Perspectives ranking policy 도입 보류와 hybrid 후보 적용 기준을 ADR로 정리했다.
-- #166: PR 본 작업 커밋에 docs 기록을 함께 포함하고 merge 후 후처리 커밋을 기본값으로 만들지 않는 기준을 정리 중이다.
+- #166/#167: PR 본 작업 커밋에 docs 기록을 함께 포함하고 merge 후 후처리 커밋을 기본값으로 만들지 않는 기준을 정리했다.
 
 ## Why #160 Matters
 
@@ -87,15 +88,15 @@ pure relevance-first는 wrong-context 기사를 끌어올릴 수 있어 바로 �
 현재 진행 중:
 
 ```text
-#166 [DOCS] PR 단위 문서 기록과 develop 커밋 이력 정리 기준 추가
+#168 [PERF] 검색 API FULLTEXT 검색어별 성능 기준선 수립
 ```
 
 목표:
 
-- merge 후 `WORK_PROGRESS.md`만 갱신하는 후처리 커밋을 기본값으로 만들지 않는다.
-- 작업 내용, 검증, docs 기록을 PR 본 작업 커밋에 함께 포함한다.
-- Reviewer 이후 diff 변경 금지와 재검토 기준을 유지한다.
-- merge 시각/closed 상태처럼 사후에만 확정되는 정보는 GitHub PR/Issue 상태로 대체한다.
+- 검색 API의 MySQL FULLTEXT 경로를 검색어 유형별로 측정할 수 있게 한다.
+- #133/#134 EXPLAIN 기반 쿼리 개선을 API p95, 실패율, 결과 수 기준선과 연결한다.
+- Elasticsearch 도입 여부는 결정하지 않고, 도입 검토 조건만 남긴다.
+- 이력서에 `검색 API MySQL FULLTEXT 실행 계획 분석 및 검색어별 p95/실패율 기준선 수립`으로 압축 가능한 근거를 만든다.
 
 다음 세션에서 새 후보를 고를 때는 먼저 develop 최신화, 열린 Issue/PR 확인, `WORK_PROGRESS.md`와 `BACKLOG.md` 확인을 다시 수행한다.
 #110은 사용자가 별도로 지시하기 전까지 다루지 않는다.
@@ -117,6 +118,9 @@ pure relevance-first는 wrong-context 기사를 끌어올릴 수 있어 바로 �
 
 참고 문서:
 
+- `docs/backend-improvement/search-fulltext-analysis.md`
+- `docs/backend-improvement/search-fulltext-term-baseline.md`
+- `docs/backend-improvement/load-test-baseline.md`
 - `docs/backend-improvement/perspectives-fulltext-generic-token-filter-result.md`
 - `docs/backend-improvement/perspectives-fulltext-ordering-comparison.md`
 - `docs/backend-improvement/perspectives-ranking-policy-adr.md`

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -97,7 +97,8 @@ Blocking 예시:
 - #160/#161에서 Perspectives FULLTEXT 정렬 기준을 latest-first, relevance-first, hybrid ordering으로 비교했다.
 - #162/#163에서 새 이슈 후보마다 overengineering 여부를 먼저 판단하는 docs guardrail을 추가했다.
 - #164/#165에서 #160 측정 결과를 바탕으로 Perspectives ranking policy 도입 보류와 hybrid 후보 적용 기준을 docs/ADR로 정리했다.
-- #166에서 PR 본 작업 커밋에 docs 기록을 함께 포함하고 merge 후 후처리 커밋을 기본값으로 만들지 않는 기준을 정리 중이다.
+- #166/#167에서 PR 본 작업 커밋에 docs 기록을 함께 포함하고 merge 후 후처리 커밋을 기본값으로 만들지 않는 기준을 정리했다.
+- #168에서 검색 API FULLTEXT 검색어별 성능 기준선을 수립 중이다.
 - 현재 반복 성능/안정성 기본기 흐름의 주요 후보(#123, #127, #129, #131, #133, #137, #140, #142, #146)와 AI workflow 보강(#144)은 merge 완료 상태다.
 
 ### #113 / PR #114 - 백엔드 개선 Backlog 및 AI 작업 운영 규칙 수립
@@ -1201,6 +1202,56 @@ Overengineering 판단:
 ```text
 git diff --check
 ```
+
+---
+
+### #168 - 검색 API FULLTEXT 검색어별 성능 기준선 수립
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/168
+- 상태: PR 기준 진행 기록
+- 작업 브랜치: `perf/#168-search-fulltext-term-baseline`
+- 주요 파일:
+  - `load-tests/k6/search-fulltext-terms.js`
+  - `docs/backend-improvement/search-fulltext-term-baseline.md`
+  - `docs/backend-improvement/load-test-baseline.md`
+  - `docs/backend-improvement/BACKLOG.md`
+  - `docs/backend-improvement/NEXT_AGENT_BRIEF.md`
+  - `docs/backend-improvement/WORK_PROGRESS.md`
+
+목표:
+
+- #133/#134에서 확인한 검색 API FULLTEXT 실행 계획 개선을 API-level p95, 실패율, 결과 수 기준선과 연결한다.
+- 영어/한국어/짧은 검색어/결과 적은 검색어를 같은 k6 조건에서 측정할 수 있게 한다.
+- Elasticsearch 도입 여부를 바로 결정하지 않고, MySQL FULLTEXT 기반 검색이 어떤 조건에서 안정적인지 설명 가능한 기준을 만든다.
+- 이력서에서는 `검색 API MySQL FULLTEXT 실행 계획 분석 및 검색어별 p95/실패율 기준선 수립`으로 압축 가능하게 한다.
+
+Overengineering 판단:
+
+- 지금 Elasticsearch나 query rewrite를 도입하면 과하다.
+- 이미 #133/#134에서 쿼리 개선 근거가 있으므로, 다음 단계는 더 큰 기술 도입이 아니라 API 기준선 수치화다.
+- 코드/API/DB 동작을 바꾸지 않고 k6 스크립트와 문서 기준선을 추가하는 범위가 현재 단계에 적절하다.
+
+수정 방향:
+
+- 검색어 세트를 순회하는 `search-fulltext-terms.js` k6 스크립트를 추가한다.
+- `search_result_count` metric으로 응답의 `data.searchArticles.length`를 기록한다.
+- `search-fulltext-term-baseline.md`에 검색어 유형, 실행 방법, 결과 기록 템플릿, 해석 기준, 이력서 문장 후보를 정리한다.
+- 기존 `load-test-baseline.md`, `BACKLOG.md`, `NEXT_AGENT_BRIEF.md`에 새 기준선 문서를 연결한다.
+
+검증:
+
+```text
+node --check load-tests/k6/search-fulltext-terms.js
+k6 inspect load-tests/k6/search-fulltext-terms.js
+k6 run load-tests/k6/search-fulltext-terms.js (SEARCH_VUS=1, SEARCH_DURATION=10s, term-by-term)
+git diff --check
+```
+
+비고:
+
+- 2026-07-09 로컬 Docker MySQL/Redis와 `bootRun` 서버(`localhost:8080`) 기준으로 검색어별 smoke baseline을 기록했다.
+- p95/failure/result count: `war` 76.63ms/0.00%/100, `korea` 60.38ms/0.00%/40, `economy` 63.24ms/0.00%/39, `technology` 103.41ms/0.00%/82, `대구` 50.14ms/0.00%/0, `AI` 24.78ms/0.00%/0.
+- 이번 PR은 검색어별 기준선 수집을 재현 가능하게 하는 스크립트와 최초 로컬 측정 기록 수립에 집중한다.
 
 ## 4. 이후 개선 로드맵
 

--- a/docs/backend-improvement/load-test-baseline.md
+++ b/docs/backend-improvement/load-test-baseline.md
@@ -73,6 +73,9 @@ k6 run .\load-tests\k6\api-baseline.js
 Redis cold cache와 warm cache의 성능 차이를 분리 측정할 때는 `load-tests/k6/perspectives-cache.js`를 사용한다.
 자세한 실행 조건과 결과 기록 방식은 `docs/backend-improvement/perspectives-cache-load-test.md`에 기록한다.
 
+검색 API를 검색어 유형별로 분리 측정할 때는 `load-tests/k6/search-fulltext-terms.js`를 사용한다.
+자세한 검색어 세트, 실행 조건, 결과 기록 방식은 `docs/backend-improvement/search-fulltext-term-baseline.md`에 기록한다.
+
 VU와 실행 시간은 환경 변수로 조정한다.
 
 ```powershell

--- a/docs/backend-improvement/search-fulltext-term-baseline.md
+++ b/docs/backend-improvement/search-fulltext-term-baseline.md
@@ -1,0 +1,167 @@
+# Search API FULLTEXT term baseline
+
+## Purpose
+
+This document defines a repeatable baseline for `GET /api/search` by search term type.
+It connects the #133/#134 MySQL FULLTEXT query-plan improvement to API-level measurements such as p95 response time, failure rate, and result count.
+
+This work does not change code behavior, DB schema, FULLTEXT query shape, API response shape, Redis policy, or translation policy.
+
+## Portfolio Summary Candidate
+
+```text
+검색 API의 MySQL FULLTEXT 쿼리를 검색어 유형별로 측정하고 실행 계획 개선 근거와 연결해, p95 응답 시간과 실패율 기준선을 수립했습니다.
+```
+
+Shorter resume keyword version:
+
+```text
+검색 API MySQL FULLTEXT 실행 계획 분석 및 검색어별 p95/실패율 기준선 수립
+```
+
+## Background
+
+#133/#134 analyzed the Search API FULLTEXT query path.
+For English inputs where the original search text and translated text are effectively the same, the previous duplicated `OR MATCH` shape could make MySQL choose `idx_article_published_at` instead of the intended FULLTEXT index.
+
+The current code avoids duplicated `OR MATCH` for same original/translated terms and keeps the OR query only when the original and translated terms differ.
+
+Known local DB-level match counts from #133:
+
+| Keyword | Match count | Interpretation |
+| --- | ---: | --- |
+| `war` | 404 | English same-term, high-match sample |
+| `technology` | 82 | English same-term, medium-match sample |
+| `economy` | 39 | English same-term, lower-match sample |
+| `대구` OR `daegu` | 0 | Korean input translated to English, zero current FULLTEXT match sample |
+
+Known API checks after #123/#126 and #133/#134:
+
+| Request | Status | Notes |
+| --- | --- | --- |
+| `/api/search?text=war` | 200 | English, many matches |
+| `/api/search?text=economy` | 200 | English, fewer matches |
+| `/api/search?text=technology` | 200 | English, medium matches |
+| `/api/search?text=대구` | 200 | Translates to `daegu`, zero current FULLTEXT matches |
+
+## Measurement Tool
+
+Use `load-tests/k6/search-fulltext-terms.js`.
+
+The script requests `/api/search` for a comma-separated search term set and tags each request with `searchTerm`.
+It also records the response `data.searchArticles.length` into the custom `search_result_count` metric.
+
+Default terms:
+
+```text
+war,korea,economy,technology,대구,AI
+```
+
+## Search Term Set
+
+| Type | Term | Why |
+| --- | --- | --- |
+| English high-match | `war` | Exercises many-match same-term FULLTEXT behavior from #133. |
+| English common topic | `korea` | Checks common English keyword behavior after #123 fixed 500 responses. |
+| English lower-match | `economy` | Checks lower result-count path. |
+| English medium-match | `technology` | Checks medium result-count path from #133. |
+| Korean translated zero-match | `대구` | Confirms translated/original search can return 200 even with zero local FULLTEXT matches. |
+| Short/common technical term | `AI` | Checks short uppercase input handling and result count variance. |
+
+Do not treat result count alone as search quality.
+This baseline records performance and stability first.
+Search relevance and multilingual quality require separate samples and manual review.
+
+## Execution
+
+Start local dependencies and server first.
+
+```powershell
+docker compose -f docker-compose.dev.yml up -d
+.\gradlew.bat bootRun
+```
+
+Run a short smoke baseline:
+
+```powershell
+$env:BASE_URL = "http://localhost:8080"
+$env:SEARCH_TERMS = "war,korea,economy,technology,대구,AI"
+$env:SEARCH_VUS = "1"
+$env:SEARCH_DURATION = "30s"
+$env:SLEEP_SECONDS = "1"
+k6 run .\load-tests\k6\search-fulltext-terms.js
+```
+
+Run a longer local baseline:
+
+```powershell
+$env:BASE_URL = "http://localhost:8080"
+$env:SEARCH_TERMS = "war,korea,economy,technology,대구,AI"
+$env:SEARCH_VUS = "3"
+$env:SEARCH_DURATION = "2m"
+$env:SLEEP_SECONDS = "1"
+k6 run .\load-tests\k6\search-fulltext-terms.js
+```
+
+Optional filters:
+
+```powershell
+$env:COUNTRY = "kr"
+$env:CATEGORY = "business"
+$env:DATE = "2026-07-01"
+```
+
+## Result Recording Template
+
+Record p95 and failure rate from k6 output.
+Record result count from `search_result_count` per `searchTerm` and confirm `SearchArticlesService` logs for `resultCount`, `dbSearchMs`, and `totalMs` when needed.
+
+| Date | Environment | Term | Type | p95 | Failure rate | Result count | Notes |
+| --- | --- | --- | --- | ---: | ---: | ---: | --- |
+|  | local/dev | `war` | English high-match |  |  |  |  |
+|  | local/dev | `korea` | English common topic |  |  |  |  |
+|  | local/dev | `economy` | English lower-match |  |  |  |  |
+|  | local/dev | `technology` | English medium-match |  |  |  |  |
+|  | local/dev | `대구` | Korean translated zero-match |  |  |  |  |
+|  | local/dev | `AI` | Short/common technical term |  |  |  |  |
+
+## Initial Local Smoke Result
+
+The first baseline was measured on 2026-07-09 with local Docker MySQL/Redis containers and a local `bootRun` server on `http://localhost:8080`.
+Each term was executed separately with `SEARCH_VUS=1`, `SEARCH_DURATION=10s`, and `SLEEP_SECONDS=1`.
+
+This is a smoke baseline, not a capacity limit test.
+Use it as a same-environment comparison point for later query, cache, or search-policy changes.
+
+| Date | Environment | Term | Type | p95 | Failure rate | Result count | Requests | Checks | Notes |
+| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
+| 2026-07-09 | local/dev | `war` | English high-match | 76.63ms | 0.00% | 100 | 10 | 100.00% | API limit-sized result set |
+| 2026-07-09 | local/dev | `korea` | English common topic | 60.38ms | 0.00% | 40 | 10 | 100.00% | Common English keyword |
+| 2026-07-09 | local/dev | `economy` | English lower-match | 63.24ms | 0.00% | 39 | 10 | 100.00% | Lower result-count sample |
+| 2026-07-09 | local/dev | `technology` | English medium-match | 103.41ms | 0.00% | 82 | 10 | 100.00% | Slowest sample in this smoke run |
+| 2026-07-09 | local/dev | `대구` | Korean translated zero-match | 50.14ms | 0.00% | 0 | 10 | 100.00% | Valid zero-match result |
+| 2026-07-09 | local/dev | `AI` | Short/common technical term | 24.78ms | 0.00% | 0 | 10 | 100.00% | Valid zero-match result |
+
+## Interpretation Rules
+
+- A 2xx response with `0` results is not a failure. It can be a valid zero-match FULLTEXT result.
+- A high result count can still be low relevance; this document is not a relevance benchmark.
+- If English same-term searches are slow, compare with #133 EXPLAIN notes and inspect whether the single-MATCH path is still used.
+- If translated/original terms differ and performance is slow, analyze the OR-MATCH path separately before considering query rewrites.
+- Elasticsearch or another search engine should be considered only after repeated evidence of missing recall, poor multilingual relevance, or p95 instability that cannot be addressed with MySQL FULLTEXT tuning.
+
+## Current Scope Decision
+
+This issue establishes the measurement baseline and script.
+The current PR validates the script shape with `node --check`, `k6 inspect`, `git diff --check`, and a local k6 smoke run against `localhost:8080`.
+The smoke run recorded per-term p95, failure rate, result count, request count, and check success rate.
+
+It intentionally avoids:
+
+- changing repository queries
+- adding Elasticsearch
+- changing translation behavior
+- changing API response shape
+- adding new DB indexes
+
+The next step is to repeat the same term set after a future query, cache, or search-policy change and compare p95/failure-rate trends by term type.

--- a/load-tests/k6/search-fulltext-terms.js
+++ b/load-tests/k6/search-fulltext-terms.js
@@ -1,0 +1,85 @@
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { Trend } from 'k6/metrics';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const SEARCH_TERMS = (__ENV.SEARCH_TERMS || 'war,korea,economy,technology,대구,AI')
+  .split(',')
+  .map((term) => term.trim())
+  .filter((term) => term.length > 0);
+const COUNTRY = __ENV.COUNTRY || '';
+const CATEGORY = __ENV.CATEGORY || '';
+const DATE = __ENV.DATE || '';
+const SLEEP_SECONDS = Number(__ENV.SLEEP_SECONDS || 1);
+
+export const searchResultCount = new Trend('search_result_count');
+
+export const options = {
+  scenarios: {
+    search_fulltext_terms: {
+      executor: 'constant-vus',
+      exec: 'searchFulltextTerms',
+      vus: Number(__ENV.SEARCH_VUS || 1),
+      duration: __ENV.SEARCH_DURATION || '30s',
+    },
+  },
+  thresholds: {
+    'http_req_failed{api:search_fulltext_terms}': ['rate<0.01'],
+    'http_req_duration{api:search_fulltext_terms}': ['p(95)<1500'],
+  },
+};
+
+function query(params) {
+  return Object.entries(params)
+    .filter(([, value]) => value !== undefined && value !== null && value !== '')
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join('&');
+}
+
+function searchResultSummary(res) {
+  try {
+    const body = res.json();
+    const articles = body && body.data && body.data.searchArticles;
+    return {
+      count: Array.isArray(articles) ? articles.length : 0,
+      hasArray: Array.isArray(articles),
+    };
+  } catch (e) {
+    return {
+      count: 0,
+      hasArray: false,
+    };
+  }
+}
+
+export function searchFulltextTerms() {
+  group('search fulltext terms', () => {
+    for (const term of SEARCH_TERMS) {
+      const params = query({
+        text: term,
+        country: COUNTRY,
+        category: CATEGORY,
+        date: DATE,
+      });
+
+      const res = http.get(`${BASE_URL}/api/search?${params}`, {
+        tags: {
+          api: 'search_fulltext_terms',
+          endpoint: 'search',
+          searchTerm: term,
+        },
+      });
+      const result = searchResultSummary(res);
+      const resultCount = result.count;
+      searchResultCount.add(resultCount, { searchTerm: term });
+
+      check(res, {
+        'status is 2xx': (r) => r.status >= 200 && r.status < 300,
+        'response has body': (r) => r.body && r.body.length > 0,
+        'response has searchArticles array': () => result.hasArray,
+      });
+
+      sleep(SLEEP_SECONDS);
+    }
+  });
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #168

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)


## 📝 작업 내용
- 검색 API 검색어별 FULLTEXT 성능 기준선 문서를 추가했습니다.
- 검색어 세트를 순회하며 `/api/search` p95, 실패율, 결과 수를 측정할 수 있는 k6 스크립트를 추가했습니다.
- 로컬 Docker MySQL/Redis와 `bootRun` 서버(`localhost:8080`) 기준으로 검색어별 최초 smoke baseline을 기록했습니다.
- 기존 load-test 기준선, BACKLOG, NEXT_AGENT_BRIEF, WORK_PROGRESS에 #168 진행 상태와 기준선 문서를 연결했습니다.
- 코드, DB schema, FULLTEXT query, API 응답 구조, Redis 정책은 변경하지 않았습니다.

## 🔍 기술적 배경
- #133/#134에서 검색 API FULLTEXT 실행 계획과 중복 `OR MATCH` 최적화는 확인했지만, 검색어 유형별 API p95/실패율/결과 수 기준선은 분리되어 있지 않았습니다.
- 이번 PR은 Elasticsearch 같은 별도 검색 엔진 도입 전에 현재 MySQL FULLTEXT 기반 검색이 어느 조건에서 안정적인지 설명 가능한 측정 틀을 만듭니다.
- 이력서에는 `검색 API MySQL FULLTEXT 실행 계획 분석 및 검색어별 p95/실패율 기준선 수립`으로 압축 가능한 작업입니다.


## 🧪 테스트/검증 (필수)
- [x] `node --check load-tests/k6/search-fulltext-terms.js`
- [x] `k6 inspect load-tests/k6/search-fulltext-terms.js`
- [x] `k6 run load-tests/k6/search-fulltext-terms.js` (`SEARCH_VUS=1`, `SEARCH_DURATION=10s`, term-by-term)
- [x] `git diff --check`

Local k6 smoke result:

| Term | p95 | Failure rate | Result count |
| --- | ---: | ---: | ---: |
| `war` | 76.63ms | 0.00% | 100 |
| `korea` | 60.38ms | 0.00% | 40 |
| `economy` | 63.24ms | 0.00% | 39 |
| `technology` | 103.41ms | 0.00% | 82 |
| `대구` | 50.14ms | 0.00% | 0 |
| `AI` | 24.78ms | 0.00% | 0 |

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?


## 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
- #168 범위가 검색 API FULLTEXT 기준선 문서/스크립트 추가에 머무르고 코드/API/DB/Redis 정책 변경이 없는지 확인해주세요.
- k6 스크립트가 검색어별 p95, 실패율, 결과 수 기준선을 수집하기에 충분한지 확인해주세요.
- 로컬 smoke 측정값이 문서와 PR 본문에 일관되게 기록됐는지 확인해주세요.
- 이력서용 요약 문장이 문제/해결/결과 지표 구조로 과장 없이 연결되는지 확인해주세요.


## ➕ 추후 계획(선택)
- 동일 검색어 세트를 향후 query/cache/search-policy 변경 후 반복 실행해 p95, 실패율, 결과 수를 비교합니다.
- 반복적으로 느린 검색어 유형이 확인되면 MySQL FULLTEXT 추가 튜닝 또는 Elasticsearch 도입 ADR을 별도 Issue로 검토합니다.
