### PR TITLE
📊 [PERF/#186] Gemini 동기 호출 servlet thread 포화 측정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	//lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -75,7 +75,7 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ### P2 후속 후보. Gemini timeout 상한 및 upstream 오류 분리
 
-- 상태: `Verified` ([#184](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/184))
+- 상태: `Done` ([#184](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/184), [PR #185](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/185))
 - AS-IS: article summary의 Gemini 호출은 고정 90초 timeout을 사용하고 non-2xx, timeout, 내부 파싱 오류를 모두 backend 500으로 반환한다.
 - TO-BE: 10초 설정형 timeout으로 사용자 대기 상한을 줄이고, Gemini non-2xx는 502, timeout은 504, 내부 오류는 500으로 분리한다.
 - 검증 결과:
@@ -84,6 +84,20 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
   - mock 3초 정상 응답은 약 3.09초에 backend 200으로 유지됐다.
 - 범위 경계:
   - retry, circuit breaker, async queue, SSE/Trend Gemini 정책 변경은 현재 근거 대비 과해 제외한다.
+
+### P2 후속 후보. Gemini 동기 호출 servlet thread 포화 및 API 영향 측정
+
+- 상태: `Verified` ([#186](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/186))
+- AS-IS: #182에서 mock latency가 summary p95를 지배함을 확인했지만, 동기 `.block()` 호출이 servlet thread를 얼마나 점유하고 다른 조회 API 지연으로 전파되는지는 측정하지 않았다.
+- TO-BE: 로컬 Tomcat thread 수와 Gemini mock 3초 지연을 통제하고, summary VU 증가에 따른 RPS/p95/실패율, busy thread, 동시 `popular` API p95를 같은 실행 구간에서 측정한다.
+- 범위 경계:
+  - 실제 포화 근거를 확보하기 전에는 async, queue, retry, circuit breaker를 구현하지 않는다.
+  - 8GB 로컬 환경에서 `5 -> 10 -> 20 -> 50 VU` 순서로 진행하고 명확한 포화가 나타나면 다음 단계를 생략한다.
+- 검증 결과:
+  - 20 summary VU에서 Tomcat busy/current가 20/20에 도달했고 summary는 6.09 RPS, p95 3.23초였다.
+  - 같은 실행에서 `popular` p95는 대조군 154.46ms에서 2.86초로 약 18.5배 증가하고 RPS는 24.55에서 3.71로 감소했다.
+  - `popular` 내부 `dbQueryMs` 36~42ms, `totalMs` 68~76ms와 client p95 차이로 servlet thread 대기 전파를 확인했다.
+  - 20 VU에서 포화가 명확해 50 VU는 안전 중단 기준에 따라 생략했고, async 전후 비교를 별도 후속 후보로 남긴다.
 
 ## P2-1. 검색 API FULLTEXT 성능 기준선
 

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -56,10 +56,11 @@ Reviewer 이후 diff 변경을 피하기 위해 merge 후 `WORK_PROGRESS.md`만 
 - Active work override, 2026-07-13:
   - #180/#181 is merged and closed. The single-instance popular baseline concluded that 20 VU was stable at about 87 RPS and 50 VU was a saturation signal.
   - #182/#183 is merged and closed. Controlled 200ms/1s/3s and 500-response measurements established the Gemini mock baseline without real API cost.
-  - Current active work is #184 `[FIX] Gemini 요약 API timeout 상한 및 upstream 오류 분리` on branch `fix/#184-gemini-timeout-upstream-errors`.
-  - #184 replaces the fixed 90-second summary timeout with configurable 10 seconds and separates Gemini non-2xx as 502, timeout as 504, and internal parsing errors as 500.
-  - In the same 15-second mock condition, p95 changed from 16.08 seconds before to 10.42 seconds after; 3-second normal response remained 200 and mock 500 returned 502.
-  - Retry, circuit breaker, async queue, and SSE/Trend Gemini policy changes remain out of scope.
+  - #184/#185 is merged and closed. The fixed 90-second summary timeout was replaced with configurable 10 seconds, with Gemini non-2xx as 502, timeout as 504, and internal parsing errors as 500.
+  - Current active work is #186 `[PERF] Gemini 동기 호출 servlet thread 포화 및 API 영향 측정` on branch `perf/#186-gemini-thread-saturation`.
+  - #186 uses a local-only 20-thread Tomcat limit, 3-second Gemini mock, summary VU steps, and fixed popular load to measure the request-thread ceiling and cross-API p95 propagation.
+  - At 20 summary VUs, Tomcat reached 20/20 busy threads, summary throughput was 6.09 RPS, and concurrent popular p95 rose from the 154ms control to 2.86 seconds.
+  - 50 VU was skipped because the 20 VU run already met the safety stop rule. Async conversion remains out of #186 scope but now has evidence for a separate before/after issue.
 
 - Repo: `SKU-GlobalTimes/GlobalTimes_BeSide`
 - Base branch: `develop`
@@ -76,7 +77,7 @@ Reviewer 이후 diff 변경을 피하기 위해 merge 후 `WORK_PROGRESS.md`만 
 - #174/#175에서 주요 기사 조회 API 고부하 부하 테스트 및 DB 병목 기준선 수립을 완료했다.
 - #176/#177에서 `articles popular` 조회의 `Using filesort`를 k6 고부하 지표와 MySQL `EXPLAIN ANALYZE`로 확인하고, 현재 데이터 규모에서는 인덱스 추가를 보류했다.
 - #178/#179에서 로컬 부하 테스트 시 k6 결과, 애플리케이션 latency 로그, Docker 리소스 지표를 같은 실행 구간에 묶어 해석하는 runbook을 완료했다.
-- #180에서 주요 조회 API 단일 인스턴스 TPS 한계와 병목 지점을 정리 중이다.
+- #180/#181에서 주요 조회 API 단일 인스턴스 TPS 한계와 병목 지점 정리를 완료했다.
 
 ## Recent Completed Work
 
@@ -110,16 +111,18 @@ pure relevance-first는 wrong-context 기사를 끌어올릴 수 있어 바로 �
 현재 진행 중:
 
 ```text
-#180 [PERF] 주요 조회 API 단일 인스턴스 TPS 한계와 병목 지점 정리
+#186 [PERF] Gemini 동기 호출 servlet thread 포화 및 API 영향 측정
 ```
 
 목표:
 
-- 로컬 Docker 기반 단일 Spring Boot 인스턴스에서 `popular` 조회의 안정 처리량과 포화 신호 구간을 정리한다.
-- #178 runbook 기준으로 k6 RPS/p95/failure, 애플리케이션 `dbQueryMs`/`totalMs`, Docker/local resource 신호를 같은 실행 구간으로 해석한다.
-- 8GB 로컬 환경을 고려해 무리한 장시간/고 VU 테스트보다 `5 -> 10 -> 20 -> 50 VU` 점진 부하 결과를 우선 기록한다.
-- 운영 코드, DB schema/index, API 응답, Repository query, Redis/cache 정책, k6 script는 변경하지 않는다.
-- 이력서에 `단일 인스턴스 조회 API TPS 한계/포화 구간 측정`으로 압축 가능한 근거를 만든다.
+- 로컬 Tomcat request thread를 20개로 통제하고 Gemini mock 3초 지연에서 동기 `.block()` 경로의 포화 시점을 재현한다.
+- summary RPS/p95/failure와 Tomcat busy thread를 측정하고, 고정 5 VU `popular` 조회의 p95가 함께 상승하는지 확인한다.
+- 8GB 로컬 환경을 고려해 `5 -> 10 -> 20 -> 50 VU` 순서로 진행하고 명확한 포화가 나타나면 더 높은 단계를 생략한다.
+- async 구현은 #186 결과가 thread 포화와 다른 API 지연 전파를 함께 증명할 때 별도 Issue로 검토한다.
+
+현재 측정에서는 20 summary VU에서 busy thread가 20/20에 도달했고, summary는 6.09 RPS/p95 3.23초, 동시 popular는 대조군 p95 154ms에서 2.86초로 상승했다.
+따라서 #186 이후 후보는 같은 조건에서 servlet thread를 반환하는 최소 async 경계를 적용하고 busy thread, summary RPS/p95, popular p95를 before/after 비교하는 작업이다.
 
 다음 세션에서 새 후보를 고를 때는 먼저 develop 최신화, 열린 Issue/PR 확인, `WORK_PROGRESS.md`와 `BACKLOG.md` 확인을 다시 수행한다.
 #110은 사용자가 별도로 지시하기 전까지 다루지 않는다.

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -1542,7 +1542,8 @@ Reviewer 결과:
 ### #180 - 주요 조회 API 단일 인스턴스 TPS 한계와 병목 지점 정리
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/180
-- 상태: In Progress
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/181
+- 상태: merged
 - 작업 브랜치: `perf/#180-single-instance-tps-baseline`
 - 주요 파일:
   - `.gitignore`
@@ -1858,8 +1859,9 @@ Reviewer 필요성:
 ### #184 - Gemini 요약 API timeout 상한 및 upstream 오류 분리
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/184
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/185
 - 작업 브랜치: `fix/#184-gemini-timeout-upstream-errors`
-- 상태: Verified (PR 및 Reviewer 대기)
+- 상태: merged
 - 주요 파일:
   - `src/main/java/com/example/globalTimes_be/domain/ai/service/AiService.java`
   - `src/main/java/com/example/globalTimes_be/domain/detail/exception/DetailErrorStatus.java`
@@ -1903,6 +1905,62 @@ Overengineering 판단:
 Reviewer 필요성:
 
 - 운영 timeout 기본값과 HTTP 오류 응답이 변경되므로 Reviewer 검토가 필요하다.
+
+### #186 - Gemini 동기 호출 servlet thread 포화 및 API 영향 측정
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/186
+- 작업 브랜치: `perf/#186-gemini-thread-saturation`
+- 상태: In Progress
+- 주요 파일:
+  - `build.gradle`
+  - `src/main/resources/application.yml`
+  - `load-tests/k6/gemini-thread-saturation.js`
+  - `docs/backend-improvement/gemini-servlet-thread-saturation-baseline.md`
+
+목표:
+
+- Gemini 3초 동기 호출 중 servlet request thread가 점유되는 구조를 Tomcat thread metric과 k6 지표로 수치화한다.
+- summary 부하가 증가할 때 Tomcat request thread ceiling 도달과 동시 `popular` 조회 p95의 지연 전파를 같은 실행 구간에서 확인한다.
+
+Overengineering 판단:
+
+- async, queue, retry, circuit breaker를 바로 구현하지 않고 현재 동기 구조의 실제 포화 근거를 먼저 측정한다.
+- 로컬 Tomcat 최대 thread를 20개로 제한해 8GB 노트북에서 낮은 VU로 재현 가능한 실험을 구성한다.
+- Actuator web endpoint는 기본 노출하지 않고 로컬 부하 테스트 환경변수에서만 health/metrics endpoint를 노출한다.
+- Tomcat 세부 thread metric에 필요한 MBean registry도 로컬 실행 환경변수에서만 활성화한다.
+
+구현 및 검증 계획:
+
+- summary VU를 `5 -> 10 -> 20 -> 50`, `popular`는 5 VU로 고정한다.
+- k6에서 summary/popular 요청 수, p95, failure를 분리하고 `tomcat.threads.busy/current/config.max`를 함께 샘플링한다.
+- mock 3초 조건에서 summary 저장을 비활성화해 모든 요청이 외부 호출 경로를 타게 한다.
+- 명확한 포화가 나타나면 노트북 안전을 위해 다음 VU 단계를 생략할 수 있다.
+- 측정 후 async 적용 또는 보류 판단을 별도 후속 이슈 기준으로 남긴다.
+
+구현 및 검증 결과:
+
+- Spring Boot Actuator를 추가하고 기본 web exposure는 비워 두며, 로컬 환경변수에서만 health/metrics와 Tomcat MBean registry를 활성화한다.
+- `gemini-thread-saturation.js`에서 summary/popular 요청 수, RPS, p95, failure와 Tomcat busy/current/max thread를 같은 실행 구간에 기록한다.
+- popular-only 5 VU 대조군은 758건, 24.55 RPS, p95 154.46ms, busy peak 6/20이었다.
+- summary 5 VU는 50건/1.55 RPS/p95 3.30초, popular p95 199.10ms, busy peak 11/20이었다.
+- summary 10 VU는 100건/3.09 RPS/p95 3.20초, popular p95 170.39ms, busy peak 16/20이었다.
+- summary 20 VU는 200건/6.09 RPS/p95 3.23초, busy/current 20/20으로 포화됐다.
+- summary RPS는 `1.55 -> 3.09 -> 6.09`로 계속 증가했으므로 20 VU 이후 처리량 plateau 자체를 관측했다고 해석하지 않는다.
+- 같은 20 VU 실행에서 popular는 122건/3.71 RPS/p95 2.86초로, 대조군보다 p95가 약 18.5배 증가하고 RPS가 약 84.9% 감소했다. 실패율은 두 조건 모두 0.00%였다.
+- 20 VU 말미 popular 로그는 `dbQueryMs=36~42`, `totalMs=68~76`이어서 client p95 2.86초의 대부분은 DB 쿼리보다 servlet thread 대기로 해석한다.
+- MySQL/Redis의 측정 직후 point-in-time CPU는 약 1.09%/0.75%, 메모리는 약 472.7MiB/11.51MiB였고 Spring Boot working set은 약 510MiB였다.
+- 20 VU에서 포화와 다른 API 지연 전파가 이미 명확해 50 VU는 안전 중단 기준에 따라 생략했다.
+- 테스트 기사 7366 summary는 측정 전 백업하고 기존 길이 420으로 복원했으며 임시 백업 테이블과 mock/backend 프로세스를 정리했다.
+
+판단:
+
+- async가 Gemini 자체의 3초 응답을 줄이지는 않지만, servlet thread 점유와 다른 API queueing을 줄일 수 있는 비교 근거가 생겼다.
+- 후속 이슈는 동일한 20-thread/3-second mock/20 summary VU/5 popular VU 조건에서 최소 async 경계의 before/after만 검증한다.
+- 실제 Gemini 처리량, 운영 SLA, 멀티 인스턴스 capacity로 일반화하지 않는다.
+
+Reviewer 필요성:
+
+- runtime dependency, metrics 노출 설정, k6 스크립트가 변경되므로 Reviewer 검토가 필요하다.
 
 ---
 

--- a/docs/backend-improvement/gemini-servlet-thread-saturation-baseline.md
+++ b/docs/backend-improvement/gemini-servlet-thread-saturation-baseline.md
@@ -1,0 +1,182 @@
+# Gemini servlet thread saturation baseline
+
+## Purpose
+
+This document measures how the synchronous Gemini summary path affects servlet thread availability and an unrelated article read API.
+
+The target is not a production capacity claim. The experiment deliberately limits one local Spring Boot instance to 20 Tomcat request threads so an 8GB laptop can reproduce saturation with controlled load.
+
+## Overengineering Guardrail
+
+This issue measures before changing the execution model.
+
+Included:
+
+- local Gemini mock with a fixed 3-second response delay
+- summary VU steps of 5, 10, 20, and 50
+- a fixed 5 VU `popular` read workload in the same run window
+- Tomcat busy/current/max thread metrics
+- k6 RPS, p95, and failure rate
+- local application and Docker resource signals
+
+Excluded:
+
+- async conversion
+- retry, circuit breaker, queue, or bulkhead libraries
+- real Gemini load traffic
+- production thread-pool tuning
+- multi-instance or Kubernetes scaling
+
+Async conversion remains a separate candidate and requires measured thread saturation or cross-API latency propagation from this issue.
+
+## Controlled Environment
+
+| Item | Value |
+| --- | --- |
+| Application | local Spring Boot, one instance |
+| DB/cache | local Docker MySQL and Redis |
+| Gemini | Node mock server on port 9090 |
+| Mock delay | 3,000ms |
+| Tomcat max threads | 20, local run override only |
+| Tomcat MBean registry | enabled for the local run only |
+| Summary persistence | disabled for the run |
+| Load generator | local k6 |
+| Summary VUs | 5 -> 10 -> 20 -> 50 |
+| Popular VUs | fixed at 5 |
+
+The theoretical summary-only upper bound is approximately:
+
+```text
+20 request threads / 3 seconds per external call = 6.7 requests/second
+```
+
+This is only a hypothesis. DB lookup, request queueing, JSON processing, metric polling, and local resource contention can lower the measured result.
+
+## Local-only Metrics Exposure
+
+Actuator web endpoints are not exposed by default. The load-test process explicitly enables `health` and `metrics`:
+
+```powershell
+$env:MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE = "health,metrics"
+$env:SERVER_TOMCAT_THREADS_MAX = "20"
+$env:SERVER_TOMCAT_MBEANREGISTRY_ENABLED = "true"
+```
+
+The k6 script samples:
+
+- `tomcat.threads.busy`
+- `tomcat.threads.current`
+- `tomcat.threads.config.max`
+
+Production API behavior, response bodies, DB schema, and query logic remain unchanged.
+
+## Run Commands
+
+Mock Gemini:
+
+```powershell
+$env:MOCK_GEMINI_DELAY_MS = "3000"
+$env:MOCK_GEMINI_STATUS = "200"
+node .\load-tests\mock-gemini-server.js
+```
+
+Application:
+
+```powershell
+$env:GEMINI_BASE_URL = "http://localhost:9090"
+$env:GEMINI_API_KEY = "local-mock-key"
+$env:AI_SUMMARY_SAVE_ENABLED = "false"
+$env:SERVER_TOMCAT_THREADS_MAX = "20"
+$env:SERVER_TOMCAT_MBEANREGISTRY_ENABLED = "true"
+$env:MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE = "health,metrics"
+.\gradlew.bat bootRun --console=plain
+```
+
+k6 shared settings:
+
+```powershell
+$env:BASE_URL = "http://localhost:8080"
+$env:ARTICLE_ID = "7366"
+$env:DURATION = "30s"
+$env:POPULAR_VUS = "5"
+$env:SUMMARY_SLEEP_SECONDS = "0.1"
+$env:POPULAR_SLEEP_SECONDS = "0.1"
+```
+
+Run a `SUMMARY_VUS=0` popular-only control first, then change only `SUMMARY_VUS` between 5, 10, 20, and 50.
+
+```powershell
+$env:SUMMARY_VUS = "5"
+k6 run .\load-tests\k6\gemini-thread-saturation.js
+```
+
+## Safety Stop Rules
+
+Stop before the next VU step when any of the following occurs:
+
+- the laptop becomes persistently unresponsive
+- application or k6 processes keep growing in memory after a run
+- repeated connection failures prevent controlled comparison
+- 20 VU already shows sustained 20/20 busy threads and severe popular API queueing
+
+Do not run the 50 VU step only to produce a larger request count when saturation is already clear.
+
+## Results
+
+| Summary VUs | Summary requests | Summary RPS | Summary p95 | Summary failure | Popular requests | Popular RPS | Popular p95 | Popular failure | Busy threads peak | Interpretation |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 0 (control) | 0 | 0 | - | - | 758 | 24.55/s | 154.46ms | 0.00% | 6/20 | popular-only control |
+| 5 | 50 | 1.55/s | 3.30s | 0.00% | 703 | 21.76/s | 199.10ms | 0.00% | 11/20 | no saturation; summary throughput scales with VU |
+| 10 | 100 | 3.09/s | 3.20s | 0.00% | 740 | 22.84/s | 170.39ms | 0.00% | 16/20 | below the configured thread limit |
+| 20 | 200 | 6.09/s | 3.23s | 0.00% | 122 | 3.71/s | 2.86s | 0.00% | 20/20 | saturated; popular queued behind summary calls |
+| 50 | skipped | - | - | - | - | - | - | - | - | 20 VU already met the safety stop rule |
+
+The 20 VU summary RPS of `6.09/s` was close to the `6.7/s` theoretical upper bound. Increasing from 10 to 20 summary VUs raised throughput from `3.09/s` to `6.09/s`, but it also consumed all configured request threads.
+
+Compared with the popular-only control, the 20 VU mixed run changed the unrelated popular API as follows:
+
+```text
+popular p95: 154.46ms -> 2,861.78ms (about 18.5x)
+popular RPS: 24.55/s -> 3.71/s (about 84.9% lower)
+failure:     0.00% -> 0.00%
+```
+
+This was latency and throughput saturation rather than an availability failure.
+
+## Application and Resource Signals
+
+Samples from the end of the 20 VU run showed:
+
+```text
+[ArticlesPopular] dbQueryMs=36~42 totalMs=68~76
+[AiSummary] aiSummaryMs=3003~3028 totalMs=3030~3245
+```
+
+The popular service-side `totalMs` remained tens of milliseconds while its client-side p95 reached 2.86 seconds. Most of the added latency therefore occurred before controller processing, consistent with waiting for an available servlet request thread rather than a slow popular DB query.
+
+Point-in-time resource samples after the saturated run:
+
+| Resource | Signal |
+| --- | --- |
+| MySQL | about 1.09% CPU, 472.7MiB |
+| Redis | about 0.75% CPU, 11.51MiB |
+| Spring Boot process | about 510MiB working set |
+
+These snapshots did not show DB/container memory pressure. They are local observations, not production capacity metrics.
+
+## Decision Rule
+
+Async is justified for a follow-up comparison only when the same run shows both:
+
+1. Tomcat busy threads reach the configured maximum while synchronous summary calls occupy the request pool
+2. the unrelated `popular` API p95 increases materially despite its DB query remaining inexpensive
+
+Both signals appeared at 20 summary VUs. Summary RPS still increased almost linearly from `1.55/s` to `3.09/s` to `6.09/s`, so this run did not directly observe a throughput plateau beyond the ceiling. It observed 20/20 request-thread occupancy and cross-API queueing; additional load would be required to measure the actual post-ceiling throughput shape. A separate follow-up issue may therefore compare the current synchronous path with a minimal async boundary under the same 20-thread, 3-second mock, and mixed popular-load conditions.
+
+This issue does not claim that async will reduce Gemini's own 3-second latency. The expected improvement is reduced servlet thread occupancy and less cross-API queueing.
+
+## Portfolio Wording Candidate
+
+```text
+Gemini 3초 동기 호출 부하 테스트에서 Tomcat request thread가 20/20 ceiling에 도달하고 일반 조회 API p95가 154ms에서 2.86초로 증가하는 지연 전파를 수치화했습니다.
+```

--- a/load-tests/k6/gemini-thread-saturation.js
+++ b/load-tests/k6/gemini-thread-saturation.js
@@ -1,0 +1,121 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Counter, Gauge, Rate, Trend } from 'k6/metrics';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const ARTICLE_ID = __ENV.ARTICLE_ID || '7366';
+const LANGUAGE = __ENV.LANGUAGE || 'English';
+const DURATION = __ENV.DURATION || '30s';
+const SUMMARY_SLEEP_SECONDS = Number(__ENV.SUMMARY_SLEEP_SECONDS || 0.1);
+const POPULAR_SLEEP_SECONDS = Number(__ENV.POPULAR_SLEEP_SECONDS || 0.1);
+const METRICS_SLEEP_SECONDS = Number(__ENV.METRICS_SLEEP_SECONDS || 1);
+const SUMMARY_VUS = Number(__ENV.SUMMARY_VUS || 5);
+const POPULAR_VUS = Number(__ENV.POPULAR_VUS || 5);
+
+export const summaryRequests = new Counter('summary_requests');
+export const summaryFailures = new Rate('summary_failures');
+export const summaryDuration = new Trend('summary_duration', true);
+export const popularRequests = new Counter('popular_requests');
+export const popularFailures = new Rate('popular_failures');
+export const popularDuration = new Trend('popular_duration', true);
+export const tomcatThreadsBusy = new Gauge('tomcat_threads_busy');
+export const tomcatThreadsCurrent = new Gauge('tomcat_threads_current');
+export const tomcatThreadsMax = new Gauge('tomcat_threads_max');
+export const metricsFailures = new Rate('thread_metrics_failures');
+
+const scenarios = {
+  popular_noise: {
+    executor: 'constant-vus',
+    exec: 'popularNoise',
+    vus: POPULAR_VUS,
+    duration: DURATION,
+    gracefulStop: '5s',
+  },
+  thread_metrics: {
+    executor: 'constant-vus',
+    exec: 'threadMetrics',
+    vus: 1,
+    duration: DURATION,
+    gracefulStop: '5s',
+  },
+};
+
+if (SUMMARY_VUS > 0) {
+  scenarios.summary_load = {
+    executor: 'constant-vus',
+    exec: 'summaryLoad',
+    vus: SUMMARY_VUS,
+    duration: DURATION,
+    gracefulStop: '5s',
+  };
+}
+
+export const options = {
+  scenarios,
+  thresholds: {
+    summary_failures: ['rate<0.05'],
+    popular_failures: ['rate<0.05'],
+    thread_metrics_failures: ['rate<0.05'],
+    'http_req_duration{endpoint:summary}': ['p(95)<15000'],
+    'http_req_duration{endpoint:popular}': ['p(95)<5000'],
+  },
+};
+
+function metricValue(name) {
+  const res = http.get(`${BASE_URL}/actuator/metrics/${name}`, {
+    tags: { api: 'thread_saturation', endpoint: 'thread_metrics', metric: name },
+  });
+
+  let value = null;
+  try {
+    const body = res.json();
+    value = body && body.measurements && body.measurements.length > 0
+      ? Number(body.measurements[0].value)
+      : null;
+  } catch (e) {
+    value = null;
+  }
+
+  const failed = res.status !== 200 || value === null || Number.isNaN(value);
+  metricsFailures.add(failed, { metric: name });
+  check(res, { [`${name} metric is available`]: () => !failed });
+  return failed ? null : value;
+}
+
+export function summaryLoad() {
+  const res = http.get(
+    `${BASE_URL}/api/ai/${encodeURIComponent(ARTICLE_ID)}/summary?language=${encodeURIComponent(LANGUAGE)}`,
+    { tags: { api: 'thread_saturation', endpoint: 'summary' } },
+  );
+
+  const failed = res.status !== 200;
+  summaryRequests.add(1);
+  summaryFailures.add(failed);
+  summaryDuration.add(res.timings.duration);
+  check(res, { 'summary status is 200': () => !failed });
+  sleep(SUMMARY_SLEEP_SECONDS);
+}
+
+export function popularNoise() {
+  const res = http.get(`${BASE_URL}/api/articles/popular?page=0&size=20`, {
+    tags: { api: 'thread_saturation', endpoint: 'popular' },
+  });
+
+  const failed = res.status !== 200;
+  popularRequests.add(1);
+  popularFailures.add(failed);
+  popularDuration.add(res.timings.duration);
+  check(res, { 'popular status is 200': () => !failed });
+  sleep(POPULAR_SLEEP_SECONDS);
+}
+
+export function threadMetrics() {
+  const busy = metricValue('tomcat.threads.busy');
+  const current = metricValue('tomcat.threads.current');
+  const max = metricValue('tomcat.threads.config.max');
+
+  if (busy !== null) tomcatThreadsBusy.add(busy);
+  if (current !== null) tomcatThreadsCurrent.add(current);
+  if (max !== null) tomcatThreadsMax.add(max);
+  sleep(METRICS_SLEEP_SECONDS);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,3 +75,12 @@ trend:
 ai:
   context-window-size: 10
   summary-save-enabled: ${AI_SUMMARY_SAVE_ENABLED:true}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: ${MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE:}
+  endpoint:
+    health:
+      show-details: never


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #186

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- Spring Boot Actuator를 추가하되 web endpoint는 기본 노출하지 않고 로컬 환경변수에서만 health/metrics를 노출하도록 구성했습니다.
- Gemini summary와 popular 조회를 동시에 호출하고 Tomcat busy/current/max thread를 함께 수집하는 k6 시나리오를 추가했습니다.
- 20-thread/3초 mock 조건에서 popular-only 대조군과 summary 5/10/20 VU를 측정하고 결과를 backend improvement 문서에 기록했습니다.
- #184/#185 merged 상태와 #186 Verified 상태를 handoff 문서에 같은 커밋으로 반영했습니다.

## 🔍 기술적 배경
- 현재 일반 summary API는 WebClient 호출 마지막의 `.block()`으로 Gemini 응답을 기다리는 동안 servlet request thread를 점유합니다.
- 20 summary VU에서 Tomcat busy/current가 20/20에 도달했고 summary 처리량은 이론 상한 6.7 RPS에 가까운 6.09 RPS였습니다.
- 같은 실행에서 popular p95는 대조군 154.46ms에서 2.86초로 약 18.5배 증가하고 RPS는 24.55에서 3.71로 감소했습니다.
- popular 내부 로그는 `dbQueryMs=36~42`, `totalMs=68~76`이어서 client 지연 대부분을 DB 쿼리보다 servlet thread 대기로 해석했습니다.
- 20 VU에서 포화가 명확해 50 VU는 8GB 노트북 안전 중단 기준에 따라 생략했습니다.

## 🧪 테스트/검증 (필수)
- [x] `./gradlew test` 전체 22개 통과
- [x] `k6 inspect -e SUMMARY_VUS=0 load-tests/k6/gemini-thread-saturation.js`
- [x] `k6 inspect -e SUMMARY_VUS=20 -e POPULAR_VUS=5 load-tests/k6/gemini-thread-saturation.js`
- [x] popular-only 5 VU: 758건, 24.55 RPS, p95 154.46ms, failure 0.00%, busy peak 6/20
- [x] summary 5 VU: 50건, 1.55 RPS, p95 3.30초, failure 0.00%, busy peak 11/20
- [x] summary 10 VU: 100건, 3.09 RPS, p95 3.20초, failure 0.00%, busy peak 16/20
- [x] summary 20 VU: 200건, 6.09 RPS, p95 3.23초, failure 0.00%, busy/current 20/20
- [x] 테스트 기사 summary 복원 및 임시 DB table/mock/backend 프로세스 정리
- [x] `git diff --check`

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop` 대상)
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 기존 운영 API 응답, DB schema/query, Redis/cache 정책을 변경하지 않았는가?

## 📸 스크린샷 (선택)
- 해당 없음

## 💬 리뷰 요구사항(선택)
- Actuator endpoint가 기본 노출되지 않고 로컬 환경변수에서만 health/metrics가 열리는지 확인해주세요.
- k6의 summary 0 VU 대조군, summary/popular 분리 지표, Tomcat metric 수집 방식이 비교 목적에 맞는지 확인해주세요.
- 20 VU 결과로 servlet thread 포화와 popular 지연 전파를 해석한 근거가 과장되지 않았는지 확인해주세요.
- API key, prompt, 기사/응답 전문 및 로컬 runtime artifact가 diff에 포함되지 않았는지 확인해주세요.

## ➕ 추후 계획(선택)
- 동일한 20-thread/3초 mock/20 summary VU/5 popular VU 조건에서 최소 async 경계 적용 전후를 별도 Issue로 비교합니다.
- async가 Gemini 자체 3초 지연을 줄인다고 주장하지 않고 servlet thread 점유와 cross-API queueing 개선 여부만 검증합니다.
