### PR TITLE
🛡️ [FIX/#184] Gemini timeout 및 upstream 오류 분리

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -61,7 +61,7 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ### P2 후속 후보. Gemini mock latency 부하 테스트
 
-- 상태: `Verified` ([#182](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/182), [PR #183](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/183))
+- 상태: `Done` ([#182](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/182), [PR #183](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/183))
 - AS-IS: 기사 상세의 AI 요약/질의응답 경로에는 Gemini 외부 호출이 포함될 수 있지만, 실제 Gemini API로 부하 테스트를 반복하면 비용, quota, rate limit, 응답 편차 문제가 생긴다.
 - TO-BE: mock AI 서버로 latency `200ms`, `1s`, `3s`, `timeout/5xx` 조건을 통제하고, 사용자 요청 경로의 p95/오류율/fallback 동작을 측정한다.
 - 진행 조건:
@@ -72,6 +72,18 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 - 측정 결과:
   - 정상 응답은 mock 200ms/1s/3s 조건에서 p95가 각각 약 263~290ms/1.04~1.06s/3.04~3.05s로 외부 지연을 따라갔다.
   - mock 500 조건은 43/43 요청이 backend 5xx로 전파되어, timeout/fallback 정책 검토가 별도 후속 후보로 남았다.
+
+### P2 후속 후보. Gemini timeout 상한 및 upstream 오류 분리
+
+- 상태: `Verified` ([#184](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/184))
+- AS-IS: article summary의 Gemini 호출은 고정 90초 timeout을 사용하고 non-2xx, timeout, 내부 파싱 오류를 모두 backend 500으로 반환한다.
+- TO-BE: 10초 설정형 timeout으로 사용자 대기 상한을 줄이고, Gemini non-2xx는 502, timeout은 504, 내부 오류는 500으로 분리한다.
+- 검증 결과:
+  - mock 15초 조건 p95가 개선 전 16.08초에서 개선 후 10.42초로 제한됐다.
+  - mock 500은 약 0.31초에 backend 502, mock 15초는 약 10.04초에 backend 504를 반환했다.
+  - mock 3초 정상 응답은 약 3.09초에 backend 200으로 유지됐다.
+- 범위 경계:
+  - retry, circuit breaker, async queue, SSE/Trend Gemini 정책 변경은 현재 근거 대비 과해 제외한다.
 
 ## P2-1. 검색 API FULLTEXT 성능 기준선
 

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -55,11 +55,11 @@ Reviewer 이후 diff 변경을 피하기 위해 merge 후 `WORK_PROGRESS.md`만 
 
 - Active work override, 2026-07-13:
   - #180/#181 is merged and closed. The single-instance popular baseline concluded that 20 VU was stable at about 87 RPS and 50 VU was a saturation signal.
-  - Current active work is #182 `[PERF] Gemini mock latency 기반 외부 호출 병목 기준선 수립` on branch `perf/#182-gemini-mock-latency-baseline`, PR #183.
-  - #182 changes runtime testability only: configurable `gemini.base-url`, local test flag `AI_SUMMARY_SAVE_ENABLED=false`, lightweight mock Gemini server, and `gemini-mock-latency-baseline.md`.
-  - #182 is Verified after controlled 200ms/1s/3s and 500-response measurements; PR #183 awaits Reviewer re-check and merge approval.
-  - Normal-path p95 followed mock latency, 200ms/20 VU reached 57.80 RPS with 0% failures, and mock 500 propagated as backend 5xx for 43/43 requests.
-  - Do not generalize this local mock result to real Gemini capacity; timeout/fallback/async changes remain a separate follow-up decision.
+  - #182/#183 is merged and closed. Controlled 200ms/1s/3s and 500-response measurements established the Gemini mock baseline without real API cost.
+  - Current active work is #184 `[FIX] Gemini 요약 API timeout 상한 및 upstream 오류 분리` on branch `fix/#184-gemini-timeout-upstream-errors`.
+  - #184 replaces the fixed 90-second summary timeout with configurable 10 seconds and separates Gemini non-2xx as 502, timeout as 504, and internal parsing errors as 500.
+  - In the same 15-second mock condition, p95 changed from 16.08 seconds before to 10.42 seconds after; 3-second normal response remained 200 and mock 500 returned 502.
+  - Retry, circuit breaker, async queue, and SSE/Trend Gemini policy changes remain out of scope.
 
 - Repo: `SKU-GlobalTimes/GlobalTimes_BeSide`
 - Base branch: `develop`

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -107,7 +107,8 @@ Blocking 예시:
 - #176/#177에서 `popular` 기사 조회의 `Using filesort`가 현재 데이터 규모에서 인덱스 추가가 필요한 병목인지 k6와 `EXPLAIN ANALYZE`로 판단했다.
 - #178/#179에서 로컬 부하 테스트 시 애플리케이션 latency 로그와 Docker/local resource 지표를 같은 실행 구간에 캡처하는 관측 runbook을 정리했다.
 - #180/#181에서 주요 조회 API 단일 인스턴스 TPS 한계와 포화 신호 구간을 정리했다.
-- #182에서 Gemini mock latency 기반 외부 호출 병목 기준선 측정을 완료했고 PR #183 merge를 기다리고 있다.
+- #182/#183에서 Gemini mock latency 기반 외부 호출 병목 기준선을 수립하고 merge를 완료했다.
+- #184에서 Gemini summary timeout 상한과 upstream 502/504 오류 분리를 진행 중이다.
 - 현재 반복 성능/안정성 기본기 흐름의 주요 후보(#123, #127, #129, #131, #133, #137, #140, #142, #146)와 AI workflow 보강(#144)은 merge 완료 상태다.
 
 ### #113 / PR #114 - 백엔드 개선 Backlog 및 AI 작업 운영 규칙 수립
@@ -1801,7 +1802,7 @@ PR comment 조회
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/182
 - PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/183
 - 작업 브랜치: `perf/#182-gemini-mock-latency-baseline`
-- 상태: Verified (Reviewer Blocking 반영 후 재검토 대기)
+- 상태: merged
 - 주요 파일:
   - `src/main/java/com/example/globalTimes_be/global/config/GeminiConfig.java`
   - `src/main/java/com/example/globalTimes_be/domain/ai/controller/AiController.java`
@@ -1853,6 +1854,55 @@ Reviewer 필요성:
 
 - 운영 기본 동작은 유지하지만 runtime config와 테스트 스크립트가 추가되므로 Reviewer 검토 대상이다.
 - 최초 Reviewer는 실제 측정 없이 #182를 닫는 상태 불일치를 Blocking으로 지적했고, 위 측정과 `Verified` 상태 갱신으로 반영했다.
+
+### #184 - Gemini 요약 API timeout 상한 및 upstream 오류 분리
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/184
+- 작업 브랜치: `fix/#184-gemini-timeout-upstream-errors`
+- 상태: Verified (PR 및 Reviewer 대기)
+- 주요 파일:
+  - `src/main/java/com/example/globalTimes_be/domain/ai/service/AiService.java`
+  - `src/main/java/com/example/globalTimes_be/domain/detail/exception/DetailErrorStatus.java`
+  - `src/main/resources/application.yml`
+  - `src/test/java/com/example/globalTimes_be/domain/ai/service/AiServiceTest.java`
+  - `docs/backend-improvement/gemini-timeout-upstream-error-policy.md`
+
+문제:
+
+- #182에서 Gemini mock 500이 43/43건 backend 500으로 전파되어 내부 오류와 외부 의존성 장애를 구분할 수 없었다.
+- `AiService`는 고정 90초 timeout을 사용해 장시간 upstream 지연이 사용자 요청을 오래 붙잡을 수 있었다.
+- 개선 전 mock 15초/1 VU/35초 조건은 3건 성공, 평균 15.43초, p95 16.08초였다.
+
+Overengineering 판단:
+
+- 현재 200ms/20 VU 범위에서 로컬 포화 신호가 없어 async queue, Kafka, circuit breaker를 바로 도입할 근거가 부족하다.
+- 기사 원문을 summary처럼 반환하는 fallback은 API 의미를 바꾸므로 제외한다.
+- 이번 이슈는 timeout 상한과 오류 원인 분리만 적용하고 SSE/Trend Gemini 경로는 변경하지 않는다.
+
+구현:
+
+- `gemini.timeout-ms` 기본값을 10000ms로 추가하고 기존 고정 90초를 교체했다.
+- Gemini non-2xx는 502 Bad Gateway, timeout은 504 Gateway Timeout, 내부 파싱 오류는 기존 500으로 분리했다.
+- 외부 오류 body 대신 status만 로그에 남기고 timeout 로그에는 설정값만 기록한다.
+- JDK local HTTP server 기반 `AiServiceTest`로 정상, 502, 504, 내부 500을 회귀 테스트한다.
+
+검증:
+
+- 전체 Gradle test 22건 통과.
+- 개선 후 동일 mock 15초 조건은 4건 504, 평균 10.16초, p95 10.42초로 대기 상한이 줄었다.
+- 단건 API 검증은 mock 15초에서 504/10.04초, mock 500/200ms에서 502/0.31초, mock 3초 정상 조건에서 200/3.09초였다.
+- 개선 후 long-delay k6 threshold 실패는 의도된 결과이며, 성공률 개선이 아니라 bounded wait와 오류 분리가 목표다.
+- 테스트 기사 summary는 원복했고 임시 DB table은 제거했다.
+
+판단:
+
+- 이력서에서는 `Gemini 외부 호출 timeout 및 502/504 오류 분리, mock before/after 검증`으로 압축할 수 있다.
+- 실제 Gemini latency나 처리량으로 일반화하지 않는다.
+- 후속 async/retry/circuit breaker는 별도 근거와 이슈 승인 전까지 구현하지 않는다.
+
+Reviewer 필요성:
+
+- 운영 timeout 기본값과 HTTP 오류 응답이 변경되므로 Reviewer 검토가 필요하다.
 
 ---
 

--- a/docs/backend-improvement/gemini-timeout-upstream-error-policy.md
+++ b/docs/backend-improvement/gemini-timeout-upstream-error-policy.md
@@ -1,0 +1,111 @@
+# Gemini timeout and upstream error policy
+
+## Problem
+
+#182 isolated the synchronous Gemini call with a local mock server.
+Normal-path p95 followed mock latency, and a mock 500 response propagated as a generic backend 500 for every request.
+
+Before #184:
+
+- `AiService` used a fixed 90-second Reactor timeout.
+- Gemini non-2xx, timeout, and internal response parsing errors all became the same backend 500.
+- the non-2xx handler logged the full upstream error body
+- a 15-second mock response kept the user-facing request waiting for the full upstream delay
+
+## Overengineering Decision
+
+This issue applies the smallest resilience change supported by the #182 evidence.
+
+Included:
+
+- configurable `gemini.timeout-ms`
+- 10-second default timeout for the synchronous article summary path
+- Gemini non-2xx mapped to 502 Bad Gateway
+- Gemini timeout mapped to 504 Gateway Timeout
+- internal parsing or application errors kept as 500 Internal Server Error
+- regression tests and mock before/after verification
+
+Not included:
+
+- retry
+- circuit breaker or Resilience4j
+- async queue, Kafka, or RabbitMQ
+- conversion of the normal summary API to an async API
+- returning article content as if it were an AI summary
+- changes to the SSE and trend Gemini paths
+
+The #182 test range did not show local saturation through 20 VU at 200ms.
+Adding queue or circuit-breaker infrastructure before defining traffic and recovery requirements would add more complexity than the current evidence supports.
+
+## Policy
+
+| Condition | Backend status | Meaning |
+| --- | ---: | --- |
+| Gemini success with valid body | 200 | summary returned normally |
+| Gemini non-2xx | 502 | the upstream AI service failed or rejected the backend request |
+| Gemini exceeds `gemini.timeout-ms` | 504 | the upstream AI service did not answer within the user-facing limit |
+| Gemini 2xx with invalid response or internal processing failure | 500 | the backend could not process the response |
+
+Runtime default:
+
+```yaml
+gemini:
+  timeout-ms: 10000
+```
+
+Environment override:
+
+```text
+GEMINI_TIMEOUT_MS=<milliseconds>
+```
+
+The 10-second default is a user-facing upper bound, not a real Gemini capacity claim.
+It leaves margin above #182's controlled 3-second normal path while reducing the previous 90-second maximum wait.
+
+## Before And After
+
+Environment:
+
+- local Spring Boot on `localhost:8080`
+- Docker MySQL and Redis
+- local Node mock Gemini on `localhost:9090`
+- existing k6 summary scenario, 1 VU, 35 seconds, `SLEEP_SECONDS=0.1`
+- test article summary backed up, cleared during measurement, and restored afterward
+- no real Gemini request or API cost
+
+| Case | Requests | Result | Average | p95 | Interpretation |
+| --- | ---: | --- | ---: | ---: | --- |
+| Before, mock 15s, fixed 90s timeout | 3 | 200, failure 0% | 15.43s | 16.08s | full upstream delay reached the user |
+| After, mock 15s, 10s timeout | 4 | 504, failure 100% | 10.16s | 10.42s | wait bounded near the configured timeout |
+
+The after run intentionally fails the existing k6 success and p95 thresholds.
+The improvement is bounded waiting and explicit failure classification, not a higher success rate.
+The long-delay run has only three or four requests, so it is timeout-policy evidence rather than a capacity test.
+
+Additional API checks:
+
+| Mock condition | Backend result | Total time |
+| --- | ---: | ---: |
+| 3-second success | 200 | 3.09s |
+| 500 after 200ms | 502 | 0.31s |
+| 15-second success with 10-second timeout | 504 | 10.04s |
+
+## Logging And Data Safety
+
+The non-2xx handler records only the upstream status.
+Timeout logging records only the configured timeout.
+The upstream response body, API key, prompt, article content, and user question are not logged.
+
+The test article's existing summary was restored after both before and after runs, and the temporary backup table was removed.
+
+## Portfolio Summary Candidate
+
+```text
+Gemini synchronous summary calls waited through a 15-second upstream delay and exposed dependency failures as generic 500 responses; a configurable 10-second timeout and 502/504 error separation bounded p95 to about 10.42 seconds and clarified the failure source using a cost-free mock server.
+```
+
+Short version:
+
+```text
+Gemini external-call timeout and 502/504 separation, verified with mock before/after load testing
+```

--- a/src/main/java/com/example/globalTimes_be/domain/ai/service/AiService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/ai/service/AiService.java
@@ -13,6 +13,7 @@ import reactor.core.publisher.Mono;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -26,6 +27,9 @@ public class AiService {
     @Value("${gemini.api-key}")
     private String geminiApiKey;
 
+    @Value("${gemini.timeout-ms:10000}")
+    private long geminiTimeoutMs;
+
     private static final String GEMINI_MODEL = "gemini-2.5-flash";
 
     public String summarizeArticle(String crawledContent, String language) {
@@ -35,16 +39,27 @@ public class AiService {
                 .retrieve()
                 .onStatus(
                         status -> !status.is2xxSuccessful(),
-                        response -> response.bodyToMono(String.class)
-                                .doOnNext(body -> log.error("[Gemini] API ?? ??: {}", body))
-                                .then(Mono.error(new BaseException(DetailErrorStatus._GPT_ERROR.getResponse())))
+                        response -> {
+                            log.warn("[Gemini] upstreamError=true status={}", response.statusCode().value());
+                            return response.releaseBody()
+                                    .then(Mono.error(new BaseException(
+                                            DetailErrorStatus._GEMINI_UPSTREAM_ERROR.getResponse()
+                                    )));
+                        }
                 )
                 .bodyToMono(Map.class)
-                .timeout(Duration.ofSeconds(90))
+                .timeout(Duration.ofMillis(geminiTimeoutMs))
+                .onErrorMap(
+                        TimeoutException.class,
+                        ex -> {
+                            log.warn("[Gemini] timeout=true timeoutMs={}", geminiTimeoutMs);
+                            return new BaseException(DetailErrorStatus._GEMINI_TIMEOUT.getResponse());
+                        }
+                )
                 .onErrorMap(
                         ex -> !(ex instanceof BaseException),
                         ex -> {
-                            log.error("[Gemini] ?? ??: {}", ex.getMessage());
+                            log.error("[Gemini] internalError=true type={}", ex.getClass().getSimpleName());
                             return new BaseException(DetailErrorStatus._GPT_ERROR.getResponse());
                         }
                 )

--- a/src/main/java/com/example/globalTimes_be/domain/detail/exception/DetailErrorStatus.java
+++ b/src/main/java/com/example/globalTimes_be/domain/detail/exception/DetailErrorStatus.java
@@ -14,6 +14,10 @@ public enum DetailErrorStatus implements BaseResponse {
 
     _CRAWLER_ERROR(HttpStatus.BAD_REQUEST, "해당 언론사는 요약 정보 제공이 불가능합니다. (크롤링 불가)"),
 
+    _GEMINI_UPSTREAM_ERROR(HttpStatus.BAD_GATEWAY, "외부 AI 요약 서비스 응답에 실패하였습니다."),
+
+    _GEMINI_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "외부 AI 요약 서비스 응답 시간이 초과되었습니다."),
+
     _GPT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GPT 요약 중 에러가 발생하였습니다."),
     ;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,6 +46,7 @@ spring:
 gemini:
   api-key: ${GEMINI_API_KEY}
   base-url: ${GEMINI_BASE_URL:https://generativelanguage.googleapis.com}
+  timeout-ms: ${GEMINI_TIMEOUT_MS:10000}
 
 # JWT 설정
 jwt:

--- a/src/test/java/com/example/globalTimes_be/domain/ai/service/AiServiceTest.java
+++ b/src/test/java/com/example/globalTimes_be/domain/ai/service/AiServiceTest.java
@@ -1,0 +1,106 @@
+package com.example.globalTimes_be.domain.ai.service;
+
+import com.example.globalTimes_be.global.exception.BaseException;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AiServiceTest {
+
+    private HttpServer mockServer;
+    private AiService aiService;
+    private volatile int responseStatus;
+    private volatile long responseDelayMs;
+    private volatile String responseBody;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        responseStatus = 200;
+        responseDelayMs = 0;
+        responseBody = """
+                {"candidates":[{"content":{"parts":[{"text":"mock summary"}]}}]}
+                """;
+
+        mockServer = HttpServer.create(new InetSocketAddress(0), 0);
+        mockServer.createContext("/v1beta/models/", this::handleGeminiRequest);
+        mockServer.start();
+
+        WebClient webClient = WebClient.builder()
+                .baseUrl("http://127.0.0.1:" + mockServer.getAddress().getPort())
+                .build();
+        aiService = new AiService(webClient);
+        ReflectionTestUtils.setField(aiService, "geminiApiKey", "dummy");
+        ReflectionTestUtils.setField(aiService, "geminiTimeoutMs", 5000L);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockServer.stop(0);
+    }
+
+    @Test
+    void summarizeArticle_returnsSummaryForSuccessfulGeminiResponse() {
+        String result = aiService.summarizeArticle("article content", "English");
+
+        assertThat(result).isEqualTo("mock summary");
+    }
+
+    @Test
+    void summarizeArticle_mapsGeminiFailureToBadGateway() {
+        responseStatus = 500;
+        responseBody = "{\"error\":{\"message\":\"mock failure\"}}";
+
+        assertThatThrownBy(() -> aiService.summarizeArticle("article content", "English"))
+                .isInstanceOfSatisfying(BaseException.class, ex ->
+                        assertThat(ex.getHttpStatus()).isEqualTo(HttpStatus.BAD_GATEWAY));
+    }
+
+    @Test
+    void summarizeArticle_mapsTimeoutToGatewayTimeout() {
+        responseDelayMs = 250;
+        ReflectionTestUtils.setField(aiService, "geminiTimeoutMs", 50L);
+
+        assertThatThrownBy(() -> aiService.summarizeArticle("article content", "English"))
+                .isInstanceOfSatisfying(BaseException.class, ex ->
+                        assertThat(ex.getHttpStatus()).isEqualTo(HttpStatus.GATEWAY_TIMEOUT));
+    }
+
+    @Test
+    void summarizeArticle_keepsInvalidResponseAsInternalServerError() {
+        responseBody = "{}";
+
+        assertThatThrownBy(() -> aiService.summarizeArticle("article content", "English"))
+                .isInstanceOfSatisfying(BaseException.class, ex ->
+                        assertThat(ex.getHttpStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR));
+    }
+
+    private void handleGeminiRequest(HttpExchange exchange) throws IOException {
+        exchange.getRequestBody().readAllBytes();
+
+        if (responseDelayMs > 0) {
+            try {
+                Thread.sleep(responseDelayMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(responseStatus, body.length);
+        exchange.getResponseBody().write(body);
+        exchange.close();
+    }
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #184

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [x] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- `gemini.timeout-ms`를 추가하고 article summary Gemini 호출의 고정 90초 timeout을 기본 10초 설정으로 교체했습니다.
- Gemini non-2xx는 502 Bad Gateway, timeout은 504 Gateway Timeout, 내부 응답 파싱 오류는 기존 500으로 분리했습니다.
- 외부 오류 응답 body 대신 status만 로그에 남기고 timeout 로그에는 설정값만 기록하도록 변경했습니다.
- JDK local HTTP server 기반 `AiServiceTest`로 정상, 502, 504, 내부 500 회귀 테스트를 추가했습니다.
- #182를 merged/Done으로 갱신하고 #184의 before/after 측정과 overengineering 경계를 문서화했습니다.

## 🔍 기술적 배경
- #182 mock 500 조건에서 43/43 요청이 일반 backend 500으로 전파되어 내부 오류와 외부 Gemini 장애를 구분할 수 없었습니다.
- 고정 90초 timeout에서는 15초 mock 지연이 사용자-facing 요청에 그대로 전파됐습니다.
- #182의 3초 정상 기준선보다 여유를 두되 장시간 대기를 제한하기 위해 10초를 기본 상한으로 선택했습니다.
- retry, circuit breaker, async queue, 본문 fallback은 현재 트래픽과 측정 근거 대비 과해 범위에서 제외했습니다.

## 🧪 테스트/검증 (필수)
- [x] `.\gradlew.bat test` - 전체 22건 통과
- [x] `node --check load-tests/mock-gemini-server.js`
- [x] 개선 전 mock 15초/1 VU/35초 - 3건 200, 평균 15.43초, p95 16.08초
- [x] 개선 후 동일 조건 - 4건 504, 평균 10.16초, p95 10.42초
- [x] mock 15초 단건 - backend 504, 약 10.04초
- [x] mock 500/200ms 단건 - backend 502, 약 0.31초
- [x] mock 3초 정상 단건 - backend 200, 약 3.09초
- [x] 테스트 기사 summary 원복 및 임시 DB table 제거
- [x] `git diff --check`

개선 전 long-delay run은 기존 p95 6초 threshold를, 개선 후 run은 p95와 HTTP failure threshold를 의도적으로 위반합니다. 성공률 개선이 아니라 대기 상한과 오류 분리가 검증 목적입니다.

## ✔️ 체크 리스트
- [x] Merge 대상이 `develop`인지 확인했습니다.
- [x] 변경과 docs 기록을 이슈 단위 단일 커밋으로 구성했습니다.
- [x] 정상 3초 mock 응답이 200으로 유지됨을 확인했습니다.
- [x] 실제 Gemini API를 호출하지 않았습니다.
- [x] API key, prompt, 기사 원문, 사용자 질문, 외부 오류 body가 diff와 로그에 포함되지 않았습니다.

## 💬 리뷰 요구사항(선택)
- 10초 기본 timeout이 #182의 정상 3초 기준선과 사용자-facing 요청 상한 사이에서 과하지 않은지 확인 부탁드립니다.
- Gemini non-2xx→502, timeout→504, 내부 파싱 오류→500 분리가 적절한지 확인 부탁드립니다.
- Reactor `timeout`과 `onErrorMap` 순서가 timeout을 504로 유지하고 다른 내부 오류를 500으로 처리하는지 확인 부탁드립니다.
- 외부 응답 body를 폐기하고 status/type만 기록하는 로그가 민감정보 관점에서 안전한지 확인 부탁드립니다.

## ➕ 추후 계획(선택)
- retry, circuit breaker, async queue, SSE/Trend Gemini 정책은 별도 근거와 승인 전까지 도입하지 않습니다.
