### PR TITLE
📊 [PERF/#174] 주요 기사 조회 API 고부하 DB 병목 기준선 수립

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -35,24 +35,25 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## P1. Perspectives API 관측성 및 성능 기준선 확보
 
-- 상태: `In Progress` ([#121](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/121))
+- 상태: `In Progress` ([#121](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/121), [#174](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/174))
 - AS-IS: 캐시 미스 시 기사 조회, 키워드 추출, 번역 API 호출, FULLTEXT 검색이 요청 경로에서 수행되지만 단계별 지연 시간과 캐시 효과를 수치로 설명할 수 없다.
 - TO-BE: 캐시 히트율, 단계별 처리 시간, 외부 번역 API 호출량, p95 응답 시간을 측정하고 부하 테스트 기준선을 만든다.
 - 성공 기준:
   - 캐시 히트/미스 시나리오별 p50, p95, 오류율을 기록한다.
   - 번역 API 호출 횟수와 캐시 히트율을 확인할 수 있다.
   - 측정 결과를 후속 개선 PR에 비교 기준으로 남긴다.
+  - #174에서 외부 호출 없는 주요 기사 조회 API의 고부하 p95/오류율과 DB 병목 후보를 분리 측정한다.
 
 ## P2. 기사 원문 크롤링 안정성 개선
 
-- 상태: `In Progress` ([#170](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/170), [#172](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/172))
+- 상태: `Done` ([#170](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/170), [PR #171](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/171), [#172](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/172), [PR #173](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/173))
 - AS-IS: 기사 상세의 요약·질의응답 요청 중 외부 언론사 페이지를 동기 크롤링하며, 외부 사이트의 지연과 실패가 사용자 요청에 직접 영향을 준다.
 - TO-BE: timeout, 실패 분류, 재시도 정책, 크롤링 결과 저장 정책을 정의하고 장애 상황에서도 예측 가능한 응답을 제공한다.
 - 성공 기준:
   - 연결 지연, 읽기 지연, 본문 없음, 차단 응답의 처리 규칙이 문서화되고 검증된다.
   - 동일 기사 요청 시 불필요한 재크롤링을 줄이는 기준을 확인한다.
   - #170/#171에서 요약 API의 동기 원문 크롤링 경로를 cold/warm/fallback 조건으로 측정할 수 있는 기준선을 수립했다.
-  - #172에서 summary hit, crawledContent hit, cold crawl, crawler fallback, AI summary 호출 시간을 단계별 로그로 분리 관측할 수 있게 한다.
+  - #172/#173에서 summary hit, crawledContent hit, cold crawl, crawler fallback, AI summary 호출 시간을 단계별 로그로 분리 관측할 수 있게 했다.
 
 ## P2-1. 검색 API FULLTEXT 성능 기준선
 

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -62,7 +62,8 @@ Reviewer 이후 diff 변경을 피하기 위해 merge 후 `WORK_PROGRESS.md`만 
 - #166/#167에서 PR 단위 문서 기록과 develop 커밋 이력 정리 기준을 문서화했다.
 - #168/#169에서 검색 API FULLTEXT 검색어별 성능 기준선 수립을 완료했다.
 - #170/#171에서 기사 원문 크롤링 동기 외부 호출 응답 지연 기준선 수립을 완료했다.
-- #172에서 기사 요약 API 외부 호출 단계별 latency 로그 추가를 진행 중이다.
+- #172/#173에서 기사 요약 API 외부 호출 단계별 latency 로그 추가를 완료했다.
+- #174에서 주요 기사 조회 API 고부하 부하 테스트 및 DB 병목 기준선 수립을 진행 중이다.
 
 ## Recent Completed Work
 
@@ -78,6 +79,7 @@ Reviewer 이후 diff 변경을 피하기 위해 merge 후 `WORK_PROGRESS.md`만 
 - #166/#167: PR 본 작업 커밋에 docs 기록을 함께 포함하고 merge 후 후처리 커밋을 기본값으로 만들지 않는 기준을 정리했다.
 - #168/#169: 검색 API FULLTEXT 검색어별 p95, 실패율, 결과 수 smoke 기준선을 수립했다.
 - #170/#171: 기사 요약 API 동기 원문 크롤링 경로의 summary-hit p95/fallback 기준선을 수립했다.
+- #172/#173: 기사 요약 API의 summary hit, crawledContent hit, cold crawl, crawler fallback, AI summary 단계별 latency 로그를 추가했다.
 
 ## Why #160 Matters
 
@@ -92,21 +94,21 @@ pure relevance-first는 wrong-context 기사를 끌어올릴 수 있어 바로 �
 현재 진행 중:
 
 ```text
-#172 [OBS/PERF] 기사 요약 API 외부 호출 단계별 latency 로그 추가
+#174 [PERF] 주요 기사 조회 API 고부하 부하 테스트 및 DB 병목 기준선 수립
 ```
 
 목표:
 
-- 기사 요약 API에서 summary hit, crawledContent hit, cold crawl, crawler fallback, AI summary 호출 시간을 단계별로 관측할 수 있게 한다.
-- #170/#171의 user-facing k6 기준선을 내부 단계별 latency 로그와 연결한다.
-- 비동기/Kafka/Redis 캐시 도입은 바로 결정하지 않고, 실제 병목 구간을 확인할 근거를 먼저 남긴다.
-- 이력서에 `기사 요약 API 동기 외부 호출 단계별 latency 로깅으로 cache/비동기 처리 판단 기준 수립`으로 압축 가능한 근거를 만든다.
+- 외부 크롤링/Gemini/번역 API가 없는 주요 기사 조회 API를 고부하 조건에서 분리 측정한다.
+- `latest`, `cursor`, `popular`, `explore`, `detail`의 p95/오류율과 서버 로그 `dbQueryMs`를 함께 해석할 기준을 만든다.
+- 바로 인덱스나 쿼리를 변경하지 않고, 후속 EXPLAIN/인덱스 후보 이슈를 고르는 근거를 남긴다.
+- 이력서에 `주요 기사 조회 API 고부하 p95/DB 병목 기준선 수립`으로 압축 가능한 근거를 만든다.
 
 다음 세션에서 새 후보를 고를 때는 먼저 develop 최신화, 열린 Issue/PR 확인, `WORK_PROGRESS.md`와 `BACKLOG.md` 확인을 다시 수행한다.
 #110은 사용자가 별도로 지시하기 전까지 다루지 않는다.
 #162 guardrail에 따라 "지금 구현하면 과한가?"를 먼저 판단한다.
-#172는 구현 변경을 하되 API 동작 변경이 아니라 관측 로그 추가에 한정한다.
-다음 단계에서 비동기/Kafka/Redis 캐시를 바로 도입하지 말고, 먼저 `AiSummary`와 `ArticleCrawlContent` 로그를 `load-tests/k6/article-crawl-baseline.js` 결과와 함께 확인한다.
+#174는 고부하 측정과 DB 병목 후보 도출이 우선이다.
+다음 단계에서 DB index/query 변경을 바로 적용하지 말고, 먼저 `load-tests/k6/articles-read-high-load.js`와 `docs/backend-improvement/articles-read-high-load-db-baseline.md`를 기준으로 slow path를 확인한다.
 
 #164 ADR 기준상 hybrid ranking code experiment는 아래 조건이 준비된 뒤 별도 Issue로 검토한다.
 
@@ -128,6 +130,7 @@ pure relevance-first는 wrong-context 기사를 끌어올릴 수 있어 바로 �
 - `docs/backend-improvement/search-fulltext-analysis.md`
 - `docs/backend-improvement/search-fulltext-term-baseline.md`
 - `docs/backend-improvement/article-crawl-latency-baseline.md`
+- `docs/backend-improvement/articles-read-high-load-db-baseline.md`
 - `docs/backend-improvement/load-test-baseline.md`
 - `docs/backend-improvement/perspectives-fulltext-generic-token-filter-result.md`
 - `docs/backend-improvement/perspectives-fulltext-ordering-comparison.md`

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -100,7 +100,8 @@ Blocking 예시:
 - #166/#167에서 PR 본 작업 커밋에 docs 기록을 함께 포함하고 merge 후 후처리 커밋을 기본값으로 만들지 않는 기준을 정리했다.
 - #168/#169에서 검색 API FULLTEXT 검색어별 성능 기준선을 수립했다.
 - #170/#171에서 기사 원문 크롤링 동기 외부 호출 응답 지연 기준선을 수립했다.
-- #172에서 기사 요약 API 외부 호출 단계별 latency 로그를 추가 중이다.
+- #172/#173에서 기사 요약 API 외부 호출 단계별 latency 로그를 추가했다.
+- #174에서 주요 기사 조회 API 고부하 부하 테스트 및 DB 병목 기준선을 수립 중이다.
 - 현재 반복 성능/안정성 기본기 흐름의 주요 후보(#123, #127, #129, #131, #133, #137, #140, #142, #146)와 AI workflow 보강(#144)은 merge 완료 상태다.
 
 ### #113 / PR #114 - 백엔드 개선 Backlog 및 AI 작업 운영 규칙 수립
@@ -1316,7 +1317,8 @@ git diff --check
 ### #172 - 기사 요약 API 외부 호출 단계별 latency 로그 추가
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/172
-- 상태: In Progress
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/173
+- 상태: merged
 - 작업 브랜치: `perf/#172-ai-summary-latency-log`
 - 주요 파일:
   - `src/main/java/com/example/globalTimes_be/domain/ai/controller/AiController.java`
@@ -1346,7 +1348,7 @@ Overengineering 판단:
 - 로그에는 기사 원문, 요약 전문, URL, 질문 전문, API key, token, `.env` 값을 남기지 않는다.
 - `article-crawl-latency-baseline.md`에 새 로그 필드와 k6 `SCENARIO_LABEL` 연계 해석 기준을 추가한다.
 
-검증 예정:
+검증:
 
 ```text
 ./gradlew.bat test
@@ -1357,6 +1359,61 @@ git diff --check
 
 - 이번 PR은 운영 코드에 로그를 추가하지만 API 응답 구조, DB schema, crawler timeout, Redis 정책, 비동기 처리 방식은 변경하지 않는다.
 - summary hit/crawledContent hit/cold crawl/fallback 구분은 `AiSummary` 로그와 `ArticleCrawlContent` 로그를 함께 보고 판단한다.
+- Reviewer 결과 `MERGE_READY`, Blocking/Non-blocking 없음으로 확인 후 2026-07-09 기준 PR #173을 squash merge했고 Issue #172는 closed 상태다.
+
+---
+
+### #174 - 주요 기사 조회 API 고부하 부하 테스트 및 DB 병목 기준선 수립
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/174
+- 상태: In Progress
+- 작업 브랜치: `perf/#174-articles-high-load-db-baseline`
+- 주요 파일:
+  - `load-tests/k6/articles-read-high-load.js`
+  - `docs/backend-improvement/articles-read-high-load-db-baseline.md`
+  - `docs/backend-improvement/load-test-baseline.md`
+  - `docs/backend-improvement/BACKLOG.md`
+  - `docs/backend-improvement/NEXT_AGENT_BRIEF.md`
+  - `docs/backend-improvement/WORK_PROGRESS.md`
+
+목표:
+
+- 외부 크롤링/Gemini/번역 API가 없는 주요 기사 조회 API를 고부하 조건에서 분리 측정한다.
+- `latest`, `cursor`, `popular`, `explore`, `detail`의 p95/오류율과 서버 로그 `dbQueryMs`를 함께 해석할 기준을 만든다.
+- k6 고부하 결과만으로 인덱스나 쿼리를 바로 변경하지 않고, 후속 EXPLAIN/인덱스 후보 이슈를 고르는 근거를 남긴다.
+- 이력서에서는 `주요 기사 조회 API 고부하 p95/DB 병목 기준선 수립`으로 압축 가능하게 한다.
+
+Overengineering 판단:
+
+- 지금 DB 인덱스 추가나 Repository query 변경을 바로 적용하면 과하다.
+- 기존 `api-baseline.js`는 smoke/baseline 성격이 강해 특정 조회 API가 고부하에서 DB 병목을 만드는지 분리하기 어렵다.
+- 운영 코드, API 응답, DB schema를 바꾸지 않고 k6 스크립트와 DB 병목 해석 문서를 추가하는 범위가 현재 단계에 적절하다.
+
+수정 방향:
+
+- `articles-read-high-load.js` k6 스크립트를 추가해 latest/cursor/popular/explore/detail API를 scenario와 tag로 분리 측정한다.
+- `articles_payload_size` metric으로 응답 크기 변화도 함께 본다.
+- `articles-read-high-load-db-baseline.md`에 API별 repository query, 서버 로그, EXPLAIN 후보, 후속 인덱스/쿼리 분석 이슈를 정리한다.
+- `load-test-baseline.md`, `BACKLOG.md`, `NEXT_AGENT_BRIEF.md`, `WORK_PROGRESS.md`에 #174 기준선을 연결한다.
+
+검증:
+
+```text
+node --check load-tests/k6/articles-read-high-load.js
+k6 inspect load-tests/k6/articles-read-high-load.js
+k6 run load-tests/k6/articles-read-high-load.js (VU 1 per API, duration 8s, smoke)
+SHOW INDEX FROM article
+EXPLAIN latest/cursor/popular/explore/detail recent query shapes
+git diff --check
+```
+
+비고:
+
+- 이번 PR은 DB 병목을 찾기 위한 기준선 수립이며, 실제 DB index/query 변경은 후속 EXPLAIN 이슈로 분리한다.
+- 고부하 p95가 높더라도 서버 로그 `dbQueryMs`가 낮으면 DB 병목이 아닐 수 있으므로, k6 결과와 애플리케이션 로그를 함께 해석한다.
+- 2026-07-09 로컬 smoke에서 전체 tagged article read p95 96.5ms, failure 0.00%를 확인했다.
+- endpoint별 p95는 latest 85.38ms, cursor 59.86ms, popular 88.52ms, explore 109.86ms, detail 95.21ms였다.
+- 초기 EXPLAIN에서 popular query shape는 `idx_article_published_at` range 후 `Using filesort`가 확인되어, 고부하 p95/dbQueryMs가 높아질 경우 후속 인덱스 후보로 검토할 수 있다.
 
 ## 4. 이후 개선 로드맵
 

--- a/docs/backend-improvement/articles-read-high-load-db-baseline.md
+++ b/docs/backend-improvement/articles-read-high-load-db-baseline.md
@@ -1,0 +1,213 @@
+# Articles read high-load DB baseline
+
+## Purpose
+
+This document defines a repeatable high-load baseline for article read APIs that are primarily DB-backed and do not call external AI, crawler, or translation services.
+It is meant to reveal which API path should receive follow-up `EXPLAIN`, query, or index analysis.
+
+This work does not change repository queries, DB indexes, API response shape, Redis policy, rate limiting, or async processing.
+
+## Portfolio Summary Candidate
+
+```text
+주요 기사 조회 API에 고부하 k6 시나리오를 적용해 p95/오류율과 DB 조회 로그를 함께 분석하고, EXPLAIN 기반 인덱스 개선 후보를 도출할 기준선을 수립했습니다.
+```
+
+Shorter resume keyword version:
+
+```text
+기사 조회 API 고부하 p95/DB 병목 기준선 수립
+```
+
+## Target APIs
+
+| API | Service log | Repository path | Main DB concern |
+| --- | --- | --- | --- |
+| `GET /api/articles/latest` | `[ArticlesLatest]` | `findAllByOrderByPublishedAtDesc(Pageable)` | Offset paging and `published_at DESC` ordering |
+| `GET /api/articles/cursor` | `[ArticlesCursor]` | `findFirstPage`, `findByCursor` | Cursor range scan on `published_at` |
+| `GET /api/articles/popular` | `[ArticlesPopular]` | `findByPublishedAtAfterOrderByViewCountDesc` | Recent-date filter plus `view_count DESC` ordering |
+| `GET /api/articles/explore` | `[Explore]` | `findByExploreFilters` | Optional `country/category/date/cursor` filters plus latest ordering |
+| `GET /api/news/detail` | none yet | `findById`, `findTop20ByIdNotOrderByPublishedAtDesc` | Detail lookup plus recent articles query and view-count update |
+
+## Measurement Tool
+
+Use `load-tests/k6/articles-read-high-load.js`.
+
+The script separates each API into its own scenario and tags requests with:
+
+- `api=articles_read_high_load`
+- `endpoint=latest|cursor|popular|explore|detail`
+- selected page/filter/id tags where useful
+
+It also records response body size with `articles_payload_size`.
+
+## Execution
+
+Start local dependencies and server first.
+
+```powershell
+docker compose -f docker-compose.dev.yml up -d
+.\gradlew.bat bootRun
+```
+
+Run a short smoke baseline:
+
+```powershell
+$env:BASE_URL = "http://localhost:8080"
+$env:ARTICLES_SIZE = "20"
+$env:LATEST_VUS = "2"
+$env:CURSOR_VUS = "2"
+$env:POPULAR_VUS = "2"
+$env:EXPLORE_VUS = "2"
+$env:DETAIL_VUS = "1"
+$env:LATEST_DURATION = "15s"
+$env:CURSOR_DURATION = "15s"
+$env:POPULAR_DURATION = "15s"
+$env:EXPLORE_DURATION = "15s"
+$env:DETAIL_DURATION = "15s"
+$env:DETAIL_IDS = "7366,8449"
+k6 run .\load-tests\k6\articles-read-high-load.js
+```
+
+Run a heavier local baseline only after the smoke run is stable:
+
+```powershell
+$env:LATEST_VUS = "10"
+$env:CURSOR_VUS = "10"
+$env:POPULAR_VUS = "10"
+$env:EXPLORE_VUS = "10"
+$env:DETAIL_VUS = "5"
+$env:LATEST_DURATION = "2m"
+$env:CURSOR_DURATION = "2m"
+$env:POPULAR_DURATION = "2m"
+$env:EXPLORE_DURATION = "2m"
+$env:DETAIL_DURATION = "2m"
+k6 run .\load-tests\k6\articles-read-high-load.js
+```
+
+## Result Recording Template
+
+Record p95 and failure rate from k6 output.
+Record service log `dbQueryMs` and `totalMs` for the same run window.
+
+| Date | Environment | API | VUs | Duration | p95 | Failure rate | Log dbQueryMs signal | Candidate follow-up |
+| --- | --- | --- | ---: | --- | ---: | ---: | --- | --- |
+|  | local/dev | latest |  |  |  |  | `[ArticlesLatest] dbQueryMs` | Offset paging or `published_at` index review |
+|  | local/dev | cursor |  |  |  |  | `[ArticlesCursor] dbQueryMs` | Cursor range scan review |
+|  | local/dev | popular |  |  |  |  | `[ArticlesPopular] dbQueryMs` | `(published_at, view_count)` or ordering index review |
+|  | local/dev | explore |  |  |  |  | `[Explore] dbQueryMs` | Optional filter composite index review |
+|  | local/dev | detail |  |  |  |  | no dedicated detail log yet | Add detail DB log or EXPLAIN recent list |
+
+## Initial Local Smoke Result
+
+The first smoke run was measured on 2026-07-09 with local Docker MySQL/Redis containers and a local `bootRun` server on `http://localhost:8080`.
+It used short staggered scenarios with `1` VU per API and `8s` duration per scenario.
+
+This is a script validation and low-load smoke baseline.
+It is not a capacity limit test.
+
+| Date | Environment | API | VUs | Duration | p95 | Failure rate | Notes |
+| --- | --- | --- | ---: | --- | ---: | ---: | --- |
+| 2026-07-09 | local/dev | all tagged article reads | max 5 combined | staggered 8s | 96.5ms | 0.00% | 157 requests |
+| 2026-07-09 | local/dev | latest | 1 | 8s | 85.38ms | 0.00% | offset page mix |
+| 2026-07-09 | local/dev | cursor | 1 | 8s | 59.86ms | 0.00% | first-page cursor smoke |
+| 2026-07-09 | local/dev | popular | 1 | 8s | 88.52ms | 0.00% | recent 30-day hot news query |
+| 2026-07-09 | local/dev | explore | 1 | 8s | 109.86ms | 0.00% | country/category filter mix |
+| 2026-07-09 | local/dev | detail | 1 | 8s | 95.21ms | 0.00% | article ids `7366,8449` |
+
+## DB Analysis Candidates
+
+Do not add indexes from k6 data alone.
+Use k6 to pick the slow path, then run `EXPLAIN`/`EXPLAIN ANALYZE` for that repository query.
+
+Candidate SQL shapes:
+
+```sql
+-- latest
+SELECT *
+FROM article
+ORDER BY published_at DESC
+LIMIT 20 OFFSET 0;
+
+-- cursor
+SELECT *
+FROM article
+WHERE published_at < :cursor
+ORDER BY published_at DESC
+LIMIT 21;
+
+-- popular
+SELECT *
+FROM article
+WHERE published_at > :from
+ORDER BY view_count DESC
+LIMIT 20 OFFSET 0;
+
+-- explore
+SELECT *
+FROM article
+WHERE (:country IS NULL OR country = :country)
+  AND (:category IS NULL OR category = :category)
+  AND (:dateFrom IS NULL OR published_at >= :dateFrom)
+  AND (:dateTo IS NULL OR published_at <= :dateTo)
+  AND (:cursor IS NULL OR published_at < :cursor)
+ORDER BY published_at DESC
+LIMIT 21;
+
+-- detail recent articles
+SELECT *
+FROM article
+WHERE article_id <> :id
+ORDER BY published_at DESC
+LIMIT 20;
+```
+
+Initial local index snapshot:
+
+| Index | Columns | Notes |
+| --- | --- | --- |
+| `PRIMARY` | `article_id` | Detail lookup |
+| `idx_article_published_at` | `published_at` | Latest/cursor/detail recent ordering |
+| `idx_article_country` | `country` | Single filter |
+| `idx_article_category` | `category` | Single filter |
+| `idx_article_country_category_date` | `country`, `category`, `published_at` | Explore filter/order candidate |
+| `ft_article_title_description` | `title`, `description` | FULLTEXT paths, not this read baseline focus |
+
+Initial local `EXPLAIN` notes from 2026-07-09:
+
+| API/query shape | Observed key | Rows estimate | Extra | Initial interpretation |
+| --- | --- | ---: | --- | --- |
+| latest | `idx_article_published_at` | 20 | `Backward index scan` | Current index fits latest ordering. |
+| cursor | `idx_article_published_at` | 5084 | `Using index condition; Backward index scan` | Cursor uses published_at range; compare with deeper cursors later. |
+| popular | `idx_article_published_at` | 2074 | `Using index condition; Using filesort` | If high-load p95/dbQueryMs is high, review an ordering index candidate. |
+| explore `country+category` | `idx_article_country_category_date` | 415 | `Backward index scan` | Existing composite index helps this filter shape. |
+| detail recent list | `idx_article_published_at` | 22 | `Using where; Backward index scan` | Recent-list query is likely acceptable at current scale. |
+
+Potential follow-up issues:
+
+- `[DB] articles popular 조회 EXPLAIN 분석 및 인덱스 후보 정리`
+- `[DB] articles explore 필터 조회 EXPLAIN 분석 및 복합 인덱스 후보 정리`
+- `[PERF] latest offset paging과 cursor paging 고부하 비교`
+- `[OBS] news detail DB 조회 단계별 latency 로그 추가`
+
+## Interpretation Rules
+
+- A high p95 with low `dbQueryMs` suggests serialization, response size, JVM, or network overhead rather than a DB query bottleneck.
+- A high p95 with high `dbQueryMs` points to a DB query, index, or sorting candidate.
+- `latest` offset paging should be compared with `cursor` before changing indexes or removing the offset API.
+- `popular` can be slow when the date filter and `view_count DESC` ordering cannot use a useful index together.
+- `explore` may need separate analysis by filter combination; optional filters can hide different plans.
+- `detail` includes a write-like view count update and a recent list lookup, so treat it separately from pure list reads.
+
+## Current Scope Decision
+
+This issue establishes a high-load measurement script and DB bottleneck interpretation document.
+It intentionally avoids:
+
+- adding DB indexes
+- changing repository queries
+- changing API response shape
+- adding Redis cache or rate limiting
+- adding async processing
+
+The next step after collecting high-load data is to choose the slowest DB-backed path and open a focused EXPLAIN/index candidate issue.

--- a/docs/backend-improvement/load-test-baseline.md
+++ b/docs/backend-improvement/load-test-baseline.md
@@ -79,6 +79,9 @@ Redis cold cache와 warm cache의 성능 차이를 분리 측정할 때는 `load
 기사 요약 API의 동기 원문 크롤링 경로를 분리 측정할 때는 `load-tests/k6/article-crawl-baseline.js`를 사용한다.
 자세한 cold/warm/fallback 해석 기준과 결과 기록 방식은 `docs/backend-improvement/article-crawl-latency-baseline.md`에 기록한다.
 
+주요 기사 조회 API에 호출이 몰리는 고부하 조건을 분리 측정할 때는 `load-tests/k6/articles-read-high-load.js`를 사용한다.
+자세한 API별 p95/오류율, DB 로그 해석 기준, 후속 EXPLAIN 후보는 `docs/backend-improvement/articles-read-high-load-db-baseline.md`에 기록한다.
+
 VU와 실행 시간은 환경 변수로 조정한다.
 
 ```powershell

--- a/load-tests/k6/articles-read-high-load.js
+++ b/load-tests/k6/articles-read-high-load.js
@@ -1,0 +1,150 @@
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { Trend } from 'k6/metrics';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const SIZE = __ENV.ARTICLES_SIZE || '20';
+const SLEEP_SECONDS = Number(__ENV.SLEEP_SECONDS || 0.2);
+
+const LATEST_PAGES = list(__ENV.LATEST_PAGES || '0,1,5,20');
+const POPULAR_PAGES = list(__ENV.POPULAR_PAGES || '0,1,5');
+const CURSORS = list(__ENV.CURSORS || '');
+const DETAIL_IDS = list(__ENV.DETAIL_IDS || '7366,8449');
+const EXPLORE_COUNTRIES = list(__ENV.EXPLORE_COUNTRIES || 'us,kr,jp');
+const EXPLORE_CATEGORIES = list(__ENV.EXPLORE_CATEGORIES || 'general,business,technology');
+const EXPLORE_DATES = list(__ENV.EXPLORE_DATES || '');
+
+export const articlesPayloadSize = new Trend('articles_payload_size');
+
+export const options = {
+  scenarios: {
+    articles_latest_high_load: {
+      executor: 'constant-vus',
+      exec: 'articlesLatest',
+      vus: Number(__ENV.LATEST_VUS || 5),
+      duration: __ENV.LATEST_DURATION || '30s',
+    },
+    articles_cursor_high_load: {
+      executor: 'constant-vus',
+      exec: 'articlesCursor',
+      vus: Number(__ENV.CURSOR_VUS || 5),
+      duration: __ENV.CURSOR_DURATION || '30s',
+      startTime: __ENV.CURSOR_START_TIME || '5s',
+    },
+    articles_popular_high_load: {
+      executor: 'constant-vus',
+      exec: 'articlesPopular',
+      vus: Number(__ENV.POPULAR_VUS || 5),
+      duration: __ENV.POPULAR_DURATION || '30s',
+      startTime: __ENV.POPULAR_START_TIME || '10s',
+    },
+    articles_explore_high_load: {
+      executor: 'constant-vus',
+      exec: 'articlesExplore',
+      vus: Number(__ENV.EXPLORE_VUS || 5),
+      duration: __ENV.EXPLORE_DURATION || '30s',
+      startTime: __ENV.EXPLORE_START_TIME || '15s',
+    },
+    news_detail_high_load: {
+      executor: 'constant-vus',
+      exec: 'newsDetail',
+      vus: Number(__ENV.DETAIL_VUS || 3),
+      duration: __ENV.DETAIL_DURATION || '30s',
+      startTime: __ENV.DETAIL_START_TIME || '20s',
+    },
+  },
+  thresholds: {
+    'http_req_failed{api:articles_read_high_load}': ['rate<0.05'],
+    'http_req_duration{api:articles_read_high_load}': ['p(95)<1500'],
+    'http_req_duration{endpoint:latest}': ['p(95)<1000'],
+    'http_req_duration{endpoint:cursor}': ['p(95)<1000'],
+    'http_req_duration{endpoint:popular}': ['p(95)<1500'],
+    'http_req_duration{endpoint:explore}': ['p(95)<1500'],
+    'http_req_duration{endpoint:detail}': ['p(95)<1500'],
+  },
+};
+
+function list(value) {
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function pick(values, fallback) {
+  if (values.length === 0) {
+    return fallback;
+  }
+  return values[__ITER % values.length];
+}
+
+function query(params) {
+  return Object.entries(params)
+    .filter(([, value]) => value !== undefined && value !== null && value !== '')
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join('&');
+}
+
+function get(path, endpoint, extraTags = {}) {
+  const res = http.get(`${BASE_URL}${path}`, {
+    tags: {
+      api: 'articles_read_high_load',
+      endpoint,
+      ...extraTags,
+    },
+  });
+
+  articlesPayloadSize.add(res.body ? res.body.length : 0, { endpoint });
+
+  check(res, {
+    'status is 2xx': (r) => r.status >= 200 && r.status < 300,
+    'response has body': (r) => r.body && r.body.length > 0,
+  });
+
+  sleep(SLEEP_SECONDS);
+  return res;
+}
+
+export function articlesLatest() {
+  group('articles latest high load', () => {
+    const page = pick(LATEST_PAGES, '0');
+    get(`/api/articles/latest?page=${encodeURIComponent(page)}&size=${encodeURIComponent(SIZE)}`, 'latest', { page });
+  });
+}
+
+export function articlesCursor() {
+  group('articles cursor high load', () => {
+    const cursor = pick(CURSORS, '');
+    const params = query({ cursor, size: SIZE });
+    get(`/api/articles/cursor?${params}`, 'cursor', { cursorProvided: cursor !== '' ? 'true' : 'false' });
+  });
+}
+
+export function articlesPopular() {
+  group('articles popular high load', () => {
+    const page = pick(POPULAR_PAGES, '0');
+    get(`/api/articles/popular?page=${encodeURIComponent(page)}&size=${encodeURIComponent(SIZE)}`, 'popular', { page });
+  });
+}
+
+export function articlesExplore() {
+  group('articles explore high load', () => {
+    const country = pick(EXPLORE_COUNTRIES, '');
+    const category = pick(EXPLORE_CATEGORIES, '');
+    const date = pick(EXPLORE_DATES, '');
+    const params = query({ country, category, date, size: SIZE });
+
+    get(`/api/articles/explore?${params}`, 'explore', {
+      country: country || 'none',
+      category: category || 'none',
+      dateProvided: date !== '' ? 'true' : 'false',
+    });
+  });
+}
+
+export function newsDetail() {
+  group('news detail high load', () => {
+    const id = pick(DETAIL_IDS, '1');
+    get(`/api/news/detail?id=${encodeURIComponent(id)}`, 'detail', { articleId: id });
+  });
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #174

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)


## 📝 작업 내용
- 주요 기사 조회 API 전용 k6 high-load 스크립트를 추가했습니다.
- `latest`, `cursor`, `popular`, `explore`, `detail` API를 scenario/tag로 분리 측정할 수 있게 했습니다.
- `articles-read-high-load-db-baseline.md`에 API별 repository query, DB 로그 해석 기준, EXPLAIN 후보, 후속 인덱스 분석 후보를 정리했습니다.
- `load-test-baseline.md`, `BACKLOG.md`, `NEXT_AGENT_BRIEF.md`, `WORK_PROGRESS.md`에 #174 진행 상태와 새 기준선 문서를 연결했습니다.
- DB index, repository query, API 응답, Redis/cache, rate limit, 비동기 처리는 변경하지 않았습니다.

## 🔍 기술적 배경
- 기존 `api-baseline.js`는 주요 API smoke/baseline 용도라, 특정 기사 조회 API가 고부하 상황에서 DB 병목을 만드는지 분리해 보기 어렵습니다.
- 이번 PR은 외부 크롤링/Gemini/번역 API가 없는 article read 경로만 대상으로 p95/오류율과 서버 로그 `dbQueryMs`를 함께 해석하는 기준선을 만듭니다.
- 고부하 결과만으로 인덱스를 바로 추가하지 않고, 느린 경로를 고른 뒤 EXPLAIN/EXPLAIN ANALYZE 기반 후속 이슈로 분리하는 방향입니다.


## 🧪 테스트/검증 (필수)
- [x] `node --check load-tests/k6/articles-read-high-load.js`
- [x] `k6 inspect load-tests/k6/articles-read-high-load.js`
- [x] `k6 run load-tests/k6/articles-read-high-load.js` (VU 1 per API, duration 8s smoke)
- [x] `SHOW INDEX FROM article`
- [x] `EXPLAIN` latest/cursor/popular/explore/detail recent query shapes
- [x] `git diff --check`

Local smoke result:

| API | p95 | Failure rate | Notes |
| --- | ---: | ---: | --- |
| all tagged article reads | 96.5ms | 0.00% | 157 requests |
| latest | 85.38ms | 0.00% | offset page mix |
| cursor | 59.86ms | 0.00% | first-page cursor smoke |
| popular | 88.52ms | 0.00% | recent 30-day hot news query |
| explore | 109.86ms | 0.00% | country/category filter mix |
| detail | 95.21ms | 0.00% | article ids `7366,8449` |

Initial EXPLAIN note:
- `popular` query shape used `idx_article_published_at` with `Using filesort`, so if high-load p95/dbQueryMs increases later, it is a natural follow-up DB/index analysis candidate.

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?


## 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
- #174 범위가 high-load 측정 스크립트와 DB 병목 기준선 문서화에 머무르고 DB index/query/API 응답/cache/rate limit/비동기 변경이 없는지 확인해주세요.
- k6 scenario/tag 구성이 latest/cursor/popular/explore/detail API를 분리 측정하기에 충분한지 확인해주세요.
- DB 병목 해석 기준이 p95만 보지 않고 서버 로그 `dbQueryMs`와 EXPLAIN을 함께 보도록 정리되어 있는지 확인해주세요.
- #172 완료 상태와 #174 진행 상태가 `BACKLOG.md`, `NEXT_AGENT_BRIEF.md`, `WORK_PROGRESS.md`에 일관되게 반영됐는지 확인해주세요.


## ➕ 추후 계획(선택)
- 실제 고부하 조건에서 p95와 `dbQueryMs`가 높은 API를 고른 뒤, EXPLAIN/EXPLAIN ANALYZE 기반 DB/index 후보 이슈로 분리합니다.
- 현재 smoke 기준으로는 `popular` query shape의 `Using filesort`가 후속 분석 후보입니다.
