### PR TITLE
📊 [PERF/#170] 기사 원문 크롤링 기준선 수립

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -45,22 +45,24 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## P2. 기사 원문 크롤링 안정성 개선
 
-- 상태: `Backlog`
+- 상태: `In Progress` ([#170](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/170))
 - AS-IS: 기사 상세의 요약·질의응답 요청 중 외부 언론사 페이지를 동기 크롤링하며, 외부 사이트의 지연과 실패가 사용자 요청에 직접 영향을 준다.
 - TO-BE: timeout, 실패 분류, 재시도 정책, 크롤링 결과 저장 정책을 정의하고 장애 상황에서도 예측 가능한 응답을 제공한다.
 - 성공 기준:
   - 연결 지연, 읽기 지연, 본문 없음, 차단 응답의 처리 규칙이 문서화되고 검증된다.
   - 동일 기사 요청 시 불필요한 재크롤링을 줄이는 기준을 확인한다.
+  - #170에서 요약 API의 동기 원문 크롤링 경로를 cold/warm/fallback 조건으로 측정할 수 있는 기준선을 수립한다.
 
 ## P2-1. 검색 API FULLTEXT 성능 기준선
 
-- 상태: `In Progress` ([#168](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/168))
+- 상태: `Done` ([#168](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/168), [PR #169](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/169))
 - AS-IS: #133/#134에서 검색 API FULLTEXT 실행 계획과 중복 `OR MATCH` 최적화는 확인했지만, 검색어 유형별 API p95, 실패율, 결과 수 기준선은 분리되어 있지 않다.
 - TO-BE: 영어/한국어/짧은 검색어/결과 적은 검색어를 같은 조건에서 측정하고, MySQL FULLTEXT 기반 검색의 안정성을 p95와 실패율로 설명한다.
 - 성공 기준:
   - 검색어별 측정 스크립트가 있다.
   - p95, 실패율, 결과 수를 기록할 수 있는 문서 템플릿이 있다.
   - Elasticsearch 도입 여부는 결정하지 않고, 도입 검토 조건만 남긴다.
+  - #168/#169에서 검색어별 smoke baseline을 기록했다.
 
 ## P3. 다국어 이슈 매칭 품질 개선
 

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -60,7 +60,8 @@ Reviewer 이후 diff 변경을 피하기 위해 merge 후 `WORK_PROGRESS.md`만 
 - #162/#163에서 새 이슈 후보마다 overengineering 여부를 먼저 판단하는 guardrail을 추가했다.
 - #164/#165에서 hybrid ranking query variant를 바로 구현하지 않는 이유와 후속 적용 기준을 docs/ADR로 정리했다.
 - #166/#167에서 PR 단위 문서 기록과 develop 커밋 이력 정리 기준을 문서화했다.
-- #168에서 검색 API FULLTEXT 검색어별 성능 기준선 수립을 진행 중이다.
+- #168/#169에서 검색 API FULLTEXT 검색어별 성능 기준선 수립을 완료했다.
+- #170에서 기사 원문 크롤링 동기 외부 호출 응답 지연 기준선 수립을 진행 중이다.
 
 ## Recent Completed Work
 
@@ -74,6 +75,7 @@ Reviewer 이후 diff 변경을 피하기 위해 merge 후 `WORK_PROGRESS.md`만 
 - #162/#163: 새 후보마다 overengineering 여부를 먼저 판단하는 guardrail을 추가했다.
 - #164/#165: Perspectives ranking policy 도입 보류와 hybrid 후보 적용 기준을 ADR로 정리했다.
 - #166/#167: PR 본 작업 커밋에 docs 기록을 함께 포함하고 merge 후 후처리 커밋을 기본값으로 만들지 않는 기준을 정리했다.
+- #168/#169: 검색 API FULLTEXT 검색어별 p95, 실패율, 결과 수 smoke 기준선을 수립했다.
 
 ## Why #160 Matters
 
@@ -88,19 +90,22 @@ pure relevance-first는 wrong-context 기사를 끌어올릴 수 있어 바로 �
 현재 진행 중:
 
 ```text
-#168 [PERF] 검색 API FULLTEXT 검색어별 성능 기준선 수립
+#170 [PERF] 기사 원문 크롤링 동기 외부 호출 응답 지연 기준선 수립
 ```
 
 목표:
 
-- 검색 API의 MySQL FULLTEXT 경로를 검색어 유형별로 측정할 수 있게 한다.
-- #133/#134 EXPLAIN 기반 쿼리 개선을 API p95, 실패율, 결과 수 기준선과 연결한다.
-- Elasticsearch 도입 여부는 결정하지 않고, 도입 검토 조건만 남긴다.
-- 이력서에 `검색 API MySQL FULLTEXT 실행 계획 분석 및 검색어별 p95/실패율 기준선 수립`으로 압축 가능한 근거를 만든다.
+- 기사 요약 API에서 동기 원문 크롤링이 사용자 요청 지연에 주는 영향을 측정할 수 있게 한다.
+- #137/#138의 timeout/fallback 및 외부 I/O 트랜잭션 분리 작업을 API p95, 실패율, crawler fallback rate 기준선과 연결한다.
+- 비동기/Kafka/Redis 캐시 도입은 바로 결정하지 않고, 도입 검토 조건만 남긴다.
+- 이력서에 `기사 요약 API 동기 외부 크롤링 p95/fallback 기준선 수립`으로 압축 가능한 근거를 만든다.
 
 다음 세션에서 새 후보를 고를 때는 먼저 develop 최신화, 열린 Issue/PR 확인, `WORK_PROGRESS.md`와 `BACKLOG.md` 확인을 다시 수행한다.
 #110은 사용자가 별도로 지시하기 전까지 다루지 않는다.
 #162 guardrail에 따라 "지금 구현하면 과한가?"를 먼저 판단한다.
+#170은 구현 변경보다 측정 기준선 수립이 우선이다.
+다음 단계에서 비동기/Kafka/Redis 캐시를 바로 도입하지 말고, 먼저 `docs/backend-improvement/article-crawl-latency-baseline.md`와 `load-tests/k6/article-crawl-baseline.js`를 기준으로 cold/warm/fallback 측정 가능성을 확인한다.
+
 #164 ADR 기준상 hybrid ranking code experiment는 아래 조건이 준비된 뒤 별도 Issue로 검토한다.
 
 ```text
@@ -120,6 +125,7 @@ pure relevance-first는 wrong-context 기사를 끌어올릴 수 있어 바로 �
 
 - `docs/backend-improvement/search-fulltext-analysis.md`
 - `docs/backend-improvement/search-fulltext-term-baseline.md`
+- `docs/backend-improvement/article-crawl-latency-baseline.md`
 - `docs/backend-improvement/load-test-baseline.md`
 - `docs/backend-improvement/perspectives-fulltext-generic-token-filter-result.md`
 - `docs/backend-improvement/perspectives-fulltext-ordering-comparison.md`

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -98,7 +98,8 @@ Blocking 예시:
 - #162/#163에서 새 이슈 후보마다 overengineering 여부를 먼저 판단하는 docs guardrail을 추가했다.
 - #164/#165에서 #160 측정 결과를 바탕으로 Perspectives ranking policy 도입 보류와 hybrid 후보 적용 기준을 docs/ADR로 정리했다.
 - #166/#167에서 PR 본 작업 커밋에 docs 기록을 함께 포함하고 merge 후 후처리 커밋을 기본값으로 만들지 않는 기준을 정리했다.
-- #168에서 검색 API FULLTEXT 검색어별 성능 기준선을 수립 중이다.
+- #168/#169에서 검색 API FULLTEXT 검색어별 성능 기준선을 수립했다.
+- #170에서 기사 원문 크롤링 동기 외부 호출 응답 지연 기준선을 수립 중이다.
 - 현재 반복 성능/안정성 기본기 흐름의 주요 후보(#123, #127, #129, #131, #133, #137, #140, #142, #146)와 AI workflow 보강(#144)은 merge 완료 상태다.
 
 ### #113 / PR #114 - 백엔드 개선 Backlog 및 AI 작업 운영 규칙 수립
@@ -1208,7 +1209,8 @@ git diff --check
 ### #168 - 검색 API FULLTEXT 검색어별 성능 기준선 수립
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/168
-- 상태: PR 기준 진행 기록
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/169
+- 상태: merged
 - 작업 브랜치: `perf/#168-search-fulltext-term-baseline`
 - 주요 파일:
   - `load-tests/k6/search-fulltext-terms.js`
@@ -1252,6 +1254,59 @@ git diff --check
 - 2026-07-09 로컬 Docker MySQL/Redis와 `bootRun` 서버(`localhost:8080`) 기준으로 검색어별 smoke baseline을 기록했다.
 - p95/failure/result count: `war` 76.63ms/0.00%/100, `korea` 60.38ms/0.00%/40, `economy` 63.24ms/0.00%/39, `technology` 103.41ms/0.00%/82, `대구` 50.14ms/0.00%/0, `AI` 24.78ms/0.00%/0.
 - 이번 PR은 검색어별 기준선 수집을 재현 가능하게 하는 스크립트와 최초 로컬 측정 기록 수립에 집중한다.
+- Reviewer 결과 `MERGE_READY`, Blocking 없음으로 확인 후 2026-07-09 기준 PR #169를 squash merge했고 Issue #168은 closed 상태다.
+
+---
+
+### #170 - 기사 원문 크롤링 동기 외부 호출 응답 지연 기준선 수립
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/170
+- 상태: In Progress
+- 작업 브랜치: `perf/#170-article-crawl-latency-baseline`
+- 주요 파일:
+  - `load-tests/k6/article-crawl-baseline.js`
+  - `docs/backend-improvement/article-crawl-latency-baseline.md`
+  - `docs/backend-improvement/load-test-baseline.md`
+  - `docs/backend-improvement/BACKLOG.md`
+  - `docs/backend-improvement/NEXT_AGENT_BRIEF.md`
+  - `docs/backend-improvement/WORK_PROGRESS.md`
+
+목표:
+
+- #137/#138에서 정리한 기사 원문 크롤링 timeout/fallback 및 외부 I/O 트랜잭션 분리를 API-level p95, 실패율, crawler fallback rate 기준선과 연결한다.
+- 기사 요약 API의 동기 외부 크롤링 경로가 사용자 요청 지연에 주는 영향을 cold/warm/fallback 조건으로 설명 가능하게 한다.
+- 비동기/Kafka/Redis 캐시 도입 여부를 바로 결정하지 않고, 도입 검토 조건만 남긴다.
+- 이력서에서는 `기사 요약 API 동기 외부 크롤링 p95/fallback 기준선 수립`으로 압축 가능하게 한다.
+
+Overengineering 판단:
+
+- 지금 Kafka, async job queue, Redis/local cache를 바로 도입하면 과하다.
+- #137/#138에서 timeout/fallback과 트랜잭션 경계 개선은 이미 완료됐지만, 사용자 요청 경로에서 어느 조건이 느린지 수치 기준선이 부족하다.
+- 운영 코드, API 응답, DB schema, crawler timeout 값을 바꾸지 않고 k6 스크립트와 문서 기준선을 추가하는 범위가 현재 단계에 적절하다.
+
+수정 방향:
+
+- `GET /api/ai/{id}/summary`를 호출하는 `article-crawl-baseline.js` k6 스크립트를 추가한다.
+- `article_crawler_fallback`, `article_summary_success`, `article_summary_payload_size` custom metric으로 summary success/fallback 결과를 분리 기록한다.
+- `article-crawl-latency-baseline.md`에 summary hit, crawled-content hit, crawl cold success, crawl fallback 해석 기준과 결과 기록 템플릿을 정리한다.
+- #168 merge 상태와 #170 진행 상태를 `BACKLOG.md`, `NEXT_AGENT_BRIEF.md`, `WORK_PROGRESS.md`에 함께 반영한다.
+
+검증:
+
+```text
+node --check load-tests/k6/article-crawl-baseline.js
+k6 inspect load-tests/k6/article-crawl-baseline.js
+k6 run load-tests/k6/article-crawl-baseline.js (ARTICLE_IDS=7366, SCENARIO_LABEL=summary_hit_smoke, ARTICLE_CRAWL_DURATION=10s)
+git diff --check
+```
+
+비고:
+
+- 일반 summary API는 저장된 `summary`가 있으면 즉시 반환하고, 없으면 `crawledContent` 확인 후 필요 시 외부 크롤링과 Gemini 요약 호출까지 이어진다.
+- 따라서 이 기준선은 순수 crawler microbenchmark가 아니라 사용자-facing summary path 기준선이다.
+- 2026-07-09 로컬 Docker MySQL/Redis와 `bootRun` 서버 기준 summary hit smoke를 기록했다.
+- `ARTICLE_IDS=7366` summary hit 조건에서 p95 332.6ms, failure 0.00%, crawler fallback 0.00%, summary success 100.00%, payload size 420을 확인했다.
+- 순수 crawler timing이 필요하면 별도 service-level instrumentation 또는 격리 테스트 이슈로 분리한다.
 
 ## 4. 이후 개선 로드맵
 

--- a/docs/backend-improvement/article-crawl-latency-baseline.md
+++ b/docs/backend-improvement/article-crawl-latency-baseline.md
@@ -1,0 +1,146 @@
+# Article crawl latency baseline
+
+## Purpose
+
+This document defines a repeatable baseline for the article summary path that may trigger synchronous external article crawling.
+It connects #137/#138 timeout/fallback and transaction-boundary work to API-level measurements such as p95 response time, failure rate, crawler fallback rate, and summary success rate.
+
+This work does not change crawler behavior, timeout values, API response shape, DB schema, Redis policy, Gemini calls, or async processing.
+
+## Portfolio Summary Candidate
+
+```text
+기사 요약 요청에서 동기 원문 크롤링으로 인한 응답 지연을 cold/warm/fallback 조건으로 분리 측정하고, 외부 호출 개선 기준선을 수립했습니다.
+```
+
+Shorter resume keyword version:
+
+```text
+기사 요약 API 동기 외부 크롤링 p95/fallback 기준선 수립
+```
+
+## Background
+
+#137/#138 stabilized the article crawling path.
+
+Current behavior:
+
+- `ArticleCrawler` uses `crawler.timeout-ms`, default `5000`.
+- `ArticleCrawler` returns `Optional.empty()` when crawling or paragraph extraction fails.
+- `DetailService#getArticleCrawledContent()` runs external crawling outside the DB transaction.
+- `ArticleCrawlContentService` handles crawl target lookup and crawled-content save in separate transactions.
+- `GET /api/ai/{id}/summary` returns cached `summary` immediately when it exists.
+- If `summary` is missing, the API tries `crawledContent`; when it is missing, it performs external crawling.
+- If crawling fails, the non-SSE summary endpoint returns HTTP 202 with `isSuccess=false` and the article lead content as fallback data.
+
+This means the summary endpoint can include different latency sources:
+
+| Scenario | What happens | What it measures |
+| --- | --- | --- |
+| Summary hit | Existing `summary` is returned | Fastest stored-summary path |
+| Crawled-content hit | Existing `crawledContent` is used, then Gemini summary may run | AI call path without external crawling |
+| Crawl cold success | External crawl succeeds, then Gemini summary may run | External crawl plus AI call path |
+| Crawl fallback | External crawl fails or paragraphs are empty | Timeout/failure handling and fallback path |
+
+Do not interpret this baseline as a pure crawler microbenchmark.
+The public API path can include AI summary generation unless the summary is already cached.
+This document intentionally measures the user-facing path first because that is the path affected by synchronous external crawling.
+
+## Measurement Tool
+
+Use `load-tests/k6/article-crawl-baseline.js`.
+
+The script requests `GET /api/ai/{id}/summary` for a comma-separated article id set and tags each request with:
+
+- `api=article_crawl_summary`
+- `endpoint=summary`
+- `articleId`
+- `scenario`
+
+It records:
+
+- `http_req_duration{api:article_crawl_summary}`
+- `http_req_failed{api:article_crawl_summary}`
+- `article_crawler_fallback`
+- `article_summary_success`
+- `article_summary_payload_size`
+
+## Execution
+
+Start local dependencies and server first.
+
+```powershell
+docker compose -f docker-compose.dev.yml up -d
+.\gradlew.bat bootRun
+```
+
+Run a short smoke baseline:
+
+```powershell
+$env:BASE_URL = "http://localhost:8080"
+$env:ARTICLE_IDS = "1"
+$env:LANGUAGE = "영어"
+$env:SCENARIO_LABEL = "summary_smoke"
+$env:ARTICLE_CRAWL_VUS = "1"
+$env:ARTICLE_CRAWL_DURATION = "30s"
+$env:SLEEP_SECONDS = "1"
+k6 run .\load-tests\k6\article-crawl-baseline.js
+```
+
+Run separate scenario labels when preparing a before/after comparison:
+
+```powershell
+$env:SCENARIO_LABEL = "summary_hit"
+k6 run .\load-tests\k6\article-crawl-baseline.js
+
+$env:SCENARIO_LABEL = "crawl_fallback"
+k6 run .\load-tests\k6\article-crawl-baseline.js
+```
+
+## Result Recording Template
+
+Record p95 and failure rate from k6 output.
+Record fallback/success rates from custom metrics.
+Use service logs to confirm whether the run was summary hit, crawled-content hit, crawl cold success, or crawl fallback.
+
+| Date | Environment | Article IDs | Scenario | p95 | Failure rate | Crawler fallback rate | Summary success rate | Notes |
+| --- | --- | --- | --- | ---: | ---: | ---: | ---: | --- |
+|  | local/dev |  | summary hit |  |  |  |  | Existing summary returned |
+|  | local/dev |  | crawled-content hit |  |  |  |  | External crawl skipped, AI may run |
+|  | local/dev |  | crawl cold success |  |  |  |  | External crawl and AI may run |
+|  | local/dev |  | crawl fallback |  |  |  |  | HTTP 202 fallback expected |
+
+## Initial Local Smoke Result
+
+The first smoke run was measured on 2026-07-09 with local Docker MySQL/Redis containers and a local `bootRun` server on `http://localhost:8080`.
+It used article `7366`, which already had both `summary` and `crawled_content`.
+
+This result validates the k6 script and records the stored-summary hit baseline.
+It does not measure cold external crawling.
+
+| Date | Environment | Article IDs | Scenario | p95 | Failure rate | Crawler fallback rate | Summary success rate | Payload size | Notes |
+| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
+| 2026-07-09 | local/dev | `7366` | summary hit | 332.6ms | 0.00% | 0.00% | 100.00% | 420 | Existing summary returned; crawler and Gemini skipped |
+
+## Interpretation Rules
+
+- HTTP 202 with `isSuccess=false` and a crawler message is a handled crawler fallback, not a server failure.
+- HTTP 5xx should be treated as an API failure.
+- A low p95 on summary hit does not prove crawler performance is good; it proves stored summary bypasses crawler/AI work.
+- A high p95 on crawl cold success can include both external crawling and Gemini summary generation.
+- If the goal is pure crawler timing, add service-level instrumentation or an isolated test in a later issue.
+- Kafka, async jobs, Redis cache changes, or crawler timeout changes should be considered only after repeated evidence that the synchronous path is unstable or too slow.
+
+## Current Scope Decision
+
+This issue establishes a measurement script and baseline document for the user-facing article summary path.
+It intentionally avoids:
+
+- changing crawler timeout values
+- adding async processing or Kafka
+- adding Redis/local cache behavior
+- changing summary or fallback API responses
+- changing DB schema
+- changing external AI call behavior
+
+The next step after collecting stable local measurements is to decide whether timeout/fallback tuning, stored-content reuse, local cache, or async processing is justified.

--- a/docs/backend-improvement/load-test-baseline.md
+++ b/docs/backend-improvement/load-test-baseline.md
@@ -76,6 +76,9 @@ Redis cold cache와 warm cache의 성능 차이를 분리 측정할 때는 `load
 검색 API를 검색어 유형별로 분리 측정할 때는 `load-tests/k6/search-fulltext-terms.js`를 사용한다.
 자세한 검색어 세트, 실행 조건, 결과 기록 방식은 `docs/backend-improvement/search-fulltext-term-baseline.md`에 기록한다.
 
+기사 요약 API의 동기 원문 크롤링 경로를 분리 측정할 때는 `load-tests/k6/article-crawl-baseline.js`를 사용한다.
+자세한 cold/warm/fallback 해석 기준과 결과 기록 방식은 `docs/backend-improvement/article-crawl-latency-baseline.md`에 기록한다.
+
 VU와 실행 시간은 환경 변수로 조정한다.
 
 ```powershell

--- a/load-tests/k6/article-crawl-baseline.js
+++ b/load-tests/k6/article-crawl-baseline.js
@@ -1,0 +1,100 @@
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { Rate, Trend } from 'k6/metrics';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const ARTICLE_IDS = (__ENV.ARTICLE_IDS || '1')
+  .split(',')
+  .map((id) => id.trim())
+  .filter((id) => id.length > 0);
+const LANGUAGE = __ENV.LANGUAGE || '영어';
+const SCENARIO_LABEL = __ENV.SCENARIO_LABEL || 'summary_baseline';
+const SLEEP_SECONDS = Number(__ENV.SLEEP_SECONDS || 1);
+
+export const crawlerFallbackRate = new Rate('article_crawler_fallback');
+export const summarySuccessRate = new Rate('article_summary_success');
+export const summaryPayloadSize = new Trend('article_summary_payload_size');
+
+export const options = {
+  scenarios: {
+    article_crawl_summary: {
+      executor: 'constant-vus',
+      exec: 'articleCrawlSummary',
+      vus: Number(__ENV.ARTICLE_CRAWL_VUS || 1),
+      duration: __ENV.ARTICLE_CRAWL_DURATION || '30s',
+    },
+  },
+  thresholds: {
+    'http_req_failed{api:article_crawl_summary}': ['rate<0.05'],
+    'http_req_duration{api:article_crawl_summary}': ['p(95)<6000'],
+  },
+};
+
+function query(params) {
+  return Object.entries(params)
+    .filter(([, value]) => value !== undefined && value !== null && value !== '')
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join('&');
+}
+
+function parseSummaryResponse(res) {
+  try {
+    const body = res.json();
+    const message = body && typeof body.message === 'string' ? body.message : '';
+    const data = body && body.data !== undefined && body.data !== null ? String(body.data) : '';
+
+    return {
+      parsed: true,
+      isSuccess: body && body.isSuccess === true,
+      isCrawlerFallback:
+        res.status === 202 ||
+        body && body.isSuccess === false && message.includes('크롤링'),
+      payloadSize: data.length,
+    };
+  } catch (e) {
+    return {
+      parsed: false,
+      isSuccess: false,
+      isCrawlerFallback: false,
+      payloadSize: 0,
+    };
+  }
+}
+
+export function articleCrawlSummary() {
+  group('article crawl summary baseline', () => {
+    for (const articleId of ARTICLE_IDS) {
+      const params = query({ language: LANGUAGE });
+      const res = http.get(`${BASE_URL}/api/ai/${articleId}/summary?${params}`, {
+        tags: {
+          api: 'article_crawl_summary',
+          endpoint: 'summary',
+          articleId,
+          scenario: SCENARIO_LABEL,
+        },
+      });
+
+      const summary = parseSummaryResponse(res);
+      crawlerFallbackRate.add(summary.isCrawlerFallback, {
+        articleId,
+        scenario: SCENARIO_LABEL,
+      });
+      summarySuccessRate.add(summary.isSuccess, {
+        articleId,
+        scenario: SCENARIO_LABEL,
+      });
+      summaryPayloadSize.add(summary.payloadSize, {
+        articleId,
+        scenario: SCENARIO_LABEL,
+      });
+
+      check(res, {
+        'status is not 5xx': (r) => r.status < 500,
+        'response is ApiResponse JSON': () => summary.parsed,
+        'response has handled summary outcome': () => summary.isSuccess || summary.isCrawlerFallback,
+      });
+
+      sleep(SLEEP_SECONDS);
+    }
+  });
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #170

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)


## 📝 작업 내용
- 기사 요약 API의 동기 원문 크롤링 경로를 측정하기 위한 k6 스크립트를 추가했습니다.
- `GET /api/ai/{id}/summary` 기준 p95, 실패율, crawler fallback rate, summary success rate, payload size를 기록할 수 있게 했습니다.
- `article-crawl-latency-baseline.md`에 summary hit, crawled-content hit, crawl cold success, crawl fallback 해석 기준과 결과 기록 템플릿을 정리했습니다.
- #168/#169 merge 완료 상태와 #170 진행 상태를 `BACKLOG.md`, `NEXT_AGENT_BRIEF.md`, `WORK_PROGRESS.md`에 반영했습니다.
- 운영 코드, API 응답, DB schema, crawler timeout, Redis 정책, 비동기 처리 방식은 변경하지 않았습니다.

## 🔍 기술적 배경
- #137/#138에서 기사 원문 크롤링 timeout/fallback과 외부 I/O 트랜잭션 분리는 정리했지만, 사용자-facing summary path의 p95/fallback 기준선은 분리되어 있지 않았습니다.
- 이번 PR은 Kafka, async job, Redis cache 같은 기술 도입 전에 동기 외부 크롤링 경로의 지연과 fallback을 측정할 수 있는 기준선을 만듭니다.
- 일반 summary API는 저장된 `summary`가 있으면 즉시 반환하고, 없으면 `crawledContent` 확인 후 필요 시 외부 크롤링과 Gemini 요약 호출까지 이어지므로, 문서에서 순수 crawler microbenchmark가 아니라 사용자-facing path 기준선임을 명시했습니다.


## 🧪 테스트/검증 (필수)
- [x] `node --check load-tests/k6/article-crawl-baseline.js`
- [x] `k6 inspect load-tests/k6/article-crawl-baseline.js`
- [x] `k6 run load-tests/k6/article-crawl-baseline.js` (`ARTICLE_IDS=7366`, `SCENARIO_LABEL=summary_hit_smoke`, `ARTICLE_CRAWL_DURATION=10s`)
- [x] `git diff --check`

Local summary-hit smoke result:

| Article ID | Scenario | p95 | Failure rate | Crawler fallback | Summary success | Payload size |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| `7366` | summary hit | 332.6ms | 0.00% | 0.00% | 100.00% | 420 |

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?


## 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
- #170 범위가 측정 스크립트/문서 기준선 추가에 머무르고 운영 코드/API/DB/Redis/crawler timeout 변경이 없는지 확인해주세요.
- summary hit, crawled-content hit, crawl cold success, crawl fallback 해석 기준이 과장 없이 분리되어 있는지 확인해주세요.
- k6 custom metric이 crawler fallback과 summary success를 구분하기에 충분한지 확인해주세요.
- #168 완료 상태와 #170 진행 상태가 `BACKLOG.md`, `NEXT_AGENT_BRIEF.md`, `WORK_PROGRESS.md`에 일관되게 반영됐는지 확인해주세요.


## ➕ 추후 계획(선택)
- cold crawl/fallback 대상 article id를 별도로 선정해 외부 크롤링과 fallback 경로 p95를 같은 스크립트로 추가 측정합니다.
- 반복적으로 느린 cold crawl 또는 fallback 지연이 확인되면 timeout/fallback 조정, stored-content reuse, Redis/local cache, async processing 도입 여부를 별도 Issue로 검토합니다.
