### PR TITLE
📊 [DB/#176] popular 조회 filesort 병목 검증

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -33,16 +33,17 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
   - 최소 1개의 후속 개선 작업이 문서화된 흐름을 따라 Issue부터 PR까지 진행된다.
   - 계획, 승인 범위, 검증 결과를 GitHub에서 확인할 수 있다.
 
-## P1. Perspectives API 관측성 및 성능 기준선 확보
+## P1. 주요 조회 API 관측성 및 성능 기준선 확보
 
-- 상태: `In Progress` ([#121](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/121), [#174](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/174))
+- 상태: `In Progress` ([#121](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/121), [#174](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/174), [#176](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/176))
 - AS-IS: 캐시 미스 시 기사 조회, 키워드 추출, 번역 API 호출, FULLTEXT 검색이 요청 경로에서 수행되지만 단계별 지연 시간과 캐시 효과를 수치로 설명할 수 없다.
 - TO-BE: 캐시 히트율, 단계별 처리 시간, 외부 번역 API 호출량, p95 응답 시간을 측정하고 부하 테스트 기준선을 만든다.
 - 성공 기준:
   - 캐시 히트/미스 시나리오별 p50, p95, 오류율을 기록한다.
   - 번역 API 호출 횟수와 캐시 히트율을 확인할 수 있다.
   - 측정 결과를 후속 개선 PR에 비교 기준으로 남긴다.
-  - #174에서 외부 호출 없는 주요 기사 조회 API의 고부하 p95/오류율과 DB 병목 후보를 분리 측정한다.
+  - #174에서 외부 호출 없는 주요 기사 조회 API의 고부하 p95/오류율과 DB 병목 후보를 분리 측정했다.
+  - #176에서 `popular` 조회의 `Using filesort`를 k6와 `EXPLAIN ANALYZE`로 확인하고, 현재 규모에서는 인덱스 추가를 보류하는 판단 기준을 남긴다.
 
 ## P2. 기사 원문 크롤링 안정성 개선
 

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -23,8 +23,8 @@ Issue
 → 구현
 → 테스트
 → PR
-→ AI Reviewer comment
-→ Blocking 확인
+→ AI Reviewer comment 또는 사용자 직접 확인
+→ Blocking 확인 또는 사용자 확인
 → merge
 → GitHub PR/Issue 상태 확인
 ```
@@ -33,6 +33,8 @@ Issue
 새 Issue/PR 본문은 repository template을 읽고 반드시 `--body-file` 방식으로 작성한다.
 작업 내용과 관련 docs 기록은 가능한 한 PR 본 작업 커밋에 함께 포함한다.
 Reviewer 이후 diff 변경을 피하기 위해 merge 후 `WORK_PROGRESS.md`만 갱신하는 후처리 커밋은 기본값으로 만들지 않는다.
+운영 코드, DB schema/index, API 응답, Repository query, Redis/cache 정책, k6/script 변경이 없는 순수 측정 결과/판단 문서 PR은 Reviewer를 생략하고 사용자 직접 확인 후 merge할 수 있다.
+반대로 코드, 스크립트, DB, cache 정책 변경이 있거나 민감 정보 노출 위험이 있으면 Reviewer 검토를 받는다.
 
 ## Overengineering Guardrail
 
@@ -63,7 +65,8 @@ Reviewer 이후 diff 변경을 피하기 위해 merge 후 `WORK_PROGRESS.md`만 
 - #168/#169에서 검색 API FULLTEXT 검색어별 성능 기준선 수립을 완료했다.
 - #170/#171에서 기사 원문 크롤링 동기 외부 호출 응답 지연 기준선 수립을 완료했다.
 - #172/#173에서 기사 요약 API 외부 호출 단계별 latency 로그 추가를 완료했다.
-- #174에서 주요 기사 조회 API 고부하 부하 테스트 및 DB 병목 기준선 수립을 진행 중이다.
+- #174/#175에서 주요 기사 조회 API 고부하 부하 테스트 및 DB 병목 기준선 수립을 완료했다.
+- #176에서 `articles popular` 조회의 `Using filesort`를 k6 고부하 지표와 MySQL `EXPLAIN ANALYZE`로 확인하고, 현재 데이터 규모에서는 인덱스 추가를 보류하는 판단을 진행 중이다.
 
 ## Recent Completed Work
 
@@ -80,6 +83,7 @@ Reviewer 이후 diff 변경을 피하기 위해 merge 후 `WORK_PROGRESS.md`만 
 - #168/#169: 검색 API FULLTEXT 검색어별 p95, 실패율, 결과 수 smoke 기준선을 수립했다.
 - #170/#171: 기사 요약 API 동기 원문 크롤링 경로의 summary-hit p95/fallback 기준선을 수립했다.
 - #172/#173: 기사 요약 API의 summary hit, crawledContent hit, cold crawl, crawler fallback, AI summary 단계별 latency 로그를 추가했다.
+- #174/#175: 주요 기사 조회 API의 고부하 p95/오류율과 DB 병목 후보를 분리 측정하는 k6 기준선을 수립했다.
 
 ## Why #160 Matters
 
@@ -94,21 +98,24 @@ pure relevance-first는 wrong-context 기사를 끌어올릴 수 있어 바로 �
 현재 진행 중:
 
 ```text
-#174 [PERF] 주요 기사 조회 API 고부하 부하 테스트 및 DB 병목 기준선 수립
+#176 [DB] articles popular 조회 고부하 지표 및 EXPLAIN ANALYZE로 인덱스 개선 필요성 판단
 ```
 
 목표:
 
-- 외부 크롤링/Gemini/번역 API가 없는 주요 기사 조회 API를 고부하 조건에서 분리 측정한다.
-- `latest`, `cursor`, `popular`, `explore`, `detail`의 p95/오류율과 서버 로그 `dbQueryMs`를 함께 해석할 기준을 만든다.
-- 바로 인덱스나 쿼리를 변경하지 않고, 후속 EXPLAIN/인덱스 후보 이슈를 고르는 근거를 남긴다.
-- 이력서에 `주요 기사 조회 API 고부하 p95/DB 병목 기준선 수립`으로 압축 가능한 근거를 만든다.
+- #174에서 발견한 `popular` query의 `Using filesort`가 실제 병목인지 확인한다.
+- 기존 k6 script로 `popular`에 부하를 집중해 p95/오류율을 확인한다.
+- MySQL `EXPLAIN ANALYZE`로 page 0/page 5/count query의 actual time을 기록한다.
+- 현재 데이터 규모에서 인덱스 추가가 필요한지, 아니면 보류해야 하는지 판단한다.
+- 이력서에 `popular 기사 조회 filesort 병목 검증`으로 압축 가능한 근거를 만든다.
 
 다음 세션에서 새 후보를 고를 때는 먼저 develop 최신화, 열린 Issue/PR 확인, `WORK_PROGRESS.md`와 `BACKLOG.md` 확인을 다시 수행한다.
 #110은 사용자가 별도로 지시하기 전까지 다루지 않는다.
 #162 guardrail에 따라 "지금 구현하면 과한가?"를 먼저 판단한다.
-#174는 고부하 측정과 DB 병목 후보 도출이 우선이다.
-다음 단계에서 DB index/query 변경을 바로 적용하지 말고, 먼저 `load-tests/k6/articles-read-high-load.js`와 `docs/backend-improvement/articles-read-high-load-db-baseline.md`를 기준으로 slow path를 확인한다.
+#176은 DB index/query 변경 없이 측정과 판단만 남기는 범위다.
+Reviewer는 생략 가능하며, PR 생성 후 사용자가 diff와 결과를 확인한 뒤 merge한다.
+#176 점진 부하에서 `popular` p95는 VU 증가에 따라 상승했지만 RPS가 비례해 늘지 않았고, DB-side `EXPLAIN ANALYZE` actual time은 낮았다.
+다음 단계에서 DB index/query 변경을 바로 적용하지 말고, 먼저 `docs/backend-improvement/articles-popular-filesort-analysis.md`의 follow-up criteria와 애플리케이션 로그/로컬 리소스 지표 캡처 필요성을 기준으로 판단한다.
 
 #164 ADR 기준상 hybrid ranking code experiment는 아래 조건이 준비된 뒤 별도 Issue로 검토한다.
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -18,8 +18,8 @@ Issue 생성
 → 구현
 → 테스트/검증
 → PR 생성
-→ AI Reviewer 검토
-→ Blocking 반영
+→ AI Reviewer 검토 또는 사용자 직접 확인
+→ Blocking 반영 또는 사용자 확인
 → 최종 Blocking 없음 확인
 → 사용자 승인 후 merge
 → GitHub PR/Issue 상태 확인
@@ -42,6 +42,8 @@ Implementer는 새 Issue/PR을 만든 뒤 Reviewer Agent에게 전달할 검토 
 다만 develop commit history를 이슈별 핵심 변경 중심으로 유지하기 위해, 작업 내용과 관련 docs 기록은 가능한 한 PR 본 작업 커밋에 함께 포함한다.
 merge 후 `WORK_PROGRESS.md`만 갱신하는 후처리 커밋은 기본값으로 만들지 않고, GitHub PR/Issue 상태로 merge 결과를 확인한다.
 후처리 커밋은 PR에 포함된 문서가 다음 세션을 잘못 안내하거나 Reviewer가 명시적으로 요구한 경우처럼 필요한 때에만 만든다.
+운영 코드, DB schema/index, API 응답, Repository query, Redis/cache 정책, k6/script 변경이 없는 순수 측정 결과/판단 문서 PR은 Reviewer를 생략하고 사용자 직접 확인 후 merge할 수 있다.
+코드, 스크립트, DB, cache 정책 변경이 있거나 민감 정보 노출 위험이 있으면 Reviewer 검토를 받는다.
 
 ### 커밋 메시지 규칙
 
@@ -101,7 +103,8 @@ Blocking 예시:
 - #168/#169에서 검색 API FULLTEXT 검색어별 성능 기준선을 수립했다.
 - #170/#171에서 기사 원문 크롤링 동기 외부 호출 응답 지연 기준선을 수립했다.
 - #172/#173에서 기사 요약 API 외부 호출 단계별 latency 로그를 추가했다.
-- #174에서 주요 기사 조회 API 고부하 부하 테스트 및 DB 병목 기준선을 수립 중이다.
+- #174/#175에서 주요 기사 조회 API 고부하 부하 테스트 및 DB 병목 기준선을 수립했다.
+- #176에서 `popular` 기사 조회의 `Using filesort`가 현재 데이터 규모에서 인덱스 추가가 필요한 병목인지 k6와 `EXPLAIN ANALYZE`로 판단 중이다.
 - 현재 반복 성능/안정성 기본기 흐름의 주요 후보(#123, #127, #129, #131, #133, #137, #140, #142, #146)와 AI workflow 보강(#144)은 merge 완료 상태다.
 
 ### #113 / PR #114 - 백엔드 개선 Backlog 및 AI 작업 운영 규칙 수립
@@ -1366,7 +1369,8 @@ git diff --check
 ### #174 - 주요 기사 조회 API 고부하 부하 테스트 및 DB 병목 기준선 수립
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/174
-- 상태: In Progress
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/175
+- 상태: merged
 - 작업 브랜치: `perf/#174-articles-high-load-db-baseline`
 - 주요 파일:
   - `load-tests/k6/articles-read-high-load.js`
@@ -1414,6 +1418,69 @@ git diff --check
 - 2026-07-09 로컬 smoke에서 전체 tagged article read p95 96.5ms, failure 0.00%를 확인했다.
 - endpoint별 p95는 latest 85.38ms, cursor 59.86ms, popular 88.52ms, explore 109.86ms, detail 95.21ms였다.
 - 초기 EXPLAIN에서 popular query shape는 `idx_article_published_at` range 후 `Using filesort`가 확인되어, 고부하 p95/dbQueryMs가 높아질 경우 후속 인덱스 후보로 검토할 수 있다.
+- Reviewer 결과 `MERGE_READY`, Blocking 없음으로 확인 후 2026-07-09 기준 PR #175를 squash merge했고 Issue #174는 closed 상태다.
+
+---
+
+### #176 - articles popular 조회 고부하 지표 및 EXPLAIN ANALYZE로 인덱스 개선 필요성 판단
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/176
+- 상태: In Progress
+- 작업 브랜치: `db/#176-popular-filesort-analysis`
+- 주요 파일:
+  - `docs/backend-improvement/articles-popular-filesort-analysis.md`
+  - `docs/backend-improvement/articles-read-high-load-db-baseline.md`
+  - `docs/backend-improvement/BACKLOG.md`
+  - `docs/backend-improvement/NEXT_AGENT_BRIEF.md`
+  - `docs/backend-improvement/WORK_PROGRESS.md`
+
+목표:
+
+- #174에서 발견한 `popular` 조회의 `Using filesort`가 현재 데이터 규모에서 실제 병목인지 확인한다.
+- 기준선 정리만 반복하지 않고, 기존 k6 스크립트로 바로 고부하 지표를 확인한다.
+- MySQL `EXPLAIN ANALYZE`로 content query와 count query의 actual time을 기록한다.
+- 인덱스 추가 여부를 수치 기반으로 판단하되, 근거가 약하면 보류한다.
+- 이력서에서는 `popular 기사 조회 filesort 병목 검증`으로 압축 가능하게 한다.
+
+Overengineering 판단:
+
+- `Using filesort`가 보인다는 이유만으로 DB 인덱스를 바로 추가하면 과하다.
+- 현재 로컬 데이터는 article 9,853건, 최근 30일 조건 2,070건 수준이다.
+- #174 smoke에서 `popular` p95가 88.52ms였고, #176의 20 VU 측정에서도 134.87ms였다.
+- 50/100 VU 점진 부하에서는 p95가 상승했지만 RPS가 비례해 증가하지 않아 DB index 변경보다 로컬/애플리케이션 처리 한계 확인이 먼저다.
+- 따라서 이번 범위는 운영 코드, Repository query, DB schema/index 변경 없이 측정과 판단 기록만 남긴다.
+
+검증:
+
+```text
+k6 run load-tests/k6/articles-read-high-load.js (popular 20 VUs, 60s)
+k6 run load-tests/k6/articles-read-high-load.js (popular 50 VUs, 30s)
+k6 run load-tests/k6/articles-read-high-load.js (popular 100 VUs, 20s)
+EXPLAIN popular page 0/page 5 query shape
+EXPLAIN ANALYZE popular page 0/page 5 query shape
+EXPLAIN ANALYZE popular count query
+git diff --check
+```
+
+측정 결과:
+
+- k6 조건: `popular` 20 VUs, 60s, `POPULAR_PAGES=0,1,5`, 다른 article read scenario는 1 VU/1s로 최소화
+- 전체 tagged article reads: 6,396 requests, p95 135.17ms, failure 0.00%
+- `popular`: p95 134.87ms, failure 0.00%
+- 50 VUs, 30s: 3,474 requests, RPS 114.33/s, `popular` p95 423.79ms, failure 0.00%
+- 100 VUs, 20s: 2,561 requests, RPS 123.61/s, `popular` p95 902.51ms, failure 0.00%
+- VUs가 20에서 100으로 늘어도 RPS는 106.29/s에서 123.61/s로만 증가해 로컬 실행환경 또는 애플리케이션 처리 한계가 섞였을 가능성이 있다.
+- MySQL page 0 content query: `idx_article_published_at` range scan 2,070 rows 후 `Using filesort`, actual time 약 6.44ms
+- MySQL page 5 content query: offset 100 기준 actual time 약 11.5ms
+- count query: covering index range scan, actual time 약 0.696ms
+
+판단:
+
+- 현재 데이터 규모와 로컬 고부하 조건에서는 `Using filesort`만으로 즉시 인덱스 추가를 정당화하기 어렵다.
+- `popular` p95는 50/100 VU에서 상승했지만, DB-side `EXPLAIN ANALYZE`는 여전히 낮고 RPS가 거의 plateau되어 애플리케이션 로그와 로컬 리소스 지표를 먼저 연결해야 한다.
+- `popular` 조회는 watch item으로 남기고, p95와 `[ArticlesPopular] dbQueryMs`가 함께 반복적으로 높아질 때 별도 인덱스 실험 이슈를 연다.
+- 이번 실행에서는 `bootRun` stdout 로그 캡처가 안정적으로 되지 않아 `[ArticlesPopular] dbQueryMs`는 기록하지 못했다. 대신 MySQL `EXPLAIN ANALYZE` actual time을 DB-side 근거로 남겼다.
+- 다음 후보는 인덱스 구현보다 로컬 성능 측정 시 애플리케이션 latency 로그와 리소스 지표 캡처를 안정화하는 작은 관측성 작업이 더 적절하다.
 
 ## 4. 이후 개선 로드맵
 

--- a/docs/backend-improvement/articles-popular-filesort-analysis.md
+++ b/docs/backend-improvement/articles-popular-filesort-analysis.md
@@ -1,0 +1,248 @@
+# Articles popular filesort analysis
+
+## Purpose
+
+This document records the follow-up measurement for the `GET /api/articles/popular` path after #174 found `Using filesort` in the initial MySQL plan.
+
+The goal is not to add an index immediately.
+The goal is to combine k6 high-load API data with MySQL `EXPLAIN ANALYZE` and decide whether the current `Using filesort` signal is strong enough to justify a DB index/query change.
+
+## Portfolio Summary Candidate
+
+```text
+기사 popular 조회 API의 고부하 p95와 MySQL EXPLAIN ANALYZE를 함께 분석해 filesort 병목 여부를 검증하고, 인덱스 적용 여부를 수치 기반으로 판단했습니다.
+```
+
+Shorter resume keyword version:
+
+```text
+popular 기사 조회 filesort 병목 검증
+```
+
+## Scope
+
+Target API:
+
+```text
+GET /api/articles/popular?page={page}&size={size}
+```
+
+Repository method:
+
+```text
+findByPublishedAtAfterOrderByViewCountDesc(LocalDateTime from, Pageable pageable)
+```
+
+Representative SQL shape:
+
+```sql
+SELECT *
+FROM article
+WHERE published_at > DATE_SUB(NOW(), INTERVAL 30 DAY)
+ORDER BY view_count DESC
+LIMIT 20 OFFSET 0;
+```
+
+This analysis does not change:
+
+- DB indexes or schema
+- Repository queries
+- API response shape
+- Redis/cache policy
+- rate limiting or async processing
+
+## Overengineering Decision
+
+Adding an index immediately would be too much for the current evidence.
+
+Reasons:
+
+- The local dataset has fewer than 10,000 article rows.
+- The first #174 smoke result showed `popular` p95 under 100ms.
+- `Using filesort` can be acceptable when the sorted candidate set is small.
+- A junior backend portfolio story is stronger if it shows measured judgment: `EXPLAIN signal -> high-load check -> EXPLAIN ANALYZE -> apply or defer`.
+
+Therefore this issue records measurement and decision criteria only.
+
+## Local Data Snapshot
+
+Measured on 2026-07-09 against local Docker MySQL.
+
+| Metric | Value |
+| --- | ---: |
+| Total `article` rows | 9,853 |
+| Recent 30-day rows | 2,070 |
+| Min `published_at` | 2015-06-07 09:25:07 |
+| Max `published_at` | 2026-06-22 15:26:57 |
+
+## k6 Popular-Focused Result
+
+Measured on 2026-07-09 with local Docker MySQL/Redis and local `bootRun` server on `http://localhost:8080`.
+
+The existing #174 script was reused.
+Other article-read scenarios were reduced to `1` VU for `1s`; `popular` was measured with gradual local load.
+
+```powershell
+$env:BASE_URL = "http://localhost:8080"
+$env:ARTICLES_SIZE = "20"
+$env:LATEST_VUS = "1"
+$env:CURSOR_VUS = "1"
+$env:POPULAR_VUS = "20"
+$env:EXPLORE_VUS = "1"
+$env:DETAIL_VUS = "1"
+$env:LATEST_DURATION = "1s"
+$env:CURSOR_DURATION = "1s"
+$env:POPULAR_DURATION = "60s"
+$env:EXPLORE_DURATION = "1s"
+$env:DETAIL_DURATION = "1s"
+$env:POPULAR_PAGES = "0,1,5"
+$env:SLEEP_SECONDS = "0.1"
+k6 run .\load-tests\k6\articles-read-high-load.js
+```
+
+Gradual local load result:
+
+| Popular VUs | Duration | Total requests | RPS | Popular p95 | Failure rate | Notes |
+| ---: | --- | ---: | ---: | ---: | ---: | --- |
+| 20 | 60s | 6,396 | 106.29/s | 134.87ms | 0.00% | Initial popular-focused baseline |
+| 50 | 30s | 3,474 | 114.33/s | 423.79ms | 0.00% | `latest` one-shot threshold crossed, but target `popular` stayed under threshold |
+| 100 | 20s | 2,561 | 123.61/s | 902.51ms | 0.00% | p95 increased sharply while RPS rose only slightly |
+
+Interpretation:
+
+- `popular` p95 increased as VUs rose: `134.87ms -> 423.79ms -> 902.51ms`.
+- RPS did not scale proportionally: `106.29/s -> 114.33/s -> 123.61/s`.
+- Failure rate stayed `0.00%` through 100 VUs.
+- This pattern suggests local execution or application-side saturation may be involved. It does not by itself prove a DB index bottleneck.
+- The run did not capture application stdout logs reliably, so `dbQueryMs` was not recorded from `[ArticlesPopular]` logs in this issue. DB-side `EXPLAIN ANALYZE` actual time is used as the supporting DB signal instead.
+
+## EXPLAIN ANALYZE Result
+
+### Page 0 content query
+
+```sql
+EXPLAIN ANALYZE
+SELECT *
+FROM article
+WHERE published_at > DATE_SUB(NOW(), INTERVAL 30 DAY)
+ORDER BY view_count DESC
+LIMIT 20 OFFSET 0;
+```
+
+Observed plan summary:
+
+| Step | Actual time | Rows |
+| --- | --- | ---: |
+| Index range scan on `idx_article_published_at` | 0.0362..4.88ms | 2,070 |
+| Sort by `view_count DESC` with top-20 limit | 6.41..6.44ms | 20 |
+| Limit | 6.41..6.44ms | 20 |
+
+Traditional `EXPLAIN` still reports:
+
+```text
+Using index condition; Using filesort
+```
+
+### Page 5 content query
+
+The script includes `POPULAR_PAGES=0,1,5`.
+Page 5 maps to `OFFSET 100` when `size=20`.
+
+```sql
+EXPLAIN ANALYZE
+SELECT *
+FROM article
+WHERE published_at > DATE_SUB(NOW(), INTERVAL 30 DAY)
+ORDER BY view_count DESC
+LIMIT 20 OFFSET 100;
+```
+
+Observed plan summary:
+
+| Step | Actual time | Rows |
+| --- | --- | ---: |
+| Index range scan on `idx_article_published_at` | 0.0935..7.95ms | 2,070 |
+| Sort by `view_count DESC` with top-120 limit | 11.2..11.4ms | 120 |
+| Limit/Offset | 11.4..11.5ms | 20 |
+
+Traditional `EXPLAIN` still reports:
+
+```text
+Using index condition; Using filesort
+```
+
+### Count query
+
+Spring Data `Page` can also trigger a count query.
+
+```sql
+EXPLAIN ANALYZE
+SELECT COUNT(*)
+FROM article
+WHERE published_at > DATE_SUB(NOW(), INTERVAL 30 DAY);
+```
+
+Observed plan summary:
+
+| Step | Actual time | Rows |
+| --- | --- | ---: |
+| Covering index range scan on `idx_article_published_at` | 0.0215..0.448ms | 2,070 |
+| Filter | 0.0242..0.616ms | 2,070 |
+| Aggregate count | 0.696..0.696ms | 1 |
+
+The count path uses `idx_article_published_at` as a covering index and is not the current concern.
+
+## Decision
+
+Defer DB index changes for now.
+
+The `popular` query does use filesort, and API p95 rises under local VU pressure.
+However, the current evidence still does not prove that a DB index change is the right next step:
+
+- `popular` k6 p95: 134.87ms at 20 VUs, 423.79ms at 50 VUs, 902.51ms at 100 VUs
+- failure rate: 0.00%
+- RPS plateaued from 106.29/s to 123.61/s while VUs increased from 20 to 100
+- page 0 DB-side actual time: about 6.44ms
+- page 5 DB-side actual time: about 11.5ms
+- count query actual time: about 0.696ms
+
+At the current data scale, the filesort is a watch item rather than an immediate optimization target.
+The sharper p95 increase should first be investigated with reliable application log capture, especially `[ArticlesPopular] dbQueryMs`, connection pool signals, and local resource usage.
+
+## Follow-up Criteria
+
+Open a DB index implementation issue only if one of the following becomes true under a repeatable measurement shape:
+
+- `popular` p95 repeatedly exceeds a chosen service threshold, for example 300ms to 500ms locally, and DB time rises with it.
+- `[ArticlesPopular] dbQueryMs` is captured and repeatedly dominates `totalMs`.
+- `EXPLAIN ANALYZE` sort time grows materially as recent 30-day rows increase.
+- deeper popular pages become product-critical and offset cost starts to dominate.
+
+Candidate index experiments, if needed later:
+
+```sql
+CREATE INDEX idx_article_view_count_published_at
+ON article (view_count DESC, published_at);
+
+CREATE INDEX idx_article_published_at_view_count
+ON article (published_at, view_count DESC);
+```
+
+These should not be applied without a before/after measurement because each index has different trade-offs:
+
+- `(view_count DESC, published_at)` may help ordering but can be less direct for the 30-day range filter.
+- `(published_at, view_count DESC)` matches the range filter first but may still not fully remove sorting after a range condition.
+- both add write/storage overhead.
+
+## Next Candidate
+
+If continuing the DB-read performance track, the next useful issue is not index implementation yet.
+A better next issue is to make local performance runs capture application logs and resource signals reliably so `dbQueryMs`, `totalMs`, connection pool behavior, and k6 output can be compared in the same run window.
+
+Candidate next issue:
+
+```text
+[OBS] 로컬 부하 테스트 시 애플리케이션 latency 로그와 리소스 지표 캡처 안정화
+```
+
+After that, rerun the same 20/50/100 VU test and decide whether the p95 growth is DB query time, application thread/connection pool pressure, or local machine saturation.

--- a/docs/backend-improvement/articles-read-high-load-db-baseline.md
+++ b/docs/backend-improvement/articles-read-high-load-db-baseline.md
@@ -185,7 +185,7 @@ Initial local `EXPLAIN` notes from 2026-07-09:
 
 Potential follow-up issues:
 
-- `[DB] articles popular 조회 EXPLAIN 분석 및 인덱스 후보 정리`
+- `[DB] articles popular 조회 EXPLAIN ANALYZE 및 인덱스 후보 판단` - completed as #176; see `articles-popular-filesort-analysis.md`
 - `[DB] articles explore 필터 조회 EXPLAIN 분석 및 복합 인덱스 후보 정리`
 - `[PERF] latest offset paging과 cursor paging 고부하 비교`
 - `[OBS] news detail DB 조회 단계별 latency 로그 추가`
@@ -211,3 +211,25 @@ It intentionally avoids:
 - adding async processing
 
 The next step after collecting high-load data is to choose the slowest DB-backed path and open a focused EXPLAIN/index candidate issue.
+
+## Follow-up: Popular Filesort Analysis
+
+#176 followed the `popular` query because #174 found `Using filesort`.
+
+Result summary:
+
+- local data: 9,853 total article rows, 2,070 rows in the recent 30-day filter
+- k6 popular-focused run: `20 -> 50 -> 100` VUs, p95 `134.87ms -> 423.79ms -> 902.51ms`, failure rate `0.00%`
+- RPS plateau: `106.29/s -> 114.33/s -> 123.61/s`, so local/application saturation should be checked before DB index changes
+- `EXPLAIN ANALYZE` page 0 content query: about `6.44ms`
+- `EXPLAIN ANALYZE` page 5 content query: about `11.5ms`
+- count query: about `0.696ms`
+
+Decision:
+
+- keep the current query/index for now
+- treat `Using filesort` as a watch item, not an immediate DB index change trigger
+- first make `[ArticlesPopular] dbQueryMs`, `totalMs`, and local resource capture reliable for the same run window
+- revisit index experiments only if `popular` p95 and captured DB query time rise together
+
+Detailed notes: `docs/backend-improvement/articles-popular-filesort-analysis.md`


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #176

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)


## 📝 작업 내용
- `popular` 기사 조회의 `Using filesort` 후속 분석 문서를 추가했습니다.
- 기존 #174 k6 스크립트로 `popular` 중심 점진 부하 측정을 실행하고 p95/오류율/RPS를 기록했습니다.
- MySQL `EXPLAIN ANALYZE`로 page 0/page 5/count query의 실제 실행 시간을 기록했습니다.
- 현재 데이터 규모에서는 인덱스 추가를 보류하고, 후속 적용 기준을 문서화했습니다.
- #174 merge 상태와 측정/문서 PR의 Reviewer 생략 기준을 backend improvement 문서에 반영했습니다.

## 🔍 기술적 배경
- #174에서 `GET /api/articles/popular` query가 `idx_article_published_at` range scan 이후 `Using filesort`를 사용하는 것으로 확인되었습니다.
- `Using filesort`는 인덱스 변경 후보가 될 수 있지만, 정렬 대상 rows가 작고 DB-side actual time이 낮으면 즉시 인덱스 추가 근거로 보기 어렵습니다.
- 이번 PR은 운영 코드, Repository query, DB schema/index를 바꾸지 않고 실제 지표와 실행 계획으로 보류 판단을 남기는 범위입니다.


## 🧪 테스트/검증 (필수)
- [x] `k6 run load-tests/k6/articles-read-high-load.js` (`popular` 20 VUs, 60s)로 p95 134.87ms, failure 0.00%, RPS 106.29/s 확인
- [x] `k6 run load-tests/k6/articles-read-high-load.js` (`popular` 50 VUs, 30s)로 p95 423.79ms, failure 0.00%, RPS 114.33/s 확인
- [x] `k6 run load-tests/k6/articles-read-high-load.js` (`popular` 100 VUs, 20s)로 p95 902.51ms, failure 0.00%, RPS 123.61/s 확인
- [x] MySQL `EXPLAIN ANALYZE`로 page 0 content query 약 6.44ms, page 5 content query 약 11.5ms, count query 약 0.696ms 확인
- [x] `git diff --check`


## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [ ] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?


## 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
- 이번 PR은 운영 코드, DB schema/index, API 응답, Repository query, Redis/cache 정책, k6/script 변경이 없는 측정 결과/판단 문서 PR입니다.
- 사용자와 합의한 기준에 따라 AI Reviewer 검토는 생략하고 사용자 직접 확인 후 merge하는 흐름을 적용합니다.


## ➕ 추후 계획(선택)
- 다음 후보는 로컬 성능 측정 시 애플리케이션 latency 로그와 리소스 지표 캡처를 안정화하는 관측성 작업입니다.
- `popular` p95와 `[ArticlesPopular] dbQueryMs`가 함께 반복적으로 높아질 때 별도 인덱스 실험 이슈를 엽니다.
