### PR TITLE
📊 [PERF/#182] Gemini mock latency 기준선 수립

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -35,8 +35,8 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## P1. 주요 조회 API 관측성 및 성능 기준선 확보
 
-- 상태: `In Progress` ([#180](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/180))
-- 완료 근거: [#121](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/121), [#174](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/174), [#176](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/176), [#178](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/178)
+- 상태: `Done` ([#180](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/180), [PR #181](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/181))
+- 완료 근거: [#121](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/121), [#174](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/174), [#176](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/176), [#178](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/178), [#180](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/180)
 - AS-IS: 캐시 미스 시 기사 조회, 키워드 추출, 번역 API 호출, FULLTEXT 검색이 요청 경로에서 수행되지만 단계별 지연 시간과 캐시 효과를 수치로 설명할 수 없다.
 - TO-BE: 캐시 히트율, 단계별 처리 시간, 외부 번역 API 호출량, p95 응답 시간을 측정하고 부하 테스트 기준선을 만든다.
 - 성공 기준:
@@ -61,7 +61,7 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ### P2 후속 후보. Gemini mock latency 부하 테스트
 
-- 상태: `Backlog`
+- 상태: `Verified` ([#182](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/182), [PR #183](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/183))
 - AS-IS: 기사 상세의 AI 요약/질의응답 경로에는 Gemini 외부 호출이 포함될 수 있지만, 실제 Gemini API로 부하 테스트를 반복하면 비용, quota, rate limit, 응답 편차 문제가 생긴다.
 - TO-BE: mock AI 서버로 latency `200ms`, `1s`, `3s`, `timeout/5xx` 조건을 통제하고, 사용자 요청 경로의 p95/오류율/fallback 동작을 측정한다.
 - 진행 조건:
@@ -69,6 +69,9 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
   - mock 서버는 테스트/로컬 설정에만 사용하고 운영 API key, prompt 전문, 사용자 질문 전문은 문서/로그에 남기지 않는다.
 - 예상 이슈:
   - `[PERF] AI 질의응답 Gemini 외부 호출 mock latency 부하 테스트`
+- 측정 결과:
+  - 정상 응답은 mock 200ms/1s/3s 조건에서 p95가 각각 약 263~290ms/1.04~1.06s/3.04~3.05s로 외부 지연을 따라갔다.
+  - mock 500 조건은 43/43 요청이 backend 5xx로 전파되어, timeout/fallback 정책 검토가 별도 후속 후보로 남았다.
 
 ## P2-1. 검색 API FULLTEXT 성능 기준선
 

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -53,6 +53,14 @@ Reviewer 이후 diff 변경을 피하기 위해 merge 후 `WORK_PROGRESS.md`만 
 
 ## Current Snapshot
 
+- Active work override, 2026-07-13:
+  - #180/#181 is merged and closed. The single-instance popular baseline concluded that 20 VU was stable at about 87 RPS and 50 VU was a saturation signal.
+  - Current active work is #182 `[PERF] Gemini mock latency 기반 외부 호출 병목 기준선 수립` on branch `perf/#182-gemini-mock-latency-baseline`, PR #183.
+  - #182 changes runtime testability only: configurable `gemini.base-url`, local test flag `AI_SUMMARY_SAVE_ENABLED=false`, lightweight mock Gemini server, and `gemini-mock-latency-baseline.md`.
+  - #182 is Verified after controlled 200ms/1s/3s and 500-response measurements; PR #183 awaits Reviewer re-check and merge approval.
+  - Normal-path p95 followed mock latency, 200ms/20 VU reached 57.80 RPS with 0% failures, and mock 500 propagated as backend 5xx for 43/43 requests.
+  - Do not generalize this local mock result to real Gemini capacity; timeout/fallback/async changes remain a separate follow-up decision.
+
 - Repo: `SKU-GlobalTimes/GlobalTimes_BeSide`
 - Base branch: `develop`
 - Long-running open issue: #110 `[Troubleshooting] 서비스 설계의 근본적 한계`

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -106,7 +106,8 @@ Blocking 예시:
 - #174/#175에서 주요 기사 조회 API 고부하 부하 테스트 및 DB 병목 기준선을 수립했다.
 - #176/#177에서 `popular` 기사 조회의 `Using filesort`가 현재 데이터 규모에서 인덱스 추가가 필요한 병목인지 k6와 `EXPLAIN ANALYZE`로 판단했다.
 - #178/#179에서 로컬 부하 테스트 시 애플리케이션 latency 로그와 Docker/local resource 지표를 같은 실행 구간에 캡처하는 관측 runbook을 정리했다.
-- #180에서 주요 조회 API 단일 인스턴스 TPS 한계와 포화 신호 구간을 정리 중이다.
+- #180/#181에서 주요 조회 API 단일 인스턴스 TPS 한계와 포화 신호 구간을 정리했다.
+- #182에서 Gemini mock latency 기반 외부 호출 병목 기준선 측정을 완료했고 PR #183 merge를 기다리고 있다.
 - 현재 반복 성능/안정성 기본기 흐름의 주요 후보(#123, #127, #129, #131, #133, #137, #140, #142, #146)와 AI workflow 보강(#144)은 merge 완료 상태다.
 
 ### #113 / PR #114 - 백엔드 개선 Backlog 및 AI 작업 운영 규칙 수립
@@ -1794,6 +1795,66 @@ PR comment 조회
 ```
 
 이 흐름이 2~3개 이상의 실제 개선 PR에서 반복되면, MCP tool로 묶는 것이 자연스럽다.
+
+### #182 - Gemini mock latency 기반 외부 호출 병목 기준선 수립
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/182
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/183
+- 작업 브랜치: `perf/#182-gemini-mock-latency-baseline`
+- 상태: Verified (Reviewer Blocking 반영 후 재검토 대기)
+- 주요 파일:
+  - `src/main/java/com/example/globalTimes_be/global/config/GeminiConfig.java`
+  - `src/main/java/com/example/globalTimes_be/domain/ai/controller/AiController.java`
+  - `src/main/resources/application.yml`
+  - `load-tests/mock-gemini-server.js`
+  - `docs/backend-improvement/gemini-mock-latency-baseline.md`
+
+목표:
+
+- 실제 Gemini API 비용, quota, rate limit, 응답 편차 없이 외부 AI 호출 지연을 통제한다.
+- `GET /api/ai/{id}/summary` 사용자-facing 경로에서 mock AI latency가 p95, RPS/TPS, failure rate에 주는 영향을 측정할 수 있게 한다.
+- 기존 k6 VU/RPS 결과를 바탕으로 8GB 로컬 노트북에서 안전한 점진 부하 범위를 정한다.
+
+Overengineering 판단:
+
+- Kafka, async queue, Redis cache, real Gemini 부하 테스트는 현재 증거 대비 과하다.
+- summary cache 때문에 첫 요청 이후 Gemini 경로가 skip되므로, 테스트 전용 `AI_SUMMARY_SAVE_ENABLED=false`가 필요하다.
+- production 기본값은 `true`로 유지해 기존 API 동작을 바꾸지 않는다.
+- `gemini.base-url`도 기본값을 실제 Gemini URL로 유지하고, 로컬 테스트에서만 mock server URL로 override한다.
+
+조사/근거:
+
+- #180 단일 인스턴스 popular 기준선은 20 VU에서 약 87 RPS, p95 약 105ms, failure 0.00%였다.
+- #180 50 VU에서는 RPS가 약 86으로 증가하지 않고 p95가 456ms로 상승해 로컬/애플리케이션 포화 신호로 해석했다.
+- #176 popular-focused 20/50/100 VU도 RPS가 `106.29/s -> 114.33/s -> 123.61/s`로 완만히 증가하는 동안 p95는 `134.87ms -> 423.79ms -> 902.51ms`로 크게 상승했다.
+- 따라서 Gemini mock 테스트는 50+ VU가 아니라 `1 -> 3 -> 5 -> 10 -> 20 VU` 순서로 점진 수행한다.
+
+구현 및 측정 결과:
+
+- `gemini.base-url`을 설정화해 local mock server로 redirect할 수 있게 한다.
+- `ai.summary-save-enabled`를 추가해 로컬 부하 테스트에서만 summary 저장을 끄고 반복 AI-path 측정을 가능하게 한다.
+- Node 내장 `http` 기반 mock Gemini server를 추가한다.
+- `200ms`는 1/3/5/10/20 VU에서 p95 `262.90~289.96ms`, 최대 57.80 RPS, failure 0.00%였다.
+- `1000ms`는 1/3/5 VU에서 p95 `1040.88~1057.59ms`, 최대 4.39 RPS, failure 0.00%였다.
+- `3000ms`는 1/3/5 VU에서 p95 `3039.06~3051.71ms`, 최대 1.59 RPS, failure 0.00%였다.
+- mock 500 응답은 1 VU/15초에서 43건 모두 backend 5xx로 전파되어 failure 100.00%였고, 의도대로 k6 threshold를 위반했다.
+- 대표 로그는 `summaryHit=false`, `aiRequested=true`, `summarySaveMs=0`을 확인했으며 `aiSummaryMs`는 200ms/1s/3s 조건에서 각각 224ms/1033ms/3020ms였다.
+- 테스트에 사용한 기사 summary는 측정 전 백업하고 측정 후 원래 값으로 복원했으며 임시 DB table도 제거했다.
+- 결과는 `docs/backend-improvement/gemini-mock-latency-baseline.md`에 실행 조건과 해석 경계까지 기록했다.
+
+판단:
+
+- 정상 경로의 p95는 mock latency를 거의 그대로 따라 외부 동기 호출이 사용자 응답 지연을 지배한다.
+- 테스트 범위에서는 VU 증가에 따른 처리량 증가가 유지되어 로컬 포화 신호는 발견되지 않았다.
+- 실제 Gemini quota/network/rate limit을 제외한 mock 결과이므로 운영 용량으로 일반화하지 않는다.
+- Gemini 5xx가 사용자-facing 5xx로 전파되는 현상은 확인했지만, timeout/fallback/async 도입은 별도 이슈에서 이 기준선과 비교해 판단한다.
+
+Reviewer 필요성:
+
+- 운영 기본 동작은 유지하지만 runtime config와 테스트 스크립트가 추가되므로 Reviewer 검토 대상이다.
+- 최초 Reviewer는 실제 측정 없이 #182를 닫는 상태 불일치를 Blocking으로 지적했고, 위 측정과 `Verified` 상태 갱신으로 반영했다.
+
+---
 
 ## 5. 다음 세션에서 바로 이어가기 위한 시작 프롬프트
 

--- a/docs/backend-improvement/gemini-mock-latency-baseline.md
+++ b/docs/backend-improvement/gemini-mock-latency-baseline.md
@@ -1,0 +1,230 @@
+# Gemini mock latency baseline
+
+## Purpose
+
+This document records the plan and baseline shape for measuring the article AI summary path with controlled Gemini-like latency.
+
+The goal is not to benchmark the real Gemini service.
+The goal is to measure how this backend behaves when the user-facing summary path includes a synchronous external AI call with predictable latency.
+
+## Portfolio Summary Candidate
+
+```text
+Gemini external call path was isolated with a local mock server and k6 load testing, so AI summary latency could be measured without API cost or quota noise.
+```
+
+Shorter resume keyword version:
+
+```text
+AI external call mock latency load-test baseline
+```
+
+## Overengineering Decision
+
+This issue adds the minimum runtime hooks needed for repeatable local measurement.
+
+Included:
+
+- configurable `gemini.base-url`
+- local-only `AI_SUMMARY_SAVE_ENABLED=false` option for repeated AI-path measurement
+- lightweight Node mock server
+- measurement document and run policy
+
+Not included:
+
+- async processing
+- queue/Kafka
+- Redis cache policy changes
+- real Gemini load testing
+- production timeout policy changes
+- API response shape changes
+
+Reasoning:
+
+- Real Gemini load testing can create cost, quota, rate-limit, and response-variance noise.
+- Existing summary caching means only the first request would hit Gemini unless persistence is disabled or the DB is reset between requests.
+- Disabling summary save is safer as a local measurement flag because production default remains enabled.
+- On the current 8GB local laptop, 50+ VUs already showed local saturation on read-only APIs, so AI-call tests should use smaller gradual steps first.
+
+## Runtime Controls
+
+Production defaults are unchanged:
+
+```yaml
+gemini:
+  base-url: https://generativelanguage.googleapis.com
+
+ai:
+  summary-save-enabled: true
+```
+
+Local mock test override:
+
+```powershell
+$env:GEMINI_BASE_URL = "http://localhost:9090"
+$env:AI_SUMMARY_SAVE_ENABLED = "false"
+```
+
+`AI_SUMMARY_SAVE_ENABLED=false` prevents the first successful mock summary from being persisted and turning later requests into summary hits.
+Use it only for local load tests.
+
+## Mock Gemini Server
+
+Start a local mock server:
+
+```powershell
+$env:MOCK_GEMINI_PORT = "9090"
+$env:MOCK_GEMINI_DELAY_MS = "200"
+$env:MOCK_GEMINI_STATUS = "200"
+node .\load-tests\mock-gemini-server.js
+```
+
+Health check:
+
+```powershell
+Invoke-WebRequest http://localhost:9090/health
+```
+
+The mock server returns a Gemini-like JSON body:
+
+```json
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "Mock Gemini summary for local load testing."
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+The mock does not log prompt bodies, API keys, article text, or user questions.
+
+## k6 Scenario
+
+Reuse the existing user-facing summary path script:
+
+```powershell
+$env:BASE_URL = "http://localhost:8080"
+$env:ARTICLE_IDS = "<article-id-with-crawled-content>"
+$env:LANGUAGE = "English"
+$env:SCENARIO_LABEL = "gemini_mock_200ms"
+$env:ARTICLE_CRAWL_DURATION = "30s"
+$env:SLEEP_SECONDS = "0.1"
+```
+
+Recommended VU steps for this laptop:
+
+```text
+1 VU / 30s
+3 VUs / 30s
+5 VUs / 30s
+10 VUs / 30s
+20 VUs / 30s only if the 10 VU run is stable
+```
+
+Do not start with 50+ VUs for this path.
+External-call latency holds request threads longer than DB read-only APIs, so the same VU count can create stronger pressure.
+
+## Existing k6 VU/RPS Context
+
+| Previous work | Scenario | VUs | RPS/TPS signal | p95 signal | Interpretation |
+| --- | --- | ---: | ---: | ---: | --- |
+| #168 | search FULLTEXT term smoke | 1 | about 10 requests per term run | 24ms to 103ms by term | query-type smoke, not capacity |
+| #170 | summary hit smoke | 1 | 30s smoke | 332.6ms | existing summary returned; Gemini skipped |
+| #176 | popular-focused read load | 20 | 106.29/s | 134.87ms | stable local read load |
+| #176 | popular-focused read load | 50 | 114.33/s | 423.79ms | p95 rose, RPS barely increased |
+| #176 | popular-focused read load | 100 | 123.61/s | 902.51ms | saturation signal, not immediate DB-index proof |
+| #180 | single-instance popular baseline | 5 | 24.19/s | 105.05ms | stable |
+| #180 | single-instance popular baseline | 10 | 45.91/s | 94.62ms | stable |
+| #180 | single-instance popular baseline | 20 | 87.29/s | 105.48ms | stable local baseline |
+| #180 | single-instance popular baseline | 50 | 86.15/s | 456.72ms | throughput plateau with latency growth |
+
+For these HTTP tests, RPS and TPS can be treated similarly when one API request is one transaction.
+VU is concurrency, not throughput.
+Throughput is the completed request rate produced by those VUs.
+
+Approximate relation:
+
+```text
+RPS ~= VUs / (average response time + sleep time + script overhead)
+```
+
+## Laptop Resource Policy
+
+Use the local laptop budget conservatively:
+
+- start from 1 VU and increase gradually
+- stop when RPS plateaus while p95 rises sharply
+- stop when failure rate becomes non-zero under the same condition
+- stop if Docker memory, app memory, or local responsiveness degrades noticeably
+- treat 20 VU as the upper normal step for AI-call mock tests on this machine
+- treat 50+ VU as an optional stress signal only after smaller steps are understood
+
+## Measurement Environment
+
+- Date: 2026-07-13
+- Backend: local Spring Boot on `localhost:8080`
+- Dependencies: Docker MySQL 8.0 and Redis 7
+- Mock: local Node server on `localhost:9090`
+- k6 scenario: `article-crawl-baseline.js`, one article ID, `SLEEP_SECONDS=0.1`
+- Test article: an article with existing `crawled_content`; its summary was backed up, cleared only for the run, and restored afterward
+- Runtime flags: `GEMINI_BASE_URL=http://localhost:9090`, `GEMINI_API_KEY=dummy`, `AI_SUMMARY_SAVE_ENABLED=false`
+
+The first manual request was excluded from the baseline because WebClient and application warm-up raised it to about 1.63 seconds.
+The following k6 runs used the warmed application path.
+
+## Results
+
+| Date | Environment | Mock delay | VUs | Duration | Requests | RPS | p95 | Failure rate | `aiSummaryMs` signal | Notes |
+| --- | --- | ---: | ---: | --- | ---: | ---: | ---: | ---: | --- | --- |
+| 2026-07-13 | local/dev | 200ms | 1 | 30s | 87 | 2.87 | 264.02ms | 0.00% | 224ms | stable |
+| 2026-07-13 | local/dev | 200ms | 3 | 30s | 252 | 8.33 | 289.96ms | 0.00% | - | stable |
+| 2026-07-13 | local/dev | 200ms | 5 | 30s | 437 | 14.45 | 262.90ms | 0.00% | - | stable |
+| 2026-07-13 | local/dev | 200ms | 10 | 30s | 864 | 28.52 | 270.10ms | 0.00% | - | stable |
+| 2026-07-13 | local/dev | 200ms | 20 | 30s | 1,753 | 57.80 | 266.27ms | 0.00% | - | stable upper step |
+| 2026-07-13 | local/dev | 1000ms | 1 | 30s | 27 | 0.88 | 1040.88ms | 0.00% | 1033ms | stable |
+| 2026-07-13 | local/dev | 1000ms | 3 | 30s | 81 | 2.63 | 1057.59ms | 0.00% | - | stable |
+| 2026-07-13 | local/dev | 1000ms | 5 | 30s | 135 | 4.39 | 1047.58ms | 0.00% | - | stable |
+| 2026-07-13 | local/dev | 3000ms | 1 | 30s | 10 | 0.32 | 3039.06ms | 0.00% | 3020ms | stable |
+| 2026-07-13 | local/dev | 3000ms | 3 | 30s | 30 | 0.95 | 3050.94ms | 0.00% | - | stable |
+| 2026-07-13 | local/dev | 3000ms | 5 | 30s | 50 | 1.59 | 3051.71ms | 0.00% | - | stable |
+| 2026-07-13 | local/dev | 500 at 200ms | 1 | 15s | 43 | 2.85 | 263.30ms | 100.00% | - | expected threshold failure |
+
+Use `[AiSummary]` logs to verify:
+
+```text
+summaryHit=false
+aiRequested=true
+summarySaveMs=0
+```
+
+`summarySaveMs=0` is expected when `AI_SUMMARY_SAVE_ENABLED=false`.
+
+Representative application logs confirmed the intended path:
+
+```text
+200ms:  summaryHit=false aiRequested=true aiSummaryMs=224  summarySaveMs=0 totalMs=264
+1000ms: summaryHit=false aiRequested=true aiSummaryMs=1033 summarySaveMs=0 totalMs=1068
+3000ms: summaryHit=false aiRequested=true aiSummaryMs=3020 summarySaveMs=0 totalMs=3052
+```
+
+## Interpretation
+
+- Normal-path p95 followed the configured mock delay closely. The synchronous external call dominates this API latency.
+- At 200ms, throughput increased from 2.87 RPS at 1 VU to 57.80 RPS at 20 VU while p95 stayed near 263ms to 290ms and failures stayed at 0%.
+- At 1s and 3s, throughput remained approximately proportional to VU count, but each VU completed fewer requests because it waited on the external call longer.
+- No local saturation was observed in the tested range. This does not predict real Gemini capacity because real quota, network variance, and rate limits were intentionally excluded.
+- A controlled Gemini 500 response produced backend 5xx responses for all 43 requests. The current summary path has no Gemini failure fallback, so external failure propagates to the user-facing API.
+- The 500 scenario intentionally crossed the k6 `http_req_failed < 5%` threshold; its non-zero exit is the expected test result.
+
+This baseline supports a later, separate decision about timeout/fallback or asynchronous processing. It does not justify adding those mechanisms in #182 by itself.
+
+## Follow-up Boundary
+
+If a follow-up issue is approved, compare a minimal timeout/fallback policy against this baseline before considering async processing, queues, or additional infrastructure.

--- a/load-tests/mock-gemini-server.js
+++ b/load-tests/mock-gemini-server.js
@@ -1,0 +1,66 @@
+import http from 'node:http';
+
+const port = Number(process.env.MOCK_GEMINI_PORT || 9090);
+const delayMs = Number(process.env.MOCK_GEMINI_DELAY_MS || 200);
+const statusCode = Number(process.env.MOCK_GEMINI_STATUS || 200);
+const responseText = process.env.MOCK_GEMINI_TEXT || 'Mock Gemini summary for local load testing.';
+
+function readBody(req) {
+  return new Promise((resolve) => {
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk;
+    });
+    req.on('end', () => resolve(body));
+  });
+}
+
+function json(res, status, payload) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(payload));
+}
+
+const server = http.createServer(async (req, res) => {
+  if (req.method === 'GET' && req.url === '/health') {
+    json(res, 200, { status: 'ok', delayMs, statusCode });
+    return;
+  }
+
+  if (req.method !== 'POST' || !req.url.startsWith('/v1beta/models/')) {
+    json(res, 404, { error: { message: 'Not found' } });
+    return;
+  }
+
+  await readBody(req);
+
+  setTimeout(() => {
+    if (statusCode >= 400) {
+      json(res, statusCode, {
+        error: {
+          code: statusCode,
+          message: 'Mock Gemini failure',
+          status: 'MOCK_FAILURE',
+        },
+      });
+      return;
+    }
+
+    json(res, statusCode, {
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                text: responseText,
+              },
+            ],
+          },
+        },
+      ],
+    });
+  }, delayMs);
+});
+
+server.listen(port, () => {
+  console.log(`[MockGemini] listening on http://localhost:${port} delayMs=${delayMs} status=${statusCode}`);
+});

--- a/src/main/java/com/example/globalTimes_be/domain/ai/controller/AiController.java
+++ b/src/main/java/com/example/globalTimes_be/domain/ai/controller/AiController.java
@@ -11,6 +11,7 @@ import com.example.globalTimes_be.global.apiPayload.code.status.GlobalSuccessSta
 import com.example.globalTimes_be.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -28,6 +29,9 @@ public class AiController implements AiControllerDocs {
     public final AiSseService aiSseService;
     public final DetailService detailService;
     public final AnonymousChatSessionService anonymousChatSessionService;
+
+    @Value("${ai.summary-save-enabled:true}")
+    private boolean summarySaveEnabled;
 
     @Override
     @GetMapping(value = "/{id}/summary")
@@ -68,10 +72,12 @@ public class AiController implements AiControllerDocs {
         String summary = aiService.summarizeArticle(crawledContent, language);
         long aiSummaryMs = elapsedMs(aiSummaryStartedAt);
 
-        // 요약 결과 DB 저장 (이후 재요청 시 GPT 스킵)
-        long summarySaveStartedAt = System.nanoTime();
-        detailService.saveArticleSummary(id, summary);
-        long summarySaveMs = elapsedMs(summarySaveStartedAt);
+        long summarySaveMs = 0;
+        if (summarySaveEnabled) {
+            long summarySaveStartedAt = System.nanoTime();
+            detailService.saveArticleSummary(id, summary);
+            summarySaveMs = elapsedMs(summarySaveStartedAt);
+        }
 
         log.info("[AiSummary] articleId={} summaryHit=false crawledContentRequested=true crawlerFallback=false aiRequested=true summaryLookupMs={} crawlContentMs={} fallbackContentMs=0 aiSummaryMs={} summarySaveMs={} totalMs={}",
                 id,

--- a/src/main/java/com/example/globalTimes_be/global/config/GeminiConfig.java
+++ b/src/main/java/com/example/globalTimes_be/global/config/GeminiConfig.java
@@ -1,5 +1,6 @@
 package com.example.globalTimes_be.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -10,9 +11,11 @@ public class GeminiConfig {
     // Gemini는 API Key를 Authorization 헤더가 아닌 URL 쿼리 파라미터로 전달
     // 실제 키는 각 서비스에서 @Value로 주입 후 URI에 직접 포함
     @Bean
-    public WebClient geminiWebClient() {
+    public WebClient geminiWebClient(
+            @Value("${gemini.base-url:https://generativelanguage.googleapis.com}") String geminiBaseUrl
+    ) {
         return WebClient.builder()
-                .baseUrl("https://generativelanguage.googleapis.com")
+                .baseUrl(geminiBaseUrl)
                 .defaultHeader("Content-Type", "application/json")
                 .codecs(configurer -> configurer
                         .defaultCodecs()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,7 @@ spring:
 # Gemini API (GPT 대체, 무료 티어: 일 1,500회 / 분 15회)
 gemini:
   api-key: ${GEMINI_API_KEY}
+  base-url: ${GEMINI_BASE_URL:https://generativelanguage.googleapis.com}
 
 # JWT 설정
 jwt:
@@ -72,3 +73,4 @@ trend:
 # AI 컨텍스트 대화 슬라이딩 윈도우 크기 (최근 N턴만 Gemini에 전달, 토큰 비용 제어)
 ai:
   context-window-size: 10
+  summary-save-enabled: ${AI_SUMMARY_SAVE_ENABLED:true}


### PR DESCRIPTION
## 관련 이슈
- closed #182

## 변경 타입
- [ ] 기능 추가 (FEAT)
- [ ] 버그 수정 (FIX)
- [ ] 리팩터링 (REFACTOR)
- [x] 테스트/문서/성능 기준선 (TEST/CHORE)

## 작업 내용
- Gemini WebClient base URL을 `gemini.base-url`로 설정화해 로컬 mock Gemini 서버로 전환 가능하게 했습니다.
- `ai.summary-save-enabled` 설정을 추가해 로컬 부하 테스트에서만 summary 저장을 끄고 반복 AI-path 측정이 가능하게 했습니다.
- Node 내장 `http` 기반 `load-tests/mock-gemini-server.js`를 추가했습니다.
- mock 200ms/1s/3s와 500 응답 조건의 k6 측정 결과, 단계별 로그, 해석 경계를 `gemini-mock-latency-baseline.md`에 기록했습니다.
- `WORK_PROGRESS.md`, `BACKLOG.md`, `NEXT_AGENT_BRIEF.md`를 #182 `Verified`, PR #183 재검토 대기 상태로 갱신했습니다.

## 기술적 배경
- 실제 Gemini API로 부하 테스트를 반복하면 비용, quota, rate limit, 응답 편차가 섞입니다.
- 기존 summary 저장 정책 때문에 첫 요청 이후에는 Gemini 경로가 summary hit로 우회되어 외부 호출 병목을 반복 측정하기 어렵습니다.
- production 기본값은 기존 동작을 유지하고, 로컬 테스트에서만 `GEMINI_BASE_URL=http://localhost:9090`, `AI_SUMMARY_SAVE_ENABLED=false`를 사용했습니다.

## 테스트/검증
- [x] `node --check load-tests/mock-gemini-server.js`
- [x] `.\gradlew.bat test`
- [x] mock `/health`에서 200ms/1s/3s 및 500 상태 설정 확인
- [x] dummy `GEMINI_API_KEY`로 backend summary 요청이 mock Gemini 응답을 반환하는지 확인
- [x] 200ms, 1/3/5/10/20 VU: 최대 57.80 RPS, p95 262.90~289.96ms, failure 0.00%
- [x] 1s, 1/3/5 VU: 최대 4.39 RPS, p95 1040.88~1057.59ms, failure 0.00%
- [x] 3s, 1/3/5 VU: 최대 1.59 RPS, p95 3039.06~3051.71ms, failure 0.00%
- [x] mock 500, 1 VU/15s: 43/43 backend 5xx, failure 100.00%, 예상된 k6 threshold 위반
- [x] 대표 로그에서 `summaryHit=false`, `aiRequested=true`, `summarySaveMs=0`, `aiSummaryMs=224/1033/3020` 확인
- [x] 테스트 기사 summary 원복 및 임시 DB table 제거
- [x] `git diff --check`

## 체크 리스트
- [x] Merge 대상 브랜치가 `develop`인지 확인했습니다.
- [x] 변경과 검증 결과를 이슈 단위 단일 커밋에 포함했습니다.
- [x] 운영 기본값 기준 API 응답/DB schema/Redis 정책은 변경하지 않았습니다.
- [x] 실제 Gemini API key, prompt 전문, 기사 원문, 사용자 질문을 로그나 문서에 남기지 않았습니다.

## 리뷰 요구사항
- 최초 Blocking이었던 #182 종료 의미와 실제 측정/문서 상태 불일치가 해소됐는지 확인 부탁드립니다.
- `gemini.base-url`과 `ai.summary-save-enabled` 기본값이 production 동작을 유지하는지 확인 부탁드립니다.
- mock 500이 backend 5xx로 전파된 결과를 timeout/fallback 별도 후속 판단으로 남긴 범위가 적절한지 확인 부탁드립니다.

## 추후 계획
- Reviewer가 MERGE_READY이고 Blocking이 없으면 사용자 승인 후 merge합니다.
- timeout/fallback/async 개선은 #182에서 구현하지 않고 별도 이슈 후보로 overengineering 여부부터 판단합니다.
