### PR TITLE
📊 [PERF/#180] 단일 인스턴스 TPS 기준선 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ out/
 application*.yml
 
 frontend/
+
+### local load-test artifacts ###
+.codex-tmp/

--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -35,8 +35,8 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## P1. 주요 조회 API 관측성 및 성능 기준선 확보
 
-- 상태: `In Progress` ([#178](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/178))
-- 완료 근거: [#121](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/121), [#174](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/174), [#176](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/176)
+- 상태: `In Progress` ([#180](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/180))
+- 완료 근거: [#121](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/121), [#174](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/174), [#176](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/176), [#178](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/178)
 - AS-IS: 캐시 미스 시 기사 조회, 키워드 추출, 번역 API 호출, FULLTEXT 검색이 요청 경로에서 수행되지만 단계별 지연 시간과 캐시 효과를 수치로 설명할 수 없다.
 - TO-BE: 캐시 히트율, 단계별 처리 시간, 외부 번역 API 호출량, p95 응답 시간을 측정하고 부하 테스트 기준선을 만든다.
 - 성공 기준:
@@ -46,6 +46,7 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
   - #174에서 외부 호출 없는 주요 기사 조회 API의 고부하 p95/오류율과 DB 병목 후보를 분리 측정했다.
   - #176에서 `popular` 조회의 `Using filesort`를 k6와 `EXPLAIN ANALYZE`로 확인하고, 현재 규모에서는 인덱스 추가를 보류하는 판단 기준을 남긴다.
   - #178에서 로컬 부하 테스트 시 k6 결과, 애플리케이션 latency 로그, Docker 리소스 지표를 같은 실행 구간에 맞춰 해석하는 runbook을 정리한다.
+  - #180에서 로컬 Docker 단일 인스턴스 기준 `popular` 조회의 안정 처리량과 포화 신호 구간을 RPS/p95/failure로 정리한다.
 
 ## P2. 기사 원문 크롤링 안정성 개선
 

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -67,7 +67,8 @@ Reviewer 이후 diff 변경을 피하기 위해 merge 후 `WORK_PROGRESS.md`만 
 - #172/#173에서 기사 요약 API 외부 호출 단계별 latency 로그 추가를 완료했다.
 - #174/#175에서 주요 기사 조회 API 고부하 부하 테스트 및 DB 병목 기준선 수립을 완료했다.
 - #176/#177에서 `articles popular` 조회의 `Using filesort`를 k6 고부하 지표와 MySQL `EXPLAIN ANALYZE`로 확인하고, 현재 데이터 규모에서는 인덱스 추가를 보류했다.
-- #178에서 로컬 부하 테스트 시 k6 결과, 애플리케이션 latency 로그, Docker 리소스 지표를 같은 실행 구간에 묶어 해석하는 runbook을 진행 중이다.
+- #178/#179에서 로컬 부하 테스트 시 k6 결과, 애플리케이션 latency 로그, Docker 리소스 지표를 같은 실행 구간에 묶어 해석하는 runbook을 완료했다.
+- #180에서 주요 조회 API 단일 인스턴스 TPS 한계와 병목 지점을 정리 중이다.
 
 ## Recent Completed Work
 
@@ -86,6 +87,7 @@ Reviewer 이후 diff 변경을 피하기 위해 merge 후 `WORK_PROGRESS.md`만 
 - #172/#173: 기사 요약 API의 summary hit, crawledContent hit, cold crawl, crawler fallback, AI summary 단계별 latency 로그를 추가했다.
 - #174/#175: 주요 기사 조회 API의 고부하 p95/오류율과 DB 병목 후보를 분리 측정하는 k6 기준선을 수립했다.
 - #176/#177: `popular` 조회의 20/50/100 VU p95와 MySQL `EXPLAIN ANALYZE`를 비교해 인덱스 추가를 보류하고 관측성 보강 필요성을 남겼다.
+- #178/#179: 로컬 부하 테스트의 k6 결과, 애플리케이션 latency 로그, Docker/local resource 지표를 같은 실행 구간에 묶는 runbook을 정리했다.
 
 ## Why #160 Matters
 
@@ -100,25 +102,24 @@ pure relevance-first는 wrong-context 기사를 끌어올릴 수 있어 바로 �
 현재 진행 중:
 
 ```text
-#178 [OBS] 로컬 부하 테스트 latency 로그와 리소스 지표 캡처 안정화
+#180 [PERF] 주요 조회 API 단일 인스턴스 TPS 한계와 병목 지점 정리
 ```
 
 목표:
 
-- k6 p95/RPS, 애플리케이션 `dbQueryMs`/`totalMs` 로그, Docker 리소스 지표를 같은 run id/time window로 묶는 로컬 runbook을 만든다.
-- #176에서 보인 p95 상승이 DB 병목인지, 애플리케이션 처리 한계인지, 로컬 자원 한계인지 구분할 판단 기준을 정리한다.
-- Gemini mock latency 부하 테스트를 후속 후보로 명시한다.
+- 로컬 Docker 기반 단일 Spring Boot 인스턴스에서 `popular` 조회의 안정 처리량과 포화 신호 구간을 정리한다.
+- #178 runbook 기준으로 k6 RPS/p95/failure, 애플리케이션 `dbQueryMs`/`totalMs`, Docker/local resource 신호를 같은 실행 구간으로 해석한다.
+- 8GB 로컬 환경을 고려해 무리한 장시간/고 VU 테스트보다 `5 -> 10 -> 20 -> 50 VU` 점진 부하 결과를 우선 기록한다.
 - 운영 코드, DB schema/index, API 응답, Repository query, Redis/cache 정책, k6 script는 변경하지 않는다.
-- 이력서에 `부하 테스트 로그/리소스 관측 기준 수립`으로 압축 가능한 근거를 만든다.
+- 이력서에 `단일 인스턴스 조회 API TPS 한계/포화 구간 측정`으로 압축 가능한 근거를 만든다.
 
 다음 세션에서 새 후보를 고를 때는 먼저 develop 최신화, 열린 Issue/PR 확인, `WORK_PROGRESS.md`와 `BACKLOG.md` 확인을 다시 수행한다.
 #110은 사용자가 별도로 지시하기 전까지 다루지 않는다.
 #162 guardrail에 따라 "지금 구현하면 과한가?"를 먼저 판단한다.
-#178은 운영 코드 변경 없이 측정 runbook과 후속 판단 기준만 남기는 범위다.
-Reviewer는 생략 가능하며, PR 생성 후 사용자가 diff와 결과를 확인한 뒤 merge한다.
-#176 점진 부하에서 `popular` p95는 VU 증가에 따라 상승했지만 RPS가 비례해 늘지 않았고, DB-side `EXPLAIN ANALYZE` actual time은 낮았다.
-다음 단계에서 DB index/query 변경을 바로 적용하지 말고, 먼저 `docs/backend-improvement/local-load-observability-runbook.md` 기준으로 애플리케이션 로그/로컬 리소스 지표를 캡처할 수 있게 한다.
-그 다음 후속 후보로 `[PERF] AI 질의응답 Gemini 외부 호출 mock latency 부하 테스트`를 검토한다.
+#180은 운영 코드 변경 없이 측정 결과와 판단 기준을 남기는 범위다.
+현재 측정에서는 `popular` 20 VU에서 약 87 RPS, p95 약 105ms, failure 0.00%였고, 50 VU에서는 약 86 RPS로 처리량이 늘지 않은 채 p95가 약 456ms로 상승했다.
+따라서 20 VU 구간을 이 로컬 환경의 안정 baseline으로 보고, 50 VU 구간은 단일 인스턴스 포화 신호로 해석한다.
+다음 후속 후보로 `[PERF] AI 질의응답 Gemini 외부 호출 mock latency 부하 테스트`를 검토한다.
 
 #164 ADR 기준상 hybrid ranking code experiment는 아래 조건이 준비된 뒤 별도 Issue로 검토한다.
 
@@ -143,6 +144,7 @@ Reviewer는 생략 가능하며, PR 생성 후 사용자가 diff와 결과를 �
 - `docs/backend-improvement/articles-read-high-load-db-baseline.md`
 - `docs/backend-improvement/articles-popular-filesort-analysis.md`
 - `docs/backend-improvement/local-load-observability-runbook.md`
+- `docs/backend-improvement/single-instance-tps-baseline.md`
 - `docs/backend-improvement/load-test-baseline.md`
 - `docs/backend-improvement/perspectives-fulltext-generic-token-filter-result.md`
 - `docs/backend-improvement/perspectives-fulltext-ordering-comparison.md`

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -105,7 +105,8 @@ Blocking 예시:
 - #172/#173에서 기사 요약 API 외부 호출 단계별 latency 로그를 추가했다.
 - #174/#175에서 주요 기사 조회 API 고부하 부하 테스트 및 DB 병목 기준선을 수립했다.
 - #176/#177에서 `popular` 기사 조회의 `Using filesort`가 현재 데이터 규모에서 인덱스 추가가 필요한 병목인지 k6와 `EXPLAIN ANALYZE`로 판단했다.
-- #178에서 로컬 부하 테스트 시 애플리케이션 latency 로그와 Docker/local resource 지표를 같은 실행 구간에 캡처하는 관측 runbook을 정리 중이다.
+- #178/#179에서 로컬 부하 테스트 시 애플리케이션 latency 로그와 Docker/local resource 지표를 같은 실행 구간에 캡처하는 관측 runbook을 정리했다.
+- #180에서 주요 조회 API 단일 인스턴스 TPS 한계와 포화 신호 구간을 정리 중이다.
 - 현재 반복 성능/안정성 기본기 흐름의 주요 후보(#123, #127, #129, #131, #133, #137, #140, #142, #146)와 AI workflow 보강(#144)은 merge 완료 상태다.
 
 ### #113 / PR #114 - 백엔드 개선 Backlog 및 AI 작업 운영 규칙 수립
@@ -1489,7 +1490,8 @@ git diff --check
 ### #178 - 로컬 부하 테스트 latency 로그와 리소스 지표 캡처 안정화
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/178
-- 상태: In Progress
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/179
+- 상태: merged
 - 작업 브랜치: `obs/#178-local-load-log-resource-capture`
 - 주요 파일:
   - `docs/backend-improvement/local-load-observability-runbook.md`
@@ -1532,6 +1534,77 @@ Reviewer 결과:
 - `## AI Reviewer 검토 결과` 제목의 Reviewer comment 기준 `MERGE_READY`, Blocking 없음.
 - Non-blocking: `BACKLOG.md` P1 상태 줄에서 진행 중 이슈와 완료 근거를 분리하면 더 읽기 쉽다는 제안이 있었고, merge 전 반영했다.
 - Non-blocking: PR 본문과 작업 기록의 "AI Reviewer 생략 가능" 표현은 이번처럼 실제 리뷰를 받은 경우 혼선을 줄 수 있어, 작업 기록은 실제 Reviewer 결과로 정리했다.
+
+---
+
+### #180 - 주요 조회 API 단일 인스턴스 TPS 한계와 병목 지점 정리
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/180
+- 상태: In Progress
+- 작업 브랜치: `perf/#180-single-instance-tps-baseline`
+- 주요 파일:
+  - `.gitignore`
+  - `docs/backend-improvement/single-instance-tps-baseline.md`
+  - `docs/backend-improvement/articles-read-high-load-db-baseline.md`
+  - `docs/backend-improvement/load-test-baseline.md`
+  - `docs/backend-improvement/BACKLOG.md`
+  - `docs/backend-improvement/NEXT_AGENT_BRIEF.md`
+  - `docs/backend-improvement/WORK_PROGRESS.md`
+
+목표:
+
+- 로컬 Docker MySQL/Redis와 단일 `bootRun` Spring Boot 인스턴스 기준으로 `popular` 조회가 어느 정도 RPS까지 안정적인지 측정한다.
+- p95, failure rate, RPS, 애플리케이션 `dbQueryMs`/`totalMs`, Docker/local resource 신호를 같은 실행 구간으로 해석한다.
+- 멀티 Pod/Kubernetes/클라우드 부하 테스트 없이도 단일 인스턴스 처리량과 포화 구간을 이력서에 설명 가능한 수준으로 남긴다.
+
+Overengineering 판단:
+
+- 지금 Kubernetes, multi Pod, cloud load test, Prometheus/Grafana/APM까지 도입하면 8GB 로컬 환경과 현재 프로젝트 단계에 과하다.
+- 이번 이슈는 운영 코드, API 응답, Repository query, DB schema/index, Redis/cache policy, 비동기 처리를 변경하지 않고 측정/판단만 남긴다.
+- 100 VU 이상을 무리하게 반복하기보다, 50 VU에서 이미 RPS plateau와 p95 상승이 보여 안전하게 중단했다.
+
+실행 조건:
+
+```text
+Run ID: 20260710-1530-single-instance-popular
+Server: local bootRun, localhost:8080
+DB/cache: Docker MySQL/Redis
+k6 script: load-tests/k6/articles-read-high-load.js
+Target: popular scenario
+Noise scenarios: latest/cursor/explore/detail each 1 VU / 1s
+Popular pages: 0,1,5
+Sleep: 0.1s
+```
+
+측정 결과:
+
+| Popular VUs | Duration | Requests | RPS | Popular avg | Popular p95 | Failure rate |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| 5 | 30s | 970 | 24.19/s | 57.61ms | 105.05ms | 0.00% |
+| 10 | 30s | 1,841 | 45.91/s | 65.16ms | 94.62ms | 0.00% |
+| 20 | 30s | 3,505 | 87.29/s | 71.84ms | 105.48ms | 0.00% |
+| 50 | 30s | 3,474 | 86.15/s | 334.86ms | 456.72ms | 0.00% |
+
+판단:
+
+- 20 VU까지는 RPS가 증가하면서 `popular` p95가 약 105ms 수준으로 유지되어 이 로컬 환경의 안정 baseline으로 볼 수 있다.
+- 50 VU에서는 RPS가 20 VU 대비 증가하지 않았고 p95가 456.72ms로 상승해 단일 인스턴스 포화 신호로 해석한다.
+- failure rate는 모든 단계에서 0.00%였으므로 availability failure가 아니라 latency saturation으로 기록한다.
+- 50 VU 말미의 `[ArticlesPopular]` 샘플 로그는 `dbQueryMs` 약 19~51ms, `totalMs` 약 31~74ms 수준이라, k6 p95 상승을 DB index 문제로 바로 해석하기 어렵다.
+- 다음 개선은 DB index보다 peak app/thread/CPU 관측 보강 또는 Gemini mock 외부 호출 병목 기준선 쪽이 더 적절하다.
+
+검증:
+
+```text
+docker ps
+k6 version
+Test-NetConnection 127.0.0.1 -Port 8080
+k6 run articles-read-high-load.js (popular 5 VUs, 30s)
+k6 run articles-read-high-load.js (popular 10 VUs, 30s)
+k6 run articles-read-high-load.js (popular 20 VUs, 30s)
+k6 run articles-read-high-load.js (popular 50 VUs, 30s)
+docker stats --no-stream
+```
 
 ## 4. 이후 개선 로드맵
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -1585,6 +1585,11 @@ Sleep: 0.1s
 | 20 | 30s | 3,505 | 87.29/s | 71.84ms | 105.48ms | 0.00% |
 | 50 | 30s | 3,474 | 86.15/s | 334.86ms | 456.72ms | 0.00% |
 
+비고:
+
+- `Duration`은 `popular` scenario의 active duration이고, `Requests/RPS`는 scenario start offset과 짧은 noise scenario를 포함한 k6 전체 run window 기준 summary 값이다.
+- 모든 단계가 같은 script shape로 실행되었으므로 같은 기준의 상대 비교와 포화 판단에는 사용할 수 있지만, 순수 30초 `popular` 단독 TPS로 해석하지 않는다.
+
 판단:
 
 - 20 VU까지는 RPS가 증가하면서 `popular` p95가 약 105ms 수준으로 유지되어 이 로컬 환경의 안정 baseline으로 볼 수 있다.

--- a/docs/backend-improvement/articles-read-high-load-db-baseline.md
+++ b/docs/backend-improvement/articles-read-high-load-db-baseline.md
@@ -245,6 +245,7 @@ Result summary:
 - RPS: `24.19/s -> 45.91/s -> 87.29/s -> 86.15/s`
 - `popular` p95: `105.05ms -> 94.62ms -> 105.48ms -> 456.72ms`
 - failure rate: `0.00%` for all measured steps
+- RPS is from the k6 whole-run summary, including scenario start offsets and short noise scenarios, so use it for same-script relative saturation judgment rather than pure 30-second popular-only TPS.
 
 Decision:
 

--- a/docs/backend-improvement/articles-read-high-load-db-baseline.md
+++ b/docs/backend-improvement/articles-read-high-load-db-baseline.md
@@ -233,3 +233,23 @@ Decision:
 - revisit index experiments only if `popular` p95 and captured DB query time rise together
 
 Detailed notes: `docs/backend-improvement/articles-popular-filesort-analysis.md`
+
+## Follow-up: Single Instance TPS Baseline
+
+#180 reused the `popular`-focused high-load scenario to summarize a local single-instance capacity shape.
+
+Result summary:
+
+- local Docker MySQL/Redis plus one local `bootRun` Spring Boot instance
+- `popular` VUs: `5 -> 10 -> 20 -> 50`
+- RPS: `24.19/s -> 45.91/s -> 87.29/s -> 86.15/s`
+- `popular` p95: `105.05ms -> 94.62ms -> 105.48ms -> 456.72ms`
+- failure rate: `0.00%` for all measured steps
+
+Decision:
+
+- treat the 20 VU run as the stable local single-instance baseline for this machine
+- treat the 50 VU run as a saturation signal because throughput did not increase while p95 rose sharply
+- do not open a DB index issue from this result alone; sampled application `dbQueryMs` remained much lower than k6 p95
+
+Detailed notes: `docs/backend-improvement/single-instance-tps-baseline.md`

--- a/docs/backend-improvement/load-test-baseline.md
+++ b/docs/backend-improvement/load-test-baseline.md
@@ -85,6 +85,9 @@ Redis cold cache와 warm cache의 성능 차이를 분리 측정할 때는 `load
 로컬 부하 테스트에서 k6 결과, 애플리케이션 latency 로그, Docker 리소스 지표를 같은 실행 구간에 묶어 해석할 때는 `docs/backend-improvement/local-load-observability-runbook.md`를 따른다.
 특히 p95가 상승했지만 DB-side `EXPLAIN ANALYZE` 시간이 낮은 경우, 인덱스 변경 전에 `[ArticlesPopular] dbQueryMs`, `totalMs`, 로컬 CPU/MEM, Docker MySQL/Redis 지표를 함께 확인한다.
 
+로컬 Docker 기반 단일 인스턴스가 어느 정도 처리량까지 안정적인지 설명할 때는 `docs/backend-improvement/single-instance-tps-baseline.md`를 기준으로 한다.
+2026-07-10 `popular` 중심 점진 부하에서는 20 VU 구간 약 87 RPS까지 p95 약 105ms, failure 0.00%로 안정적이었고, 50 VU에서는 RPS가 늘지 않은 채 p95가 약 456ms로 상승하는 포화 신호를 확인했다.
+
 VU와 실행 시간은 환경 변수로 조정한다.
 
 ```powershell

--- a/docs/backend-improvement/single-instance-tps-baseline.md
+++ b/docs/backend-improvement/single-instance-tps-baseline.md
@@ -1,0 +1,171 @@
+# Single instance TPS baseline
+
+## Purpose
+
+This document records a local single-instance capacity baseline for DB-backed article read APIs.
+
+The goal is not to prove cloud-scale throughput.
+The goal is to establish a portfolio-friendly baseline:
+
+- one Spring Boot application instance
+- local Docker MySQL and Redis
+- local k6 load generator
+- p95, failure rate, RPS/TPS, application latency logs, and resource signals in the same run window
+
+This issue does not change production code, API responses, repository queries, DB schema/indexes, Redis/cache policy, async processing, or Kubernetes settings.
+
+## Portfolio Summary Candidate
+
+```text
+로컬 Docker 기반 단일 인스턴스 환경에서 주요 기사 조회 API의 점진 부하 테스트를 수행해 20 VU 구간 약 87 RPS까지 안정적으로 처리되고, 50 VU에서는 RPS가 증가하지 않은 채 p95가 456ms로 상승하는 포화 신호를 확인했습니다.
+```
+
+Shorter resume keyword version:
+
+```text
+단일 인스턴스 조회 API TPS 한계/포화 구간 측정
+```
+
+## Environment
+
+| Item | Value |
+| --- | --- |
+| Date | 2026-07-10 |
+| Run ID | `20260710-1530-single-instance-popular` |
+| Application | local `bootRun`, one Spring Boot instance on `localhost:8080` |
+| DB/cache | Docker MySQL and Redis |
+| Load generator | local k6 |
+| Dataset note | article rows around `9,853`; recent 30-day `popular` filter returned `2,066` rows during this run |
+| Log file | `.codex-tmp/load-runs/20260710-1530-single-instance-popular/application.log` |
+
+Runtime artifacts under `.codex-tmp/` are local-only and must not be committed.
+
+## Scope Decision
+
+This issue intentionally measures before implementing.
+
+Not included:
+
+- DB index changes
+- query changes
+- Redis/local cache changes
+- connection pool tuning
+- async processing
+- multi-process or Kubernetes Pod scaling
+- cloud load testing
+
+Reasoning:
+
+- On an 8GB local machine, very high VU counts can saturate the laptop before the application or DB bottleneck is clear.
+- #176 already showed that `Using filesort` alone did not justify an immediate DB index.
+- #178 added a runbook for correlating k6, application logs, and local resource signals.
+- Therefore #180 focuses on single-instance capacity shape: stable range, saturation signal, and next investigation criteria.
+
+## Scenario
+
+The existing `load-tests/k6/articles-read-high-load.js` script was reused.
+`popular` received the main load, while other article-read scenarios were kept at `1 VU / 1s` to keep basic script coverage with minimal noise.
+
+Shared settings:
+
+```powershell
+$env:BASE_URL = "http://localhost:8080"
+$env:ARTICLES_SIZE = "20"
+$env:LATEST_VUS = "1"
+$env:CURSOR_VUS = "1"
+$env:EXPLORE_VUS = "1"
+$env:DETAIL_VUS = "1"
+$env:LATEST_DURATION = "1s"
+$env:CURSOR_DURATION = "1s"
+$env:EXPLORE_DURATION = "1s"
+$env:DETAIL_DURATION = "1s"
+$env:POPULAR_PAGES = "0,1,5"
+$env:SLEEP_SECONDS = "0.1"
+```
+
+Popular VU steps:
+
+```text
+5 VUs / 30s
+10 VUs / 30s
+20 VUs / 30s
+50 VUs / 30s
+```
+
+The planned 100 VU step was skipped for this run because 50 VU already showed a clear local saturation signal: RPS did not increase from the 20 VU run while p95 rose sharply.
+
+## Results
+
+| Popular VUs | Duration | Requests | RPS | Popular avg | Popular p95 | Failure rate |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| 5 | 30s | 970 | 24.19/s | 57.61ms | 105.05ms | 0.00% |
+| 10 | 30s | 1,841 | 45.91/s | 65.16ms | 94.62ms | 0.00% |
+| 20 | 30s | 3,505 | 87.29/s | 71.84ms | 105.48ms | 0.00% |
+| 50 | 30s | 3,474 | 86.15/s | 334.86ms | 456.72ms | 0.00% |
+
+Interpretation:
+
+- 5 -> 10 -> 20 VUs increased throughput from `24.19/s` to `87.29/s` while p95 stayed around `95ms ~ 105ms`.
+- 20 -> 50 VUs did not increase throughput (`87.29/s` -> `86.15/s`) but raised popular p95 from `105.48ms` to `456.72ms`.
+- This is a local single-instance saturation signal: extra concurrency queued or waited somewhere instead of increasing completed requests.
+- Since failure rate stayed `0.00%`, this was latency saturation rather than availability failure.
+
+## Resource Signals
+
+Resource samples were taken with `docker stats --no-stream` before/after runs.
+These are point-in-time samples, not peak metrics.
+
+| Moment | MySQL CPU | MySQL memory | Redis CPU | Redis memory | App process memory |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Before run | 4.39% | 392.2MiB | 0.59% | 8.18MiB | 291MiB |
+| After 5 VU | 0.69% | 407.3MiB | 0.65% | 8.05MiB | 332MiB |
+| After 20 VU | 0.76% | 413.0MiB | 0.62% | 8.05MiB | 335MiB |
+| After 50 VU | 0.66% | 414.3MiB | 0.53% | 8.05MiB | 338MiB |
+
+Observed implication:
+
+- MySQL and Redis memory stayed stable.
+- `docker stats --no-stream` did not capture a sustained DB/container saturation after the runs.
+- The 50 VU plateau should not be interpreted as a DB index issue without peak app/thread/CPU metrics or repeated application `dbQueryMs` aggregation.
+
+## Application Log Signal
+
+`[ArticlesPopular]` logs were captured in the same run window.
+
+Sample signal near the 50 VU run end:
+
+```text
+[ArticlesPopular] ... dbQueryMs=37 totalMs=70
+[ArticlesPopular] ... dbQueryMs=34 totalMs=48
+[ArticlesPopular] ... dbQueryMs=49 totalMs=71
+[ArticlesPopular] ... dbQueryMs=51 totalMs=70
+[ArticlesPopular] ... dbQueryMs=19 totalMs=34
+```
+
+Interpretation:
+
+- Sampled service-side `totalMs` values were far lower than k6 p95 `456.72ms` in the 50 VU run.
+- This suggests part of the latency may be outside the repository call itself, such as servlet thread scheduling, request queueing, local machine contention, k6/application sharing the same host, or response transfer timing.
+- A DB index change is not justified from this run alone.
+
+## Capacity Statement
+
+For this local 8GB development environment:
+
+```text
+The `popular` read path was stable up to the 20 VU step at about 87 RPS with p95 around 105ms and 0.00% failure rate.
+At 50 VUs, throughput stayed around 86 RPS while p95 rose to 456ms, so the practical single-instance saturation signal appeared between 20 and 50 VUs.
+```
+
+This is not a production SLA.
+It is a local single-instance baseline that can support follow-up reasoning:
+
+- if app-side `dbQueryMs` also rises, open a query/index issue
+- if `dbQueryMs` stays low but k6 p95 rises, inspect application threads, local CPU contention, response serialization, connection pool, or k6 host contention
+- if stable single-instance RPS is needed for scale-out estimation, use the 20 VU result as a conservative local baseline before assuming multi-Pod scaling
+
+## Follow-up Candidates
+
+- `[OBS] 로컬 부하 테스트 중 애플리케이션 thread/CPU peak 지표 캡처 보강`
+- `[PERF] latest/cursor 단일 인스턴스 TPS 비교`
+- `[PERF] Gemini mock latency 기반 외부 호출 병목 기준선 수립`

--- a/docs/backend-improvement/single-instance-tps-baseline.md
+++ b/docs/backend-improvement/single-instance-tps-baseline.md
@@ -103,6 +103,10 @@ The planned 100 VU step was skipped for this run because 50 VU already showed a 
 | 20 | 30s | 3,505 | 87.29/s | 71.84ms | 105.48ms | 0.00% |
 | 50 | 30s | 3,474 | 86.15/s | 334.86ms | 456.72ms | 0.00% |
 
+`Duration` is the active `popular` scenario duration.
+`Requests` and `RPS` are from the k6 summary and use the whole local run window, including scenario start offsets and short noise scenarios.
+Because every measured step used the same script shape, the RPS values are comparable for saturation judgment, but they are not a pure 30-second popular-only TPS calculation.
+
 Interpretation:
 
 - 5 -> 10 -> 20 VUs increased throughput from `24.19/s` to `87.29/s` while p95 stayed around `95ms ~ 105ms`.


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #180

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)


## 📝 작업 내용
- 로컬 Docker 기반 단일 Spring Boot 인스턴스에서 `popular` 조회 API의 점진 부하 결과를 정리했습니다.
- `5 -> 10 -> 20 -> 50 VU` 조건에서 RPS, p95, failure rate, 애플리케이션 로그, Docker/local resource 신호를 함께 기록했습니다.
- #178/#179 runbook 완료 상태와 #180 진행 상태를 `WORK_PROGRESS.md`, `BACKLOG.md`, `NEXT_AGENT_BRIEF.md`에 반영했습니다.
- 로컬 실행 산출물 `.codex-tmp/`가 커밋되지 않도록 `.gitignore`에 추가했습니다.

## 🔍 기술적 배경
- #174/#176에서는 주요 조회 API 고부하와 `popular` filesort 판단을 진행했지만, 포트폴리오 관점의 “단일 인스턴스 안정 처리량/포화 구간” 요약은 별도로 정리되어 있지 않았습니다.
- 이번 측정에서는 20 VU 구간에서 약 87 RPS, p95 약 105ms, failure 0.00%로 안정적이었고, 50 VU에서는 RPS가 약 86 RPS로 증가하지 않은 채 p95가 약 456ms로 상승했습니다.
- 50 VU 말미의 `[ArticlesPopular]` 샘플 로그는 `dbQueryMs` 약 19~51ms, `totalMs` 약 31~74ms 수준이라, k6 p95 상승을 DB index 문제로 바로 해석하지 않고 단일 인스턴스 포화 신호로 기록했습니다.


## 🧪 테스트/검증 (필수)
- [x] `docker ps`로 MySQL/Redis 컨테이너 상태를 확인했습니다.
- [x] `k6 version`으로 로컬 k6 실행 가능 상태를 확인했습니다.
- [x] `Test-NetConnection 127.0.0.1 -Port 8080`으로 서버 기동/종료 상태를 확인했습니다.
- [x] `k6 run load-tests/k6/articles-read-high-load.js`를 `popular` 5/10/20/50 VU 조건으로 실행했습니다.
- [x] `docker stats --no-stream`으로 Docker resource 신호를 확인했습니다.
- [x] `git diff --cached --check` 통과를 확인했습니다.


## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?


## 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
- 운영 코드, API 응답, Repository query, DB schema/index, Redis/cache policy, k6 script 변경은 없습니다.
- 문서와 `.gitignore`만 변경했으므로 사용자 직접 확인 후 merge 가능한 범위로 판단했습니다.


## ➕ 추후 계획(선택)
- `[PERF] Gemini mock latency 기반 외부 호출 병목 기준선 수립`으로 외부 동기 호출 latency가 API p95에 전파되는 조건을 분리 측정합니다.
