### PR TITLE
🔎 [OBS/#178] 로컬 부하 테스트 관측 runbook 정리

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -35,7 +35,8 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## P1. 주요 조회 API 관측성 및 성능 기준선 확보
 
-- 상태: `In Progress` ([#121](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/121), [#174](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/174), [#176](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/176), [#178](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/178))
+- 상태: `In Progress` ([#178](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/178))
+- 완료 근거: [#121](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/121), [#174](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/174), [#176](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/176)
 - AS-IS: 캐시 미스 시 기사 조회, 키워드 추출, 번역 API 호출, FULLTEXT 검색이 요청 경로에서 수행되지만 단계별 지연 시간과 캐시 효과를 수치로 설명할 수 없다.
 - TO-BE: 캐시 히트율, 단계별 처리 시간, 외부 번역 API 호출량, p95 응답 시간을 측정하고 부하 테스트 기준선을 만든다.
 - 성공 기준:

--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -35,7 +35,7 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## P1. 주요 조회 API 관측성 및 성능 기준선 확보
 
-- 상태: `In Progress` ([#121](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/121), [#174](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/174), [#176](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/176))
+- 상태: `In Progress` ([#121](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/121), [#174](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/174), [#176](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/176), [#178](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/178))
 - AS-IS: 캐시 미스 시 기사 조회, 키워드 추출, 번역 API 호출, FULLTEXT 검색이 요청 경로에서 수행되지만 단계별 지연 시간과 캐시 효과를 수치로 설명할 수 없다.
 - TO-BE: 캐시 히트율, 단계별 처리 시간, 외부 번역 API 호출량, p95 응답 시간을 측정하고 부하 테스트 기준선을 만든다.
 - 성공 기준:
@@ -44,6 +44,7 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
   - 측정 결과를 후속 개선 PR에 비교 기준으로 남긴다.
   - #174에서 외부 호출 없는 주요 기사 조회 API의 고부하 p95/오류율과 DB 병목 후보를 분리 측정했다.
   - #176에서 `popular` 조회의 `Using filesort`를 k6와 `EXPLAIN ANALYZE`로 확인하고, 현재 규모에서는 인덱스 추가를 보류하는 판단 기준을 남긴다.
+  - #178에서 로컬 부하 테스트 시 k6 결과, 애플리케이션 latency 로그, Docker 리소스 지표를 같은 실행 구간에 맞춰 해석하는 runbook을 정리한다.
 
 ## P2. 기사 원문 크롤링 안정성 개선
 
@@ -55,6 +56,17 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
   - 동일 기사 요청 시 불필요한 재크롤링을 줄이는 기준을 확인한다.
   - #170/#171에서 요약 API의 동기 원문 크롤링 경로를 cold/warm/fallback 조건으로 측정할 수 있는 기준선을 수립했다.
   - #172/#173에서 summary hit, crawledContent hit, cold crawl, crawler fallback, AI summary 호출 시간을 단계별 로그로 분리 관측할 수 있게 했다.
+
+### P2 후속 후보. Gemini mock latency 부하 테스트
+
+- 상태: `Backlog`
+- AS-IS: 기사 상세의 AI 요약/질의응답 경로에는 Gemini 외부 호출이 포함될 수 있지만, 실제 Gemini API로 부하 테스트를 반복하면 비용, quota, rate limit, 응답 편차 문제가 생긴다.
+- TO-BE: mock AI 서버로 latency `200ms`, `1s`, `3s`, `timeout/5xx` 조건을 통제하고, 사용자 요청 경로의 p95/오류율/fallback 동작을 측정한다.
+- 진행 조건:
+  - #178의 로컬 부하 테스트 로그/리소스 캡처 기준을 먼저 적용한다.
+  - mock 서버는 테스트/로컬 설정에만 사용하고 운영 API key, prompt 전문, 사용자 질문 전문은 문서/로그에 남기지 않는다.
+- 예상 이슈:
+  - `[PERF] AI 질의응답 Gemini 외부 호출 mock latency 부하 테스트`
 
 ## P2-1. 검색 API FULLTEXT 성능 기준선
 

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -66,7 +66,8 @@ Reviewer 이후 diff 변경을 피하기 위해 merge 후 `WORK_PROGRESS.md`만 
 - #170/#171에서 기사 원문 크롤링 동기 외부 호출 응답 지연 기준선 수립을 완료했다.
 - #172/#173에서 기사 요약 API 외부 호출 단계별 latency 로그 추가를 완료했다.
 - #174/#175에서 주요 기사 조회 API 고부하 부하 테스트 및 DB 병목 기준선 수립을 완료했다.
-- #176에서 `articles popular` 조회의 `Using filesort`를 k6 고부하 지표와 MySQL `EXPLAIN ANALYZE`로 확인하고, 현재 데이터 규모에서는 인덱스 추가를 보류하는 판단을 진행 중이다.
+- #176/#177에서 `articles popular` 조회의 `Using filesort`를 k6 고부하 지표와 MySQL `EXPLAIN ANALYZE`로 확인하고, 현재 데이터 규모에서는 인덱스 추가를 보류했다.
+- #178에서 로컬 부하 테스트 시 k6 결과, 애플리케이션 latency 로그, Docker 리소스 지표를 같은 실행 구간에 묶어 해석하는 runbook을 진행 중이다.
 
 ## Recent Completed Work
 
@@ -84,6 +85,7 @@ Reviewer 이후 diff 변경을 피하기 위해 merge 후 `WORK_PROGRESS.md`만 
 - #170/#171: 기사 요약 API 동기 원문 크롤링 경로의 summary-hit p95/fallback 기준선을 수립했다.
 - #172/#173: 기사 요약 API의 summary hit, crawledContent hit, cold crawl, crawler fallback, AI summary 단계별 latency 로그를 추가했다.
 - #174/#175: 주요 기사 조회 API의 고부하 p95/오류율과 DB 병목 후보를 분리 측정하는 k6 기준선을 수립했다.
+- #176/#177: `popular` 조회의 20/50/100 VU p95와 MySQL `EXPLAIN ANALYZE`를 비교해 인덱스 추가를 보류하고 관측성 보강 필요성을 남겼다.
 
 ## Why #160 Matters
 
@@ -98,24 +100,25 @@ pure relevance-first는 wrong-context 기사를 끌어올릴 수 있어 바로 �
 현재 진행 중:
 
 ```text
-#176 [DB] articles popular 조회 고부하 지표 및 EXPLAIN ANALYZE로 인덱스 개선 필요성 판단
+#178 [OBS] 로컬 부하 테스트 latency 로그와 리소스 지표 캡처 안정화
 ```
 
 목표:
 
-- #174에서 발견한 `popular` query의 `Using filesort`가 실제 병목인지 확인한다.
-- 기존 k6 script로 `popular`에 부하를 집중해 p95/오류율을 확인한다.
-- MySQL `EXPLAIN ANALYZE`로 page 0/page 5/count query의 actual time을 기록한다.
-- 현재 데이터 규모에서 인덱스 추가가 필요한지, 아니면 보류해야 하는지 판단한다.
-- 이력서에 `popular 기사 조회 filesort 병목 검증`으로 압축 가능한 근거를 만든다.
+- k6 p95/RPS, 애플리케이션 `dbQueryMs`/`totalMs` 로그, Docker 리소스 지표를 같은 run id/time window로 묶는 로컬 runbook을 만든다.
+- #176에서 보인 p95 상승이 DB 병목인지, 애플리케이션 처리 한계인지, 로컬 자원 한계인지 구분할 판단 기준을 정리한다.
+- Gemini mock latency 부하 테스트를 후속 후보로 명시한다.
+- 운영 코드, DB schema/index, API 응답, Repository query, Redis/cache 정책, k6 script는 변경하지 않는다.
+- 이력서에 `부하 테스트 로그/리소스 관측 기준 수립`으로 압축 가능한 근거를 만든다.
 
 다음 세션에서 새 후보를 고를 때는 먼저 develop 최신화, 열린 Issue/PR 확인, `WORK_PROGRESS.md`와 `BACKLOG.md` 확인을 다시 수행한다.
 #110은 사용자가 별도로 지시하기 전까지 다루지 않는다.
 #162 guardrail에 따라 "지금 구현하면 과한가?"를 먼저 판단한다.
-#176은 DB index/query 변경 없이 측정과 판단만 남기는 범위다.
+#178은 운영 코드 변경 없이 측정 runbook과 후속 판단 기준만 남기는 범위다.
 Reviewer는 생략 가능하며, PR 생성 후 사용자가 diff와 결과를 확인한 뒤 merge한다.
 #176 점진 부하에서 `popular` p95는 VU 증가에 따라 상승했지만 RPS가 비례해 늘지 않았고, DB-side `EXPLAIN ANALYZE` actual time은 낮았다.
-다음 단계에서 DB index/query 변경을 바로 적용하지 말고, 먼저 `docs/backend-improvement/articles-popular-filesort-analysis.md`의 follow-up criteria와 애플리케이션 로그/로컬 리소스 지표 캡처 필요성을 기준으로 판단한다.
+다음 단계에서 DB index/query 변경을 바로 적용하지 말고, 먼저 `docs/backend-improvement/local-load-observability-runbook.md` 기준으로 애플리케이션 로그/로컬 리소스 지표를 캡처할 수 있게 한다.
+그 다음 후속 후보로 `[PERF] AI 질의응답 Gemini 외부 호출 mock latency 부하 테스트`를 검토한다.
 
 #164 ADR 기준상 hybrid ranking code experiment는 아래 조건이 준비된 뒤 별도 Issue로 검토한다.
 
@@ -138,6 +141,8 @@ Reviewer는 생략 가능하며, PR 생성 후 사용자가 diff와 결과를 �
 - `docs/backend-improvement/search-fulltext-term-baseline.md`
 - `docs/backend-improvement/article-crawl-latency-baseline.md`
 - `docs/backend-improvement/articles-read-high-load-db-baseline.md`
+- `docs/backend-improvement/articles-popular-filesort-analysis.md`
+- `docs/backend-improvement/local-load-observability-runbook.md`
 - `docs/backend-improvement/load-test-baseline.md`
 - `docs/backend-improvement/perspectives-fulltext-generic-token-filter-result.md`
 - `docs/backend-improvement/perspectives-fulltext-ordering-comparison.md`

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -1526,10 +1526,12 @@ Overengineering 판단:
 git diff --check
 ```
 
-Reviewer 판단:
+Reviewer 결과:
 
 - 이번 PR은 문서/runbook-only 변경이며 운영 코드, DB schema/index, Repository query, Redis/cache policy, k6 script 변경이 없다.
-- 따라서 AI Reviewer 검토는 생략하고 사용자 직접 확인 후 merge할 수 있는 범위다.
+- `## AI Reviewer 검토 결과` 제목의 Reviewer comment 기준 `MERGE_READY`, Blocking 없음.
+- Non-blocking: `BACKLOG.md` P1 상태 줄에서 진행 중 이슈와 완료 근거를 분리하면 더 읽기 쉽다는 제안이 있었고, merge 전 반영했다.
+- Non-blocking: PR 본문과 작업 기록의 "AI Reviewer 생략 가능" 표현은 이번처럼 실제 리뷰를 받은 경우 혼선을 줄 수 있어, 작업 기록은 실제 Reviewer 결과로 정리했다.
 
 ## 4. 이후 개선 로드맵
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -104,7 +104,8 @@ Blocking 예시:
 - #170/#171에서 기사 원문 크롤링 동기 외부 호출 응답 지연 기준선을 수립했다.
 - #172/#173에서 기사 요약 API 외부 호출 단계별 latency 로그를 추가했다.
 - #174/#175에서 주요 기사 조회 API 고부하 부하 테스트 및 DB 병목 기준선을 수립했다.
-- #176에서 `popular` 기사 조회의 `Using filesort`가 현재 데이터 규모에서 인덱스 추가가 필요한 병목인지 k6와 `EXPLAIN ANALYZE`로 판단 중이다.
+- #176/#177에서 `popular` 기사 조회의 `Using filesort`가 현재 데이터 규모에서 인덱스 추가가 필요한 병목인지 k6와 `EXPLAIN ANALYZE`로 판단했다.
+- #178에서 로컬 부하 테스트 시 애플리케이션 latency 로그와 Docker/local resource 지표를 같은 실행 구간에 캡처하는 관측 runbook을 정리 중이다.
 - 현재 반복 성능/안정성 기본기 흐름의 주요 후보(#123, #127, #129, #131, #133, #137, #140, #142, #146)와 AI workflow 보강(#144)은 merge 완료 상태다.
 
 ### #113 / PR #114 - 백엔드 개선 Backlog 및 AI 작업 운영 규칙 수립
@@ -1425,7 +1426,8 @@ git diff --check
 ### #176 - articles popular 조회 고부하 지표 및 EXPLAIN ANALYZE로 인덱스 개선 필요성 판단
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/176
-- 상태: In Progress
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/177
+- 상태: merged
 - 작업 브랜치: `db/#176-popular-filesort-analysis`
 - 주요 파일:
   - `docs/backend-improvement/articles-popular-filesort-analysis.md`
@@ -1481,6 +1483,53 @@ git diff --check
 - `popular` 조회는 watch item으로 남기고, p95와 `[ArticlesPopular] dbQueryMs`가 함께 반복적으로 높아질 때 별도 인덱스 실험 이슈를 연다.
 - 이번 실행에서는 `bootRun` stdout 로그 캡처가 안정적으로 되지 않아 `[ArticlesPopular] dbQueryMs`는 기록하지 못했다. 대신 MySQL `EXPLAIN ANALYZE` actual time을 DB-side 근거로 남겼다.
 - 다음 후보는 인덱스 구현보다 로컬 성능 측정 시 애플리케이션 latency 로그와 리소스 지표 캡처를 안정화하는 작은 관측성 작업이 더 적절하다.
+
+---
+
+### #178 - 로컬 부하 테스트 latency 로그와 리소스 지표 캡처 안정화
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/178
+- 상태: In Progress
+- 작업 브랜치: `obs/#178-local-load-log-resource-capture`
+- 주요 파일:
+  - `docs/backend-improvement/local-load-observability-runbook.md`
+  - `docs/backend-improvement/load-test-baseline.md`
+  - `docs/backend-improvement/articles-popular-filesort-analysis.md`
+  - `docs/backend-improvement/articles-read-high-load-db-baseline.md`
+  - `docs/backend-improvement/BACKLOG.md`
+  - `docs/backend-improvement/NEXT_AGENT_BRIEF.md`
+  - `docs/backend-improvement/WORK_PROGRESS.md`
+
+목표:
+
+- #176에서 확인한 p95 상승과 DB-side `EXPLAIN ANALYZE` actual time 간 차이를 해석할 수 있도록 같은 실행 구간의 관측 절차를 고정한다.
+- k6 p95/RPS/failure, Spring application latency log, Docker MySQL/Redis resource 지표, 로컬 CPU/MEM 상태를 같은 run id로 묶어 기록한다.
+- 이후 Gemini/mock 외부 호출 부하 테스트에서 mock latency, Spring 처리 시간, DB/connection/local resource 병목을 구분할 수 있는 최소 관측 기준을 만든다.
+- 이력서에서는 `부하 테스트 로그/리소스 관측 기준 수립`으로 압축 가능하게 한다.
+
+Overengineering 판단:
+
+- 현재 단계에서 별도 APM, Prometheus/Grafana, tracing stack을 도입하면 프로젝트 규모와 포트폴리오 설명 난이도 대비 과하다.
+- #176의 병목 후보는 DB index 변경보다 관측 데이터 부족이 먼저였으므로, 운영 코드나 스크립트를 바꾸기 전에 문서화된 실행 절차를 고정하는 편이 적절하다.
+- 이번 범위는 운영 코드, API 응답, Repository query, DB schema/index, Redis/cache policy, k6 script 변경 없이 runbook과 판단 기준만 남긴다.
+
+작업 내용:
+
+- `local-load-observability-runbook.md`를 추가해 run id, 로그 저장 위치, Spring file logging 실행 방식, k6 결과 캡처 항목, `docker stats --no-stream` 기준, 로컬 리소스 기록 항목을 정리했다.
+- high p95가 나타났을 때 `dbQueryMs`, `totalMs`, Docker/local resource 신호 조합별 해석 규칙을 표로 정리했다.
+- #176 결과를 runbook 관점에서 재해석해 `popular` p95 상승이 곧바로 DB index 추가 근거가 아니라는 판단을 이어가도록 기록했다.
+- 다음 후보로 Gemini 외부 호출 mock latency 부하 테스트를 남기되, 실제 Gemini API 비용을 쓰지 않고 mock 조건별 latency와 failure/timeout을 분리 측정하는 방향을 명시했다.
+
+검증:
+
+```text
+git diff --check
+```
+
+Reviewer 판단:
+
+- 이번 PR은 문서/runbook-only 변경이며 운영 코드, DB schema/index, Repository query, Redis/cache policy, k6 script 변경이 없다.
+- 따라서 AI Reviewer 검토는 생략하고 사용자 직접 확인 후 merge할 수 있는 범위다.
 
 ## 4. 이후 개선 로드맵
 

--- a/docs/backend-improvement/articles-popular-filesort-analysis.md
+++ b/docs/backend-improvement/articles-popular-filesort-analysis.md
@@ -245,4 +245,7 @@ Candidate next issue:
 [OBS] 로컬 부하 테스트 시 애플리케이션 latency 로그와 리소스 지표 캡처 안정화
 ```
 
+This was started as #178.
+The runbook is `docs/backend-improvement/local-load-observability-runbook.md`.
+
 After that, rerun the same 20/50/100 VU test and decide whether the p95 growth is DB query time, application thread/connection pool pressure, or local machine saturation.

--- a/docs/backend-improvement/articles-read-high-load-db-baseline.md
+++ b/docs/backend-improvement/articles-read-high-load-db-baseline.md
@@ -229,7 +229,7 @@ Decision:
 
 - keep the current query/index for now
 - treat `Using filesort` as a watch item, not an immediate DB index change trigger
-- first make `[ArticlesPopular] dbQueryMs`, `totalMs`, and local resource capture reliable for the same run window
+- first make `[ArticlesPopular] dbQueryMs`, `totalMs`, and local resource capture reliable for the same run window; see `local-load-observability-runbook.md`
 - revisit index experiments only if `popular` p95 and captured DB query time rise together
 
 Detailed notes: `docs/backend-improvement/articles-popular-filesort-analysis.md`

--- a/docs/backend-improvement/load-test-baseline.md
+++ b/docs/backend-improvement/load-test-baseline.md
@@ -82,6 +82,9 @@ Redis cold cache와 warm cache의 성능 차이를 분리 측정할 때는 `load
 주요 기사 조회 API에 호출이 몰리는 고부하 조건을 분리 측정할 때는 `load-tests/k6/articles-read-high-load.js`를 사용한다.
 자세한 API별 p95/오류율, DB 로그 해석 기준, 후속 EXPLAIN 후보는 `docs/backend-improvement/articles-read-high-load-db-baseline.md`에 기록한다.
 
+로컬 부하 테스트에서 k6 결과, 애플리케이션 latency 로그, Docker 리소스 지표를 같은 실행 구간에 묶어 해석할 때는 `docs/backend-improvement/local-load-observability-runbook.md`를 따른다.
+특히 p95가 상승했지만 DB-side `EXPLAIN ANALYZE` 시간이 낮은 경우, 인덱스 변경 전에 `[ArticlesPopular] dbQueryMs`, `totalMs`, 로컬 CPU/MEM, Docker MySQL/Redis 지표를 함께 확인한다.
+
 VU와 실행 시간은 환경 변수로 조정한다.
 
 ```powershell

--- a/docs/backend-improvement/local-load-observability-runbook.md
+++ b/docs/backend-improvement/local-load-observability-runbook.md
@@ -1,0 +1,257 @@
+# Local load observability runbook
+
+## Purpose
+
+This runbook defines how to capture local load-test evidence in the same run window:
+
+- k6 p95, failure rate, request count, and RPS
+- Spring Boot application latency logs such as `dbQueryMs` and `totalMs`
+- local Docker resource signals for MySQL and Redis
+
+The goal is to avoid jumping from "p95 increased" directly to "DB index needed".
+For local tests, k6, Spring Boot, MySQL, Redis, IDE, and the OS share the same machine, so local CPU/memory or application thread pressure can look like API latency.
+
+## Portfolio Summary Candidate
+
+```text
+로컬 부하 테스트에서 k6 p95/RPS, 애플리케이션 dbQueryMs 로그, Docker 리소스 지표를 같은 실행 구간에 매칭해 DB 병목과 실행 환경 한계를 구분할 수 있는 관측 절차를 정리했습니다.
+```
+
+Shorter resume keyword version:
+
+```text
+부하 테스트 로그/리소스 관측 기준 수립
+```
+
+## Scope Decision
+
+This issue does not change:
+
+- production code
+- API response shape
+- Repository queries
+- DB schema or indexes
+- Redis/cache policy
+- k6 scripts
+- Gemini or external API behavior
+
+It only standardizes how local load-test evidence should be captured and interpreted.
+
+## Why This Comes Before Gemini Mock Load Testing
+
+Gemini mock latency testing is useful, but it needs reliable observation first.
+
+Without this runbook, a slow AI question-answering test can be misread:
+
+```text
+mock latency 1s -> API p95 2s
+```
+
+Possible causes include:
+
+- controlled mock latency
+- Spring request thread pressure
+- DB lookup or summary persistence delay
+- connection pool pressure
+- local CPU/memory saturation
+- k6 and the application competing on the same laptop
+
+Therefore the next AI mock test should reuse this runbook so that `AiSummary` logs, k6 output, and local resource signals are captured together.
+
+## Run ID
+
+Use a short run id for every local load test.
+
+Format:
+
+```text
+YYYYMMDD-HHmm-<target>-<vus>
+```
+
+Examples:
+
+```text
+20260710-1430-popular-20vu
+20260710-1440-popular-50vu
+20260710-1450-ai-mock-1s-20vu
+```
+
+Use the same run id for:
+
+- application log file name
+- k6 output note
+- resource snapshot note
+- final documentation row
+
+## Log Directory
+
+Runtime logs must stay local and must not be committed.
+
+Recommended local directory:
+
+```text
+.codex-tmp/load-runs/<RUN_ID>/
+```
+
+The repository already ignores `*.log`.
+Do not add API keys, `.env` values, prompt text, user questions, full article text, or external API response bodies to committed docs.
+
+## Application Log Capture
+
+Preferred command for a local run:
+
+```powershell
+$runId = "20260710-1430-popular-20vu"
+$runDir = ".codex-tmp/load-runs/$runId"
+New-Item -ItemType Directory -Force $runDir
+.\gradlew.bat bootRun --console=plain --args="--logging.file.name=$runDir/application.log"
+```
+
+If the terminal must stay available, use a separate PowerShell window for `bootRun`.
+For repeatable evidence, prefer a visible terminal over hidden background process execution because Windows batch output redirection can be fragile.
+
+Confirm the server is available:
+
+```powershell
+Test-NetConnection 127.0.0.1 -Port 8080
+```
+
+Expected log signals for article read APIs:
+
+```text
+[ArticlesPopular] page={} size={} from={} resultCount={} totalElements={} dbQueryMs={} totalMs={}
+[ArticlesLatest] page={} size={} resultCount={} totalElements={} dbQueryMs={} totalMs={}
+[ArticlesCursor] cursorProvided={} size={} resultCount={} hasNext={} dbQueryMs={} totalMs={}
+[Explore] country={} category={} date={} cursorProvided={} size={} resultCount={} hasNext={} dbQueryMs={} totalMs={}
+```
+
+Expected log signals for AI summary/question-answering paths:
+
+```text
+[AiSummary] articleId={} summaryHit={} crawledContentRequested={} crawlerFallback={} aiRequested={} summaryLookupMs={} crawlContentMs={} fallbackContentMs={} aiSummaryMs={} summarySaveMs={} totalMs={}
+[ArticleCrawlContent] articleId={} crawledContentHit={} crawlAttempted={} crawlSuccess={} crawlTargetLookupMs={} crawlMs={} saveMs={} totalMs={}
+```
+
+## k6 Capture
+
+Run k6 in a second terminal and record the start/end time manually in the run note.
+
+Example popular-focused run:
+
+```powershell
+$env:BASE_URL = "http://localhost:8080"
+$env:ARTICLES_SIZE = "20"
+$env:LATEST_VUS = "1"
+$env:CURSOR_VUS = "1"
+$env:POPULAR_VUS = "20"
+$env:EXPLORE_VUS = "1"
+$env:DETAIL_VUS = "1"
+$env:LATEST_DURATION = "1s"
+$env:CURSOR_DURATION = "1s"
+$env:POPULAR_DURATION = "60s"
+$env:EXPLORE_DURATION = "1s"
+$env:DETAIL_DURATION = "1s"
+$env:POPULAR_PAGES = "0,1,5"
+$env:SLEEP_SECONDS = "0.1"
+k6 run .\load-tests\k6\articles-read-high-load.js
+```
+
+Record at least:
+
+- target endpoint
+- VUs
+- duration
+- total requests
+- RPS
+- p95
+- failure rate
+
+## Resource Capture
+
+For Docker containers:
+
+```powershell
+docker stats --no-stream
+```
+
+Record:
+
+- MySQL CPU %
+- MySQL memory usage
+- Redis CPU %
+- Redis memory usage
+- whether either container looked saturated during the run
+
+For local machine signals, use Windows Task Manager or Resource Monitor and record short notes:
+
+- CPU was normal / high / saturated
+- memory was normal / high / saturated
+- disk looked normal / busy
+- system responsiveness was normal / laggy
+
+Do not over-interpret local resource numbers as production capacity.
+They are only local evidence to separate DB query cost from laptop saturation.
+
+## Result Template
+
+| Run ID | Target | VUs | Duration | Requests | RPS | p95 | Failure rate | App log signal | Resource signal | Interpretation |
+| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | --- | --- | --- |
+|  | popular |  |  |  |  |  |  | `[ArticlesPopular] dbQueryMs=?, totalMs=?` | MySQL CPU/MEM, local CPU/MEM |  |
+
+## Interpretation Rules
+
+| k6 p95 | App `dbQueryMs` | App `totalMs` | Resource signal | Likely next step |
+| --- | --- | --- | --- | --- |
+| high | high | high | normal | DB query/index investigation |
+| high | low | high | normal | application processing, serialization, thread pool, or external call investigation |
+| high | low or mixed | high | local CPU/memory high | local environment saturation; reduce VUs or move test to isolated environment |
+| high | high | high | MySQL CPU/memory high | DB load investigation, connection pool review, or query/index candidate |
+| normal | low | low | normal | no immediate performance change |
+
+## #176 Popular Result Reinterpretation
+
+#176 found:
+
+| Popular VUs | RPS | Popular p95 | Failure rate |
+| ---: | ---: | ---: | ---: |
+| 20 | 106.29/s | 134.87ms | 0.00% |
+| 50 | 114.33/s | 423.79ms | 0.00% |
+| 100 | 123.61/s | 902.51ms | 0.00% |
+
+MySQL `EXPLAIN ANALYZE` remained low:
+
+- page 0 content query: about `6.44ms`
+- page 5 content query: about `11.5ms`
+- count query: about `0.696ms`
+
+Interpretation:
+
+- p95 rose under VU pressure.
+- RPS plateaued rather than scaling with VUs.
+- DB-side single-query actual time stayed low.
+- The next run must capture `[ArticlesPopular] dbQueryMs`, `totalMs`, and resource signals before opening an index implementation issue.
+
+## Gemini Mock Follow-up
+
+After this runbook is available, the next external-call performance issue can use a mock AI server.
+
+Candidate:
+
+```text
+[PERF] AI 질의응답 Gemini 외부 호출 mock latency 부하 테스트
+```
+
+Recommended controlled conditions:
+
+- mock latency 200ms
+- mock latency 1s
+- mock latency 3s
+- timeout or 5xx fallback
+
+Required evidence:
+
+- k6 p95/failure rate
+- `AiSummary` or question-answering service `totalMs`
+- external/mock call latency field if available
+- local resource signal
+- decision on whether synchronous external call, timeout policy, fallback, cache, or async processing should be considered next


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #178

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)


## 📝 작업 내용
- 로컬 부하 테스트에서 k6 결과, Spring Boot latency 로그, Docker/local resource 지표를 같은 실행 구간으로 묶는 runbook을 추가했습니다.
- #176의 `popular` filesort 분석 결과를 관측성 기준과 연결하고, 바로 DB index를 추가하지 않는 판단 기준을 문서화했습니다.
- 후속 후보로 Gemini 외부 호출 mock latency 부하 테스트를 남기되, 실제 API 비용 없이 mock latency/failure/timeout을 분리 측정하는 방향을 BACKLOG와 handoff 문서에 반영했습니다.

## 🔍 기술적 배경
- #176에서 `popular` p95는 VU 증가에 따라 상승했지만, MySQL `EXPLAIN ANALYZE` actual time은 낮고 RPS는 plateau되어 DB index 변경 전에 애플리케이션 로그와 로컬 리소스 지표를 같은 구간에서 확인해야 했습니다.
- 현재 단계에서 APM/Prometheus/Grafana 같은 별도 관측 스택 도입은 과하므로, 로컬 실행 기준의 run id, 로그 파일, k6 지표, `docker stats --no-stream`, 로컬 CPU/MEM 기록 절차를 먼저 고정했습니다.
- 이번 PR은 문서/runbook-only 변경이며 운영 코드, API 응답, Repository query, DB schema/index, Redis/cache policy, k6 script를 변경하지 않습니다.


## 🧪 테스트/검증 (필수)
- [x] `git diff --check`로 문서 diff 공백/마크다운 패치 오류가 없음을 확인했습니다.
- [x] `WORK_PROGRESS.md`, `BACKLOG.md`, `NEXT_AGENT_BRIEF.md`의 #176 merged 상태와 #178 In Progress 상태가 서로 충돌하지 않는지 확인했습니다.


## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?


## 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
- 문서/runbook-only 변경이므로 AI Reviewer 검토는 생략 가능하다고 판단했습니다. 사용자 직접 확인 후 merge할 수 있는 범위입니다.


## ➕ 추후 계획(선택)
- `[PERF] AI 질의응답 Gemini 외부 호출 mock latency 부하 테스트`에서 이 runbook을 사용해 mock latency, 애플리케이션 처리 시간, DB/local resource 신호를 분리 측정합니다.
