### PR TITLE
📊 [PERF/#188] Gemini summary Servlet async 전후 비교

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -87,7 +87,7 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ### P2 후속 후보. Gemini 동기 호출 servlet thread 포화 및 API 영향 측정
 
-- 상태: `Verified` ([#186](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/186))
+- 상태: `Done` ([#186](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/186), [PR #187](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/187))
 - AS-IS: #182에서 mock latency가 summary p95를 지배함을 확인했지만, 동기 `.block()` 호출이 servlet thread를 얼마나 점유하고 다른 조회 API 지연으로 전파되는지는 측정하지 않았다.
 - TO-BE: 로컬 Tomcat thread 수와 Gemini mock 3초 지연을 통제하고, summary VU 증가에 따른 RPS/p95/실패율, busy thread, 동시 `popular` API p95를 같은 실행 구간에서 측정한다.
 - 범위 경계:
@@ -98,6 +98,19 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
   - 같은 실행에서 `popular` p95는 대조군 154.46ms에서 2.86초로 약 18.5배 증가하고 RPS는 24.55에서 3.71로 감소했다.
   - `popular` 내부 `dbQueryMs` 36~42ms, `totalMs` 68~76ms와 client p95 차이로 servlet thread 대기 전파를 확인했다.
   - 20 VU에서 포화가 명확해 50 VU는 안전 중단 기준에 따라 생략했고, async 전후 비교를 별도 후속 후보로 남긴다.
+
+### P2 후속 후보. Gemini summary Servlet async 전환 전후 비교
+
+- 상태: `Done` ([#188](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/188), [PR #189](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/189))
+- AS-IS: 동기 20 VU에서 Tomcat thread 20/20과 popular 지연 전파를 확인했지만, 별도 worker 격리가 실제로 다른 API를 보호하는지는 검증하지 않았다.
+- TO-BE: 동기 50 VU 기준선을 추가하고 `WebAsyncTask + bounded executor` 적용 후 20/50 VU를 같은 조건에서 비교한다.
+- 검증 결과:
+  - 동기 50 VU는 summary 6.28 RPS/p95 8.98초, popular 0.91 RPS/p95 5.97초, Tomcat busy 20/20이었다.
+  - async 50 VU는 summary 6.29 RPS/p95 9.15초로 비슷했지만 popular는 22.40 RPS/p95 172.98ms, Tomcat busy peak 8/20으로 회복했다.
+  - async executor는 active 20, queue peak 30이어서 병목 제거가 아니라 bounded pool 격리임을 확인했다.
+  - mock 500은 502, MVC async timeout과 executor rejection은 503, 내부 오류는 500으로 분리한다.
+- 범위 경계:
+  - 전면 WebFlux, Kafka, retry/circuit breaker, SSE/ask/Trend 변경은 현재 근거 대비 과해 제외한다.
 
 ## P2-1. 검색 API FULLTEXT 성능 기준선
 

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -57,10 +57,10 @@ Reviewer 이후 diff 변경을 피하기 위해 merge 후 `WORK_PROGRESS.md`만 
   - #180/#181 is merged and closed. The single-instance popular baseline concluded that 20 VU was stable at about 87 RPS and 50 VU was a saturation signal.
   - #182/#183 is merged and closed. Controlled 200ms/1s/3s and 500-response measurements established the Gemini mock baseline without real API cost.
   - #184/#185 is merged and closed. The fixed 90-second summary timeout was replaced with configurable 10 seconds, with Gemini non-2xx as 502, timeout as 504, and internal parsing errors as 500.
-  - Current active work is #186 `[PERF] Gemini 동기 호출 servlet thread 포화 및 API 영향 측정` on branch `perf/#186-gemini-thread-saturation`.
-  - #186 uses a local-only 20-thread Tomcat limit, 3-second Gemini mock, summary VU steps, and fixed popular load to measure the request-thread ceiling and cross-API p95 propagation.
-  - At 20 summary VUs, Tomcat reached 20/20 busy threads, summary throughput was 6.09 RPS, and concurrent popular p95 rose from the 154ms control to 2.86 seconds.
-  - 50 VU was skipped because the 20 VU run already met the safety stop rule. Async conversion remains out of #186 scope but now has evidence for a separate before/after issue.
+  - #186/#187 is merged and closed. At 20 summary VUs, Tomcat reached 20/20 busy threads and concurrent popular p95 rose from the 154ms control to 2.86 seconds.
+  - #188/#189 is merged and closed. It added a synchronous 50 VU baseline and a `WebAsyncTask + bounded executor` comparison at 20/50 VU.
+  - At 50 VU, popular p95 changed from 5.97 seconds synchronous to 173ms async while summary stayed near 6.29 RPS and 9 seconds p95.
+  - Tomcat busy peak changed from 20 to 8; the async executor reached 20 active and 30 queued, so the bottleneck was isolated rather than removed.
 
 - Repo: `SKU-GlobalTimes/GlobalTimes_BeSide`
 - Base branch: `develop`
@@ -108,29 +108,25 @@ pure relevance-first는 wrong-context 기사를 끌어올릴 수 있어 바로 �
 
 ## Recommended Next Backend Issue
 
-현재 진행 중:
+현재 진행 중인 backend improvement Issue는 없다.
 
 ```text
-#186 [PERF] Gemini 동기 호출 servlet thread 포화 및 API 영향 측정
+다음 후보는 develop 최신화와 열린 Issue/PR 재확인 후 선정
 ```
 
-목표:
+최근 완료:
 
-- 로컬 Tomcat request thread를 20개로 통제하고 Gemini mock 3초 지연에서 동기 `.block()` 경로의 포화 시점을 재현한다.
-- summary RPS/p95/failure와 Tomcat busy thread를 측정하고, 고정 5 VU `popular` 조회의 p95가 함께 상승하는지 확인한다.
-- 8GB 로컬 환경을 고려해 `5 -> 10 -> 20 -> 50 VU` 순서로 진행하고 명확한 포화가 나타나면 더 높은 단계를 생략한다.
-- async 구현은 #186 결과가 thread 포화와 다른 API 지연 전파를 함께 증명할 때 별도 Issue로 검토한다.
+- 동기 50 VU에서 실제 post-ceiling RPS/p95와 popular 지연 전파를 측정한다.
+- `WebAsyncTask + bounded executor`로 summary blocking 작업을 격리하고 같은 20/50 VU 조건을 비교한다.
+- Tomcat busy와 executor active/queued를 함께 기록해 병목 제거와 격리를 구분한다.
+- API 응답 의미를 유지하고 timeout/rejection overload는 503으로 분리한다.
 
-현재 측정에서는 20 summary VU에서 busy thread가 20/20에 도달했고, summary는 6.09 RPS/p95 3.23초, 동시 popular는 대조군 p95 154ms에서 2.86초로 상승했다.
-따라서 #186 이후 후보는 같은 조건에서 servlet thread를 반환하는 최소 async 경계를 적용하고 busy thread, summary RPS/p95, popular p95를 before/after 비교하는 작업이다.
+현재 측정에서는 async 50 VU에서 summary 자체 처리량/p95는 개선되지 않았지만 popular p95가 5.97초에서 173ms로 감소했고 Tomcat busy peak가 20에서 8로 줄었다.
+executor active 20/queued 30을 함께 기록했으므로 완전한 non-blocking 또는 병목 제거로 과장하지 않는다.
 
 다음 세션에서 새 후보를 고를 때는 먼저 develop 최신화, 열린 Issue/PR 확인, `WORK_PROGRESS.md`와 `BACKLOG.md` 확인을 다시 수행한다.
 #110은 사용자가 별도로 지시하기 전까지 다루지 않는다.
 #162 guardrail에 따라 "지금 구현하면 과한가?"를 먼저 판단한다.
-#180은 운영 코드 변경 없이 측정 결과와 판단 기준을 남기는 범위다.
-현재 측정에서는 `popular` 20 VU에서 약 87 RPS, p95 약 105ms, failure 0.00%였고, 50 VU에서는 약 86 RPS로 처리량이 늘지 않은 채 p95가 약 456ms로 상승했다.
-따라서 20 VU 구간을 이 로컬 환경의 안정 baseline으로 보고, 50 VU 구간은 단일 인스턴스 포화 신호로 해석한다.
-다음 후속 후보로 `[PERF] AI 질의응답 Gemini 외부 호출 mock latency 부하 테스트`를 검토한다.
 
 #164 ADR 기준상 hybrid ranking code experiment는 아래 조건이 준비된 뒤 별도 Issue로 검토한다.
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -1909,8 +1909,9 @@ Reviewer 필요성:
 ### #186 - Gemini 동기 호출 servlet thread 포화 및 API 영향 측정
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/186
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/187
 - 작업 브랜치: `perf/#186-gemini-thread-saturation`
-- 상태: In Progress
+- 상태: Merged
 - 주요 파일:
   - `build.gradle`
   - `src/main/resources/application.yml`
@@ -1961,6 +1962,58 @@ Overengineering 판단:
 Reviewer 필요성:
 
 - runtime dependency, metrics 노출 설정, k6 스크립트가 변경되므로 Reviewer 검토가 필요하다.
+
+### #188 - Gemini summary Servlet async 전환 전후 thread 점유 비교
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/188
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/189
+- 작업 브랜치: `perf/#188-gemini-servlet-async-comparison`
+- 상태: Merged
+- 주요 파일:
+  - `src/main/java/com/example/globalTimes_be/global/config/AiSummaryAsyncConfig.java`
+  - `src/main/java/com/example/globalTimes_be/domain/ai/controller/AiController.java`
+  - `src/main/java/com/example/globalTimes_be/global/exception/GlobalErrorHandler.java`
+  - `load-tests/k6/gemini-thread-saturation.js`
+  - `docs/backend-improvement/gemini-servlet-async-comparison.md`
+
+목표:
+
+- #186의 20/20 Tomcat thread ceiling과 popular queueing 근거를 실제 async before/after 결과로 연결한다.
+- async가 Gemini 자체 latency를 줄이는지보다 unrelated API의 request-thread availability를 보호하는지 검증한다.
+
+Overengineering 판단:
+
+- 전면 WebFlux나 Kafka보다 기존 MVC/JPA 흐름을 유지하는 `WebAsyncTask + bounded executor`를 최소 변경으로 선택한다.
+- blocking work는 제거되지 않고 전용 worker로 이동하므로 executor active/queued metric을 함께 기록한다.
+- 50 VU는 20-thread ceiling 이후 처리량 shape와 async 격리 효과를 비교하는 근거로만 사용한다.
+
+구현:
+
+- summary API는 기존 orchestration을 `aiSummaryExecutor`에서 실행하는 `WebAsyncTask`를 반환한다.
+- executor 기본값은 core/max 20, queue 100이며 모두 환경변수로 조정 가능하다.
+- MVC async timeout 기본값은 15초다.
+- executor rejection과 timeout interruption은 503, Gemini non-2xx는 502, Gemini timeout은 504, 내부 오류는 500을 유지한다.
+- k6는 `executor.active`, `executor.queued`, `executor.pool.size`를 Tomcat metric과 함께 수집한다.
+
+검증:
+
+- 동기 50 VU는 summary 220건/6.28 RPS/p95 8.98초, popular 32건/0.91 RPS/p95 5.97초, Tomcat busy 20/20이었다.
+- async 20 VU는 summary 6.12 RPS/p95 3.39초, popular 23.38 RPS/p95 160.99ms, Tomcat busy peak 6, executor active 20/queued 0이었다.
+- async 50 VU는 summary 220건/6.29 RPS/p95 9.15초, popular 784건/22.40 RPS/p95 172.98ms, Tomcat busy peak 8이었다.
+- async 50 VU executor는 active 20/queued 30으로, 병목이 제거되지 않고 bounded pool로 격리됐음을 확인했다.
+- mock 500은 async dispatch에서도 502를 유지했고, local 1초 MVC async timeout은 약 1.81초에 503을 반환했다.
+- 전체 Gradle test에 controller defer, task rejection 503, interruption 503, unexpected 500 회귀 테스트를 포함한다.
+- 테스트 기사 summary는 기존 길이 420으로 복원했고 임시 table 및 backend/mock 프로세스를 제거했다.
+
+판단:
+
+- 50 VU에서 popular p95가 약 97.1% 감소하고 RPS가 약 24.5배로 회복해 Servlet request-thread 격리 효과가 확인됐다.
+- summary 자체 capacity/latency는 개선되지 않았으므로 외부 API 성능 개선 또는 완전한 non-blocking 처리로 표현하지 않는다.
+- queue peak 30과 503 overload 정책을 남겼으며 Kafka/WebFlux 도입은 별도 요구가 생기기 전까지 보류한다.
+
+Reviewer 필요성:
+
+- API 실행 방식, executor/timeout 설정, 503 오류 정책, k6 계측이 변경되므로 Reviewer 검토가 필요하다.
 
 ---
 

--- a/docs/backend-improvement/gemini-servlet-async-comparison.md
+++ b/docs/backend-improvement/gemini-servlet-async-comparison.md
@@ -1,0 +1,133 @@
+# Gemini Servlet async before/after comparison
+
+## Purpose
+
+This document compares the synchronous article summary path from #186 with a minimal Spring MVC asynchronous request boundary.
+
+The goal is not to reduce the controlled 3-second Gemini latency. The goal is to release Tomcat request threads while the blocking summary orchestration runs on a dedicated bounded executor, then measure whether an unrelated `popular` API remains responsive.
+
+## Overengineering Guardrail
+
+The implementation deliberately stops before a full reactive or messaging architecture.
+
+Chosen:
+
+- Spring MVC `WebAsyncTask`
+- dedicated `ThreadPoolTaskExecutor`
+- fixed and configurable worker/queue limits
+- 503 response for executor rejection or MVC async timeout
+- Tomcat and executor metrics in the same k6 run
+
+Not chosen:
+
+- end-to-end WebFlux/Reactor conversion
+- Kafka or another message queue
+- retry or circuit breaker
+- API job ID/polling contract
+- SSE/ask/Trend path changes
+
+The current JPA and WebClient `.block()` work still occupies an `ai-summary-*` worker. This is Servlet thread isolation, not non-blocking I/O.
+
+## Implementation
+
+The summary controller now returns:
+
+```text
+WebAsyncTask<ResponseEntity<ApiResponse>>
+```
+
+The existing summary orchestration is executed by `aiSummaryExecutor`:
+
+| Setting | Default |
+| --- | ---: |
+| core pool size | 20 |
+| max pool size | 20 |
+| queue capacity | 100 |
+| MVC async timeout | 15,000ms |
+
+All values can be overridden with environment variables. The pool and queue are bounded so async traffic cannot create unbounded threads.
+
+The k6 script records:
+
+- summary/popular request count, RPS, p95, and failure rate
+- Tomcat busy/current/max threads
+- async executor active/queued/pool size
+
+## Environment
+
+| Item | Value |
+| --- | --- |
+| Application | one local Spring Boot instance |
+| Tomcat max threads | 20, local override |
+| Async executor | 20 workers, queue capacity 100 |
+| Gemini | local mock, fixed 3-second delay |
+| DB/cache | Docker MySQL and Redis |
+| Summary persistence | disabled for the run |
+| Popular load | fixed 5 VU |
+| Duration | 30 seconds plus graceful stop |
+
+The test article had its summary backed up and cleared for each run so every summary request used the mock Gemini path.
+
+## Results
+
+### 20 Summary VUs
+
+| Mode | Summary RPS | Summary p95 | Popular RPS | Popular p95 | Failure | Tomcat busy peak | Executor active/queued |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| synchronous (#186) | 6.09/s | 3.23s | 3.71/s | 2.86s | 0.00% | 20/20 | - |
+| Servlet async | 6.12/s | 3.39s | 23.38/s | 160.99ms | 0.00% | 6/20 | 20/0 |
+
+Interpretation:
+
+- summary throughput and latency remained effectively similar
+- popular p95 decreased by about 94.4%
+- popular RPS increased by about 6.3 times
+- Tomcat busy peak decreased from 20 to 6
+- all 20 async workers were active, with no queue at this VU level
+
+### 50 Summary VUs
+
+| Mode | Summary requests | Summary RPS | Summary p95 | Popular requests | Popular RPS | Popular p95 | Failure | Tomcat busy peak | Executor active/queued |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| synchronous | 220 | 6.28/s | 8.98s | 32 | 0.91/s | 5.97s | 0.00% | 20/20 | - |
+| Servlet async | 220 | 6.29/s | 9.15s | 784 | 22.40/s | 172.98ms | 0.00% | 8/20 | 20/30 |
+
+Both 50 VU runs ended with 10 interrupted iterations during the 5-second graceful-stop window.
+
+Interpretation:
+
+- synchronous 50 VU directly showed the post-ceiling shape: summary RPS stayed near 6.28/s while p95 increased to 8.98 seconds
+- async did not improve summary throughput or queueing latency; p95 remained about 9.15 seconds
+- popular p95 decreased by about 97.1%
+- popular RPS increased by about 24.5 times
+- Tomcat busy peak decreased from 20 to 8
+- executor active reached 20 and queue reached 30, proving that the bottleneck was isolated rather than removed
+
+## Error and Cleanup Verification
+
+- mock Gemini 500 still returned backend 502 through async dispatch
+- a local 1-second MVC async timeout with a 3-second mock returned backend 503 in about 1.81 seconds
+- executor rejection is mapped to the same 503 response
+- unexpected internal exceptions remain backend 500
+- full Gradle tests passed after the async and error-handler changes
+- article 7366 summary was restored to its original 420-character value
+- temporary backup table and local backend/mock processes were removed
+
+## Decision
+
+The minimal Servlet async boundary is justified for the current MVC/JPA architecture because it protects unrelated request traffic without changing the summary response contract.
+
+The result must be described accurately:
+
+- improved: Tomcat request-thread availability and cross-API isolation
+- unchanged: Gemini latency and summary capacity
+- moved: blocking summary work to a bounded executor
+- remaining limit: executor queue growth and 503 overload policy
+
+Kafka or full reactive conversion is not justified by this result alone. Reconsider them only when durable background processing, job recovery, much higher event volume, or the need to remove blocking worker occupancy is demonstrated.
+
+## Portfolio Wording Candidate
+
+```text
+Gemini 동기 호출을 전용 bounded executor 기반 Servlet async로 격리해 50 VU 혼합 부하에서 일반 조회 API p95를 5.97초에서 173ms로 낮추고 Tomcat busy thread peak를 20에서 8로 개선했습니다.
+```

--- a/load-tests/k6/gemini-thread-saturation.js
+++ b/load-tests/k6/gemini-thread-saturation.js
@@ -21,6 +21,9 @@ export const popularDuration = new Trend('popular_duration', true);
 export const tomcatThreadsBusy = new Gauge('tomcat_threads_busy');
 export const tomcatThreadsCurrent = new Gauge('tomcat_threads_current');
 export const tomcatThreadsMax = new Gauge('tomcat_threads_max');
+export const asyncExecutorActive = new Gauge('async_executor_active');
+export const asyncExecutorQueued = new Gauge('async_executor_queued');
+export const asyncExecutorPoolSize = new Gauge('async_executor_pool_size');
 export const metricsFailures = new Rate('thread_metrics_failures');
 
 const scenarios = {
@@ -61,8 +64,8 @@ export const options = {
   },
 };
 
-function metricValue(name) {
-  const res = http.get(`${BASE_URL}/actuator/metrics/${name}`, {
+function metricValue(name, query = '') {
+  const res = http.get(`${BASE_URL}/actuator/metrics/${name}${query}`, {
     tags: { api: 'thread_saturation', endpoint: 'thread_metrics', metric: name },
   });
 
@@ -113,9 +116,16 @@ export function threadMetrics() {
   const busy = metricValue('tomcat.threads.busy');
   const current = metricValue('tomcat.threads.current');
   const max = metricValue('tomcat.threads.config.max');
+  const executorQuery = '?tag=name:aiSummaryExecutor';
+  const executorActive = metricValue('executor.active', executorQuery);
+  const executorQueued = metricValue('executor.queued', executorQuery);
+  const executorPoolSize = metricValue('executor.pool.size', executorQuery);
 
   if (busy !== null) tomcatThreadsBusy.add(busy);
   if (current !== null) tomcatThreadsCurrent.add(current);
   if (max !== null) tomcatThreadsMax.add(max);
+  if (executorActive !== null) asyncExecutorActive.add(executorActive);
+  if (executorQueued !== null) asyncExecutorQueued.add(executorQueued);
+  if (executorPoolSize !== null) asyncExecutorPoolSize.add(executorPoolSize);
   sleep(METRICS_SLEEP_SECONDS);
 }

--- a/src/main/java/com/example/globalTimes_be/domain/ai/controller/AiController.java
+++ b/src/main/java/com/example/globalTimes_be/domain/ai/controller/AiController.java
@@ -7,16 +7,20 @@ import com.example.globalTimes_be.domain.detail.exception.DetailErrorStatus;
 import com.example.globalTimes_be.domain.detail.exception.DetailSuccessStatus;
 import com.example.globalTimes_be.domain.detail.service.DetailService;
 import com.example.globalTimes_be.global.apiPayload.code.ApiResponse;
+import com.example.globalTimes_be.global.apiPayload.code.status.GlobalErrorStatus;
 import com.example.globalTimes_be.global.apiPayload.code.status.GlobalSuccessStatus;
 import com.example.globalTimes_be.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.springframework.web.context.request.async.WebAsyncTask;
 
 import java.util.Collections;
 
@@ -29,14 +33,32 @@ public class AiController implements AiControllerDocs {
     public final AiSseService aiSseService;
     public final DetailService detailService;
     public final AnonymousChatSessionService anonymousChatSessionService;
+    @Qualifier("aiSummaryExecutor")
+    public final AsyncTaskExecutor aiSummaryExecutor;
 
     @Value("${ai.summary-save-enabled:true}")
     private boolean summarySaveEnabled;
 
+    @Value("${ai.summary-async.timeout-ms:15000}")
+    private long summaryAsyncTimeoutMs;
+
     @Override
     @GetMapping(value = "/{id}/summary")
-    public ResponseEntity<ApiResponse> summarizeArticle(@PathVariable Long id,
-                                                        @RequestParam(defaultValue = "영어") String language) {
+    public WebAsyncTask<ResponseEntity<ApiResponse>> summarizeArticle(@PathVariable Long id,
+                                                                      @RequestParam(defaultValue = "영어") String language) {
+        WebAsyncTask<ResponseEntity<ApiResponse>> task = new WebAsyncTask<>(
+                summaryAsyncTimeoutMs,
+                aiSummaryExecutor,
+                () -> summarizeArticleSync(id, language)
+        );
+        task.onTimeout(() -> {
+            log.warn("[AiSummaryAsync] timeout=true timeoutMs={}", summaryAsyncTimeoutMs);
+            return ApiResponse.fail(GlobalErrorStatus._SERVICE_UNAVAILABLE.getResponse());
+        });
+        return task;
+    }
+
+    private ResponseEntity<ApiResponse> summarizeArticleSync(Long id, String language) {
         long startedAt = System.nanoTime();
 
         // DB에 저장된 요약이 있으면 GPT 스킵

--- a/src/main/java/com/example/globalTimes_be/domain/ai/controller/AiControllerDocs.java
+++ b/src/main/java/com/example/globalTimes_be/domain/ai/controller/AiControllerDocs.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.springframework.web.context.request.async.WebAsyncTask;
 
 @Tag(name = "AI 기사 분석", description = "기사 요약 및 질의 관련 API입니다.")
 public interface AiControllerDocs {
@@ -81,7 +82,7 @@ public interface AiControllerDocs {
                     )
             )
     })
-    public ResponseEntity<?> summarizeArticle(
+    public WebAsyncTask<ResponseEntity<com.example.globalTimes_be.global.apiPayload.code.ApiResponse>> summarizeArticle(
             @Parameter(description = "뉴스기사 ID", example = "1")
             @NotNull(message = "뉴스기사 id는 비어있을 수 없습니다.")
             @PathVariable Long id,

--- a/src/main/java/com/example/globalTimes_be/global/apiPayload/code/status/GlobalErrorStatus.java
+++ b/src/main/java/com/example/globalTimes_be/global/apiPayload/code/status/GlobalErrorStatus.java
@@ -13,6 +13,7 @@ public enum GlobalErrorStatus implements BaseResponse {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "해당 요청에 접근 권한이 없습니다."),
     _NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 리소스입니다."),
     _CONFLICT(HttpStatus.CONFLICT,"잘못된 입력입니다."),
+    _SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "요청이 많아 잠시 후 다시 시도해주세요."),
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생하였습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/globalTimes_be/global/config/AiSummaryAsyncConfig.java
+++ b/src/main/java/com/example/globalTimes_be/global/config/AiSummaryAsyncConfig.java
@@ -1,0 +1,26 @@
+package com.example.globalTimes_be.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class AiSummaryAsyncConfig {
+
+    @Bean(name = "aiSummaryExecutor")
+    public ThreadPoolTaskExecutor aiSummaryExecutor(
+            @Value("${ai.summary-async.core-pool-size:20}") int corePoolSize,
+            @Value("${ai.summary-async.max-pool-size:20}") int maxPoolSize,
+            @Value("${ai.summary-async.queue-capacity:100}") int queueCapacity) {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(corePoolSize);
+        executor.setMaxPoolSize(maxPoolSize);
+        executor.setQueueCapacity(queueCapacity);
+        executor.setThreadNamePrefix("ai-summary-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(10);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/global/exception/GlobalErrorHandler.java
+++ b/src/main/java/com/example/globalTimes_be/global/exception/GlobalErrorHandler.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.core.task.TaskRejectedException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -98,12 +99,33 @@ public class GlobalErrorHandler {
         return ApiResponse.fail(e.getMessage(), e.getHttpStatus());
     }
 
+    @ExceptionHandler(TaskRejectedException.class)
+    public ResponseEntity<ApiResponse> handleTaskRejectedException(TaskRejectedException e) {
+        log.warn("Async task rejected: {}", e.getClass().getSimpleName());
+        return ApiResponse.fail(GlobalErrorStatus._SERVICE_UNAVAILABLE.getResponse());
+    }
+
     //500 나머지 에러
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse> handleNullPointerException(Exception e, HttpServletRequest request){
+        if (hasCause(e, InterruptedException.class)) {
+            log.warn("Async task interrupted: {}", e.getClass().getSimpleName());
+            return ApiResponse.fail(GlobalErrorStatus._SERVICE_UNAVAILABLE.getResponse());
+        }
         log.error("발생한 예외 타입: {}", e.getClass().getSimpleName());
         log.error("Exception Error", e);
         return ApiResponse.fail(GlobalErrorStatus._INTERNAL_SERVER_ERROR.getResponse());
+    }
+
+    private boolean hasCause(Throwable throwable, Class<? extends Throwable> causeType) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (causeType.isInstance(current)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,6 +75,11 @@ trend:
 ai:
   context-window-size: 10
   summary-save-enabled: ${AI_SUMMARY_SAVE_ENABLED:true}
+  summary-async:
+    core-pool-size: ${AI_SUMMARY_ASYNC_CORE_POOL_SIZE:20}
+    max-pool-size: ${AI_SUMMARY_ASYNC_MAX_POOL_SIZE:20}
+    queue-capacity: ${AI_SUMMARY_ASYNC_QUEUE_CAPACITY:100}
+    timeout-ms: ${AI_SUMMARY_ASYNC_TIMEOUT_MS:15000}
 
 management:
   endpoints:

--- a/src/test/java/com/example/globalTimes_be/domain/ai/controller/AiControllerTest.java
+++ b/src/test/java/com/example/globalTimes_be/domain/ai/controller/AiControllerTest.java
@@ -1,0 +1,65 @@
+package com.example.globalTimes_be.domain.ai.controller;
+
+import com.example.globalTimes_be.domain.ai.service.AiService;
+import com.example.globalTimes_be.domain.ai.service.AiSseService;
+import com.example.globalTimes_be.domain.chat.service.AnonymousChatSessionService;
+import com.example.globalTimes_be.domain.detail.service.DetailService;
+import com.example.globalTimes_be.global.apiPayload.code.ApiResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.context.request.async.WebAsyncTask;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AiControllerTest {
+
+    @Mock
+    private AiService aiService;
+    @Mock
+    private AiSseService aiSseService;
+    @Mock
+    private DetailService detailService;
+    @Mock
+    private AnonymousChatSessionService anonymousChatSessionService;
+
+    private AiController aiController;
+
+    @BeforeEach
+    void setUp() {
+        aiController = new AiController(
+                aiService,
+                aiSseService,
+                detailService,
+                anonymousChatSessionService,
+                new SimpleAsyncTaskExecutor()
+        );
+        ReflectionTestUtils.setField(aiController, "summarySaveEnabled", true);
+        ReflectionTestUtils.setField(aiController, "summaryAsyncTimeoutMs", 15000L);
+    }
+
+    @Test
+    void summarizeArticleDefersWorkToAsyncTask() throws Exception {
+        when(detailService.getArticleSummary(1L, "English")).thenReturn("saved summary");
+
+        WebAsyncTask<ResponseEntity<ApiResponse>> task = aiController.summarizeArticle(1L, "English");
+
+        verify(detailService, never()).getArticleSummary(1L, "English");
+
+        Object result = task.getCallable().call();
+
+        assertThat(result).isInstanceOf(ResponseEntity.class);
+        assertThat(((ResponseEntity<?>) result).getStatusCode().is2xxSuccessful()).isTrue();
+        verify(detailService).getArticleSummary(1L, "English");
+        verify(aiService, never()).summarizeArticle(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString());
+    }
+}

--- a/src/test/java/com/example/globalTimes_be/global/exception/GlobalErrorHandlerTest.java
+++ b/src/test/java/com/example/globalTimes_be/global/exception/GlobalErrorHandlerTest.java
@@ -1,0 +1,47 @@
+package com.example.globalTimes_be.global.exception;
+
+import com.example.globalTimes_be.global.apiPayload.code.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.task.TaskRejectedException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class GlobalErrorHandlerTest {
+
+    private final GlobalErrorHandler handler = new GlobalErrorHandler();
+
+    @Test
+    void taskRejectedReturnsServiceUnavailable() {
+        ResponseEntity<ApiResponse> response = handler.handleTaskRejectedException(
+                new TaskRejectedException("rejected")
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    void interruptedAsyncTaskReturnsServiceUnavailable() {
+        Exception exception = new RuntimeException(new InterruptedException("async timeout"));
+
+        ResponseEntity<ApiResponse> response = handler.handleNullPointerException(
+                exception,
+                mock(HttpServletRequest.class)
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    void unexpectedExceptionStillReturnsInternalServerError() {
+        ResponseEntity<ApiResponse> response = handler.handleNullPointerException(
+                new RuntimeException("unexpected"),
+                mock(HttpServletRequest.class)
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #188

## 🧭 변경 타입
- [x] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [x] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- Gemini summary orchestration을 `WebAsyncTask`와 전용 bounded executor로 분리했습니다.
- executor 크기/queue/MVC timeout을 설정화하고 active/queued/pool metric을 k6에 추가했습니다.
- executor 거절 및 async timeout interruption은 503으로 분리하고 기존 Gemini 502/504와 내부 500 의미를 유지했습니다.
- 동기 50 VU 및 async 20/50 VU 혼합 부하 결과와 overengineering 판단을 backend improvement 문서에 기록했습니다.

## 🔍 기술적 배경
- 기존 동기 구조는 Gemini mock 3초 호출 중 Tomcat request thread를 점유해, summary 20 VU에서 busy thread 20/20과 동시 popular API p95 2.86초를 만들었습니다.
- blocking 작업 자체를 제거하지 않고 전용 bounded executor로 이동해 Tomcat request thread를 반환하고, unrelated API 지연 전파를 격리하는 최소 Spring MVC async 경계를 적용했습니다.
- 50 VU에서 executor active 20/queued 30이 관측됐으므로 병목 제거가 아니라 격리로 해석합니다. WebFlux/Kafka/retry 도입은 이번 범위에서 제외했습니다.

## 🧪 테스트/검증 (필수)
- [x] `./gradlew test` 전체 회귀 테스트 통과
- [x] Controller async defer, task rejection 503, interruption 503, unexpected exception 500 단위 테스트
- [x] `node --check load-tests/mock-gemini-server.js`
- [x] `k6 inspect -e SUMMARY_VUS=20/50 load-tests/k6/gemini-thread-saturation.js`
- [x] `git diff --check`
- [x] mock Gemini 500은 backend 502, local MVC async timeout은 backend 503 확인
- [x] 테스트 기사 summary 복원 및 임시 table/backend/mock 프로세스 정리

### 측정 결과

| 조건 | Summary RPS / p95 | Popular RPS / p95 | Tomcat busy peak | Executor active / queued |
| --- | --- | --- | ---: | --- |
| 동기 20 VU (#186) | 6.09 / 3.23s | 3.71 / 2.86s | 20/20 | - |
| async 20 VU | 6.12 / 3.39s | 23.38 / 160.99ms | 6/20 | 20 / 0 |
| 동기 50 VU | 6.28 / 8.98s | 0.91 / 5.97s | 20/20 | - |
| async 50 VU | 6.29 / 9.15s | 22.40 / 172.98ms | 8/20 | 20 / 30 |

- 50 VU에서 popular p95는 약 97.1% 감소하고 RPS는 약 24.5배로 회복했습니다.
- summary 자체 처리량과 latency는 개선되지 않았으며, 완전한 non-blocking I/O 전환으로 표현하지 않습니다.
- 두 50 VU 실행은 5초 graceful stop 중 각각 10 iteration이 종료됐습니다.

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop` 대상)
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 기존 정상/fallback/Gemini 502/504/내부 500 응답 의미를 유지했는가?

## 📸 스크린샷 (선택)
- 해당 없음

## 💬 리뷰 요구사항(선택)
- `WebAsyncTask + aiSummaryExecutor` 경계와 bounded pool 설정이 현재 MVC/JPA 구조에서 적절한지 확인 부탁드립니다.
- timeout callback과 interrupted worker의 503 매핑, executor rejection 503 처리에 Blocking 문제가 없는지 확인 부탁드립니다.
- 측정 결과가 summary 성능 개선이 아닌 Tomcat request-thread 격리 효과로 정확히 기술됐는지 확인 부탁드립니다.

## ➕ 추후 계획(선택)
- 실제 운영 traffic/SLA에서 queue 포화나 durable background job 요구가 확인되기 전까지 Kafka/WebFlux 확장은 보류합니다.
