### PR TITLE
🧪 [TEST/PERF/#190] Gemini executor 포화 503 및 회복 검증

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -112,6 +112,21 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 - 범위 경계:
   - 전면 WebFlux, Kafka, retry/circuit breaker, SSE/ask/Trend 변경은 현재 근거 대비 과해 제외한다.
 
+### P2 후속 후보. Gemini async executor 포화 503 및 queue 보호 검증
+
+- 상태: `Done` ([#190](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/190), [PR #191](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/191))
+- AS-IS: #188의 50 VU에서 executor active 20/queued 30까지 관측했지만 queue capacity 100 포화와 실제 HTTP 503 rejection/recovery 경로는 검증하지 않았다.
+- TO-BE: 로컬 executor를 5 workers/queue 10으로 축소하고 점진 부하를 적용해 200/503, queue 상한, popular API 보호, 부하 종료 후 회복을 같은 실행 흐름에서 검증한다.
+- 범위 경계:
+  - 기본 executor 20/100 변경, rate limiter, retry/circuit breaker, Kafka/WebFlux, EC2 capacity 추정은 측정 결과 없이 진행하지 않는다.
+  - 결과는 제한된 로컬 단일 인스턴스의 overload protection 검증으로 한정한다.
+- 검증 결과:
+  - 15 VU에서 active 5/queued 10으로 executor를 모두 사용하면서 55/55건이 200이었다.
+  - 20 VU부터 실제 503이 발생했고, 20/30 VU 모두 queue는 설정 상한 10을 넘지 않았다.
+  - 20 VU는 200 55건/503 1,158건, accepted p95 9.41초/rejected p95 49.55ms, popular p95 254.51ms였다.
+  - 30 VU는 200 55건/503 3,720건, accepted p95 9.34초/rejected p95 34.25ms, popular p95 256.03ms였다.
+  - 부하 종료 후 active/queued 0/0과 recovery 5 VU의 25/25 HTTP 200을 확인했다.
+
 ## P2-1. 검색 API FULLTEXT 성능 기준선
 
 - 상태: `Done` ([#168](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/168), [PR #169](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/169))

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -61,6 +61,9 @@ Reviewer 이후 diff 변경을 피하기 위해 merge 후 `WORK_PROGRESS.md`만 
   - #188/#189 is merged and closed. It added a synchronous 50 VU baseline and a `WebAsyncTask + bounded executor` comparison at 20/50 VU.
   - At 50 VU, popular p95 changed from 5.97 seconds synchronous to 173ms async while summary stayed near 6.29 RPS and 9 seconds p95.
   - Tomcat busy peak changed from 20 to 8; the async executor reached 20 active and 30 queued, so the bottleneck was isolated rather than removed.
+  - #190/#191 is merged and closed. It verified real HTTP 503 rejection, bounded queue protection, and recovery with a locally reduced executor.
+  - With a local 5-worker/queue-10 executor, 15 VU filled the queue without rejection and 20 VU was the first tested stage to return real HTTP 503 responses.
+  - At 20/30 VU the queue stayed at 10, accepted summary throughput stayed near 1.57 RPS, and popular p95 stayed near 255ms; a later 5 VU recovery returned 25/25 HTTP 200.
 
 - Repo: `SKU-GlobalTimes/GlobalTimes_BeSide`
 - Base branch: `develop`
@@ -116,10 +119,13 @@ pure relevance-first는 wrong-context 기사를 끌어올릴 수 있어 바로 �
 
 최근 완료:
 
-- 동기 50 VU에서 실제 post-ceiling RPS/p95와 popular 지연 전파를 측정한다.
-- `WebAsyncTask + bounded executor`로 summary blocking 작업을 격리하고 같은 20/50 VU 조건을 비교한다.
-- Tomcat busy와 executor active/queued를 함께 기록해 병목 제거와 격리를 구분한다.
-- API 응답 의미를 유지하고 timeout/rejection overload는 503으로 분리한다.
+- 로컬 executor를 5 workers/queue 10으로 축소해 높은 VU 없이 실제 rejection 경계를 재현한다.
+- summary 200/503, executor active/queued, Tomcat busy, popular p95를 같은 구간에서 기록한다.
+- 부하 종료 후 queue 감소와 정상 summary 응답 회복을 확인한다.
+- 기본 20/100 설정은 결과와 별도 승인 없이 변경하지 않는다.
+
+측정은 완료됐다. 20/30 VU에서 초과 요청은 503으로 빠르게 거절되고 queue는 10을 넘지 않았으며, 부하 종료 후 active/queued 0/0과 25/25 정상 응답 회복을 확인했다.
+높은 503 비율은 fast rejection 뒤 0.1초마다 재요청하는 closed-model 특성이므로 운영 실패율로 일반화하지 않는다.
 
 현재 측정에서는 async 50 VU에서 summary 자체 처리량/p95는 개선되지 않았지만 popular p95가 5.97초에서 173ms로 감소했고 Tomcat busy peak가 20에서 8로 줄었다.
 executor active 20/queued 30을 함께 기록했으므로 완전한 non-blocking 또는 병목 제거로 과장하지 않는다.
@@ -153,6 +159,7 @@ executor active 20/queued 30을 함께 기록했으므로 완전한 non-blocking
 - `docs/backend-improvement/local-load-observability-runbook.md`
 - `docs/backend-improvement/single-instance-tps-baseline.md`
 - `docs/backend-improvement/load-test-baseline.md`
+- `docs/backend-improvement/gemini-executor-overload-protection.md`
 - `docs/backend-improvement/perspectives-fulltext-generic-token-filter-result.md`
 - `docs/backend-improvement/perspectives-fulltext-ordering-comparison.md`
 - `docs/backend-improvement/perspectives-ranking-policy-adr.md`

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -2015,6 +2015,60 @@ Reviewer 필요성:
 
 - API 실행 방식, executor/timeout 설정, 503 오류 정책, k6 계측이 변경되므로 Reviewer 검토가 필요하다.
 
+### #190 - Gemini async executor 포화 503 및 queue 보호 검증
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/190
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/191
+- 작업 브랜치: `test/#190-gemini-executor-overload`
+- 상태: Merged
+- 주요 파일:
+  - `load-tests/k6/gemini-thread-saturation.js`
+  - `docs/backend-improvement/gemini-executor-overload-protection.md`
+
+목표:
+
+- #188에서 실제로 도달하지 않은 bounded executor queue 포화와 HTTP 503 rejection 경로를 낮은 로컬 자원으로 재현한다.
+- 포화 중 popular API 보호와 부하 종료 후 executor 회복을 함께 확인한다.
+
+Overengineering 판단:
+
+- 기본 worker/queue를 바로 조정하거나 신규 미들웨어를 도입하지 않고, 로컬 환경변수로 5 workers/queue 10을 구성해 기존 보호 동작을 먼저 측정한다.
+- 결과는 EC2 또는 대규모 운영 capacity로 일반화하지 않고 향후 인스턴스별 설정과 부하 테스트의 기반으로 한정한다.
+
+계획:
+
+- k6에서 summary HTTP 200/503과 rejection 비율을 분리한다.
+- mock Gemini 3초, summary `10 -> 15 -> 20 -> 30 VU`, popular 5 VU, metrics 1 VU를 점진 실행한다.
+- executor active/queued, Tomcat busy, popular p95와 포화 후 낮은 VU 회복 결과를 기록한다.
+- 기본 executor 20/100 설정 변경은 이번 측정 결과와 별도 승인 없이는 진행하지 않는다.
+
+구현 및 검증 결과:
+
+- k6가 summary HTTP 200/503/unexpected 응답 수와 accepted/rejected latency를 분리하도록 보강했다.
+- 로컬 executor 5 workers/queue 10, Gemini mock 3초, popular 5 VU, metrics 1 VU 조건으로 10/15/20/30 VU를 각각 30초 실행했다.
+- 10 VU는 51/51건 200, queue peak 5, accepted p95 6.75초, popular p95 371.10ms였다.
+- 15 VU는 55/55건 200, active 5/queued 10, accepted p95 9.35초, popular p95 163.49ms였다.
+- 20 VU는 200 55건/503 1,158건, accepted p95 9.41초/rejected p95 49.55ms, queue peak 10, popular p95 254.51ms였다.
+- 30 VU는 200 55건/503 3,720건, accepted p95 9.34초/rejected p95 34.25ms, queue peak 10, popular p95 256.03ms였다.
+- 모든 단계에서 unexpected summary status, popular failure, metrics failure는 0이었다.
+- 20/30 VU의 높은 503 비율은 fast rejection 뒤 0.1초마다 재요청하는 closed-model 특성이므로 운영 실패율이나 capacity로 일반화하지 않는다.
+- 30 VU 종료 직후 active/queued는 0/0이었고 recovery 5 VU에서 25/25건 200, queue peak 0, summary p95 3.68초를 확인했다.
+- 앱 working set은 20 VU 종료 후 약 482MiB였고 MySQL/Redis는 약 486MiB/11.5MiB로 안정적이었다.
+- 테스트 기사 7366 summary를 기존 길이 420으로 복원하고 임시 backup table 및 backend/mock 프로세스를 제거했다.
+
+판단:
+
+- queue 10 상한과 실제 HTTP 503 dispatch, 포화 후 회복이 검증됐다.
+- queue 증가는 처리량을 늘리지 않으며, 15 VU accepted p95 9.35초는 5-worker 기준 queue 두 batch 대기를 보여준다.
+- 기본 20/100은 이번 축소 실험만으로 변경하지 않는다. 고정 인스턴스 환경에서 arrival RPS, Gemini latency/quota, 허용 대기시간을 함께 측정한 뒤 조정한다.
+- 빠른 503에 즉시 재시도하면 rejection storm을 만들 수 있으므로 실제 client는 delay/backoff가 필요하다.
+
+Reviewer 필요성:
+
+- k6 시나리오와 측정 문서가 변경되므로 Reviewer 검토가 필요하다.
+- 최초 Reviewer는 unexpected status를 5%까지 허용하는 threshold와 빠른 503이 섞인 aggregate summary p95 threshold를 Blocking으로 지적했다.
+- unexpected threshold를 `rate==0`, latency threshold를 HTTP 200 전용 `summary_accepted_duration p95<15초`로 변경해 두 Blocking을 반영했다.
+
 ---
 
 ## 5. 다음 세션에서 바로 이어가기 위한 시작 프롬프트

--- a/docs/backend-improvement/gemini-executor-overload-protection.md
+++ b/docs/backend-improvement/gemini-executor-overload-protection.md
@@ -1,0 +1,133 @@
+# Gemini executor overload protection baseline
+
+## Purpose
+
+#188 proved that a dedicated bounded executor protects unrelated APIs from slow Gemini summary calls. Its 50 VU run reached 20 active workers and 30 queued tasks, but did not fill the default queue capacity of 100 or exercise real HTTP rejection.
+
+This baseline reduces only the local executor capacity and verifies:
+
+- the first observable saturation boundary
+- actual HTTP 503 dispatch after task rejection
+- the configured queue upper bound
+- `popular` API behavior during rejection
+- summary recovery after overload ends
+
+It is a controlled single-instance protection test, not an EC2 capacity result or a production traffic claim.
+
+## Overengineering guardrail
+
+Chosen:
+
+- existing Spring MVC async implementation
+- local environment overrides only
+- existing mock Gemini server and k6 scenario
+- explicit 200, 503, and unexpected status metrics
+- low VU saturation through a reduced executor
+
+Not chosen:
+
+- changing the default 20 workers / queue 100
+- rate limiter or automatic retry
+- circuit breaker
+- Kafka or WebFlux
+- distributed k6 or EC2 extrapolation
+
+The reduced executor makes the same bounded rejection behavior reproducible on an 8GB laptop without generating hundreds of concurrent VUs.
+
+## Environment
+
+| Item | Value |
+| --- | --- |
+| Application | one local Spring Boot instance |
+| Tomcat max threads | 20 |
+| Async executor | core/max 5, queue capacity 10 |
+| MVC async timeout | 15 seconds |
+| Gemini | local mock, fixed 3-second delay, HTTP 200 |
+| Summary persistence | disabled |
+| DB/cache | Docker MySQL and Redis |
+| Popular load | 5 VU |
+| Metrics load | 1 VU |
+| Saturation duration | 30 seconds plus 5-second graceful stop |
+| Recovery duration | 15 seconds plus graceful stop |
+
+Article 7366 had crawled content and its existing 420-character summary was backed up and cleared. The summary was restored and the temporary table was removed after all runs.
+
+## k6 metric change
+
+The summary scenario now separates:
+
+- `summary_responses_200`
+- `summary_responses_503`
+- `summary_responses_unexpected`
+- `summary_accepted_duration`
+- `summary_rejected_duration`
+- `summary_unexpected_failures`
+
+`ALLOW_SUMMARY_503=true` treats only 200 and 503 as expected during an overload run. Any 500, 502, 504, or other status fails the strict `summary_unexpected_failures: rate==0` threshold.
+
+The pass/fail latency threshold uses `summary_accepted_duration: p(95)<15000`, which contains only HTTP 200 responses. The aggregate summary request duration remains visible for analysis but is not a latency guard because fast 503 responses would hide slow accepted responses.
+
+k6 still counts HTTP 503 in its built-in `http_req_failed` metric. The overload decision therefore uses the explicit custom status metrics rather than treating built-in HTTP failures as unexpected backend errors.
+
+## Results
+
+| Summary VU | Requests | HTTP 200 | HTTP 503 | Accepted p95 | Rejected p95 | Queue peak | Popular p95 | Tomcat busy peak |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 10 | 51 | 51 | 0 | 6.75s | - | 5/10 | 371.10ms | 13/20 |
+| 15 | 55 | 55 | 0 | 9.35s | - | 10/10 | 163.49ms | 9/20 |
+| 20 | 1,213 | 55 | 1,158 | 9.41s | 49.55ms | 10/10 | 254.51ms | 11/20 |
+| 30 | 3,775 | 55 | 3,720 | 9.34s | 34.25ms | 10/10 | 256.03ms | 20/20 |
+| recovery 5 | 25 | 25 | 0 | 3.68s | - | 0/10 | 575.41ms | 7/20 |
+
+Unexpected summary status, popular failure, and metrics failure were 0 in every run.
+
+### Boundary interpretation
+
+- 10 VU used 5 workers and queued at most 5 tasks.
+- 15 VU filled all 5 workers and all 10 queue slots without rejection.
+- 20 VU was the first tested stage above the 15-task executor capacity and produced real HTTP 503 responses.
+- 20 and 30 VU both kept the queue at its configured maximum of 10.
+- Accepted throughput stayed at 55 requests per 35-second total run, about 1.57 RPS, close to the controlled `5 workers / 3 seconds` service limit after application overhead.
+- Increasing VU above the executor capacity did not increase accepted throughput. It increased only fast rejection volume.
+
+The 95.46% and 98.54% rejection ratios at 20 and 30 VU are specific to this closed-model script. A VU receiving a fast 503 sleeps only 0.1 seconds and immediately retries, creating a rejection storm. These ratios must not be presented as production traffic failure rates or arrival-rate capacity.
+
+### Queue and timeout interpretation
+
+With five workers and a 3-second service time:
+
+```text
+theoretical service capacity = 5 / 3 seconds = about 1.67 RPS
+```
+
+A queue of 10 represents approximately two additional 5-task batches. The 15 VU accepted p95 of 9.35 seconds is consistent with two queue batches plus the 3-second execution time and local application overhead.
+
+General configuration guidance:
+
+```text
+workers ~= target RPS * external-call latency / target utilization
+queue ~= service throughput * allowed queue-wait time
+queue wait + external-call timeout < MVC async timeout
+```
+
+Increasing queue size does not increase throughput. Sustained load requires additional permitted external-call concurrency or more instances, subject to the total Gemini quota. If external capacity cannot increase, bounded rejection and client backoff are safer than an unbounded queue.
+
+## Recovery
+
+Immediately after the 30 VU run, Actuator reported executor active 0 and queued 0. A subsequent 5 VU run returned 25/25 HTTP 200 responses, no 503, queue peak 0, and summary p95 3.68 seconds.
+
+This verifies functional recovery of the executor and summary path. The recovery `popular` p95 of 575.41ms is local-run variance and is not claimed as an improvement; it remained failure-free and below the existing 5-second guard threshold.
+
+## Decision
+
+- Keep the default executor settings at 20 workers and queue 100 in this issue.
+- Use 503 as an intentional temporary-overload response, not a server defect.
+- Require clients to apply retry delay/backoff; immediate retry can amplify rejection traffic.
+- Size each future instance from measured arrival RPS, external-call latency, acceptable wait, and total Gemini quota.
+- Re-run the same script in a fixed EC2/container environment before making production capacity claims.
+
+## Portfolio wording candidate
+
+```text
+Gemini 외부 호출용 bounded executor를 5 workers/queue 10으로 축소한 포화 실험에서 20 VU부터 초과 요청을 p95 34~50ms의 503으로 차단하고 queue 상한을 유지했으며, 동시 popular API p95를 약 255ms로 격리하고 부하 종료 후 25/25 정상 응답 회복을 검증했습니다.
+```

--- a/load-tests/k6/gemini-thread-saturation.js
+++ b/load-tests/k6/gemini-thread-saturation.js
@@ -11,10 +11,18 @@ const POPULAR_SLEEP_SECONDS = Number(__ENV.POPULAR_SLEEP_SECONDS || 0.1);
 const METRICS_SLEEP_SECONDS = Number(__ENV.METRICS_SLEEP_SECONDS || 1);
 const SUMMARY_VUS = Number(__ENV.SUMMARY_VUS || 5);
 const POPULAR_VUS = Number(__ENV.POPULAR_VUS || 5);
+const ALLOW_SUMMARY_503 = (__ENV.ALLOW_SUMMARY_503 || 'false').toLowerCase() === 'true';
 
 export const summaryRequests = new Counter('summary_requests');
+export const summaryResponses200 = new Counter('summary_responses_200');
+export const summaryResponses503 = new Counter('summary_responses_503');
+export const summaryResponsesUnexpected = new Counter('summary_responses_unexpected');
 export const summaryFailures = new Rate('summary_failures');
+export const summaryRejections = new Rate('summary_rejections');
+export const summaryUnexpectedFailures = new Rate('summary_unexpected_failures');
 export const summaryDuration = new Trend('summary_duration', true);
+export const summaryAcceptedDuration = new Trend('summary_accepted_duration', true);
+export const summaryRejectedDuration = new Trend('summary_rejected_duration', true);
 export const popularRequests = new Counter('popular_requests');
 export const popularFailures = new Rate('popular_failures');
 export const popularDuration = new Trend('popular_duration', true);
@@ -53,16 +61,21 @@ if (SUMMARY_VUS > 0) {
   };
 }
 
-export const options = {
-  scenarios,
-  thresholds: {
-    summary_failures: ['rate<0.05'],
-    popular_failures: ['rate<0.05'],
-    thread_metrics_failures: ['rate<0.05'],
-    'http_req_duration{endpoint:summary}': ['p(95)<15000'],
-    'http_req_duration{endpoint:popular}': ['p(95)<5000'],
-  },
+const thresholds = {
+  popular_failures: ['rate<0.05'],
+  thread_metrics_failures: ['rate<0.05'],
+  'http_req_duration{endpoint:popular}': ['p(95)<5000'],
 };
+
+if (SUMMARY_VUS > 0) {
+  thresholds.summary_unexpected_failures = ['rate==0'];
+  thresholds.summary_accepted_duration = ['p(95)<15000'];
+  if (!ALLOW_SUMMARY_503) {
+    thresholds.summary_failures = ['rate<0.05'];
+  }
+}
+
+export const options = { scenarios, thresholds };
 
 function metricValue(name, query = '') {
   const res = http.get(`${BASE_URL}/actuator/metrics/${name}${query}`, {
@@ -91,11 +104,23 @@ export function summaryLoad() {
     { tags: { api: 'thread_saturation', endpoint: 'summary' } },
   );
 
-  const failed = res.status !== 200;
+  const accepted = res.status === 200;
+  const rejected = res.status === 503;
+  const unexpected = !accepted && !rejected;
+  const failed = !accepted;
   summaryRequests.add(1);
+  if (accepted) summaryResponses200.add(1);
+  if (rejected) summaryResponses503.add(1);
+  if (unexpected) summaryResponsesUnexpected.add(1);
   summaryFailures.add(failed);
+  summaryRejections.add(rejected);
+  summaryUnexpectedFailures.add(unexpected);
   summaryDuration.add(res.timings.duration);
-  check(res, { 'summary status is 200': () => !failed });
+  if (accepted) summaryAcceptedDuration.add(res.timings.duration);
+  if (rejected) summaryRejectedDuration.add(res.timings.duration);
+  check(res, {
+    'summary status is expected': () => accepted || (ALLOW_SUMMARY_503 && rejected),
+  });
   sleep(SUMMARY_SLEEP_SECONDS);
 }
 


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #190

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- k6 summary 계측을 HTTP 200, 의도된 503 rejection, unexpected status로 분리했습니다.
- accepted/rejected latency와 unexpected failure threshold를 추가했습니다.
- 로컬 executor 5 workers/queue 10과 Gemini mock 3초 조건에서 10/15/20/30 VU 포화 및 5 VU 회복을 측정했습니다.
- 결과, queue/timeout 산정 기준, 운영 환경으로 일반화할 수 없는 한계를 backend improvement 문서에 기록했습니다.

## 🔍 기술적 배경
- #188의 기본 executor 20/100, summary 50 VU에서는 active 20/queued 30까지만 도달해 실제 queue 포화와 HTTP rejection dispatch를 검증하지 못했습니다.
- 높은 VU 대신 로컬 executor만 5/5/10으로 축소해 동일한 bounded rejection 경계를 8GB 환경에서 재현했습니다.
- queue는 순간 부하 buffer이며 처리량을 늘리지 않습니다. 포화 이후 초과 요청을 빠른 503으로 거절해 무한 대기와 전체 API 지연 전파를 제한하는지를 확인했습니다.

## 🧪 테스트/검증 (필수)
- [x] `./gradlew test`
- [x] overload/normal 모드 `k6 inspect`
- [x] `node --check load-tests/mock-gemini-server.js`
- [x] `git diff --check`
- [x] 테스트 기사 summary 길이 420 복원, 임시 table/backend/mock 프로세스 정리

### 측정 결과

| Summary VU | HTTP 200 | HTTP 503 | Accepted p95 | Rejected p95 | Queue peak | Popular p95 |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 10 | 51 | 0 | 6.75s | - | 5/10 | 371.10ms |
| 15 | 55 | 0 | 9.35s | - | 10/10 | 163.49ms |
| 20 | 55 | 1,158 | 9.41s | 49.55ms | 10/10 | 254.51ms |
| 30 | 55 | 3,720 | 9.34s | 34.25ms | 10/10 | 256.03ms |
| recovery 5 | 25 | 0 | 3.68s | - | 0/10 | 575.41ms |

- 20 VU가 15-task capacity를 넘은 첫 측정 단계이며 실제 HTTP 503이 발생했습니다.
- 모든 단계에서 unexpected summary status, popular failure, metrics failure는 0이었습니다.
- 20/30 VU의 높은 503 비율은 fast rejection 후 0.1초마다 재요청하는 closed-model 특성입니다. 운영 실패율이나 arrival-rate capacity로 해석하지 않습니다.
- recovery popular p95는 로컬 편차로 개선 수치로 사용하지 않으며, 25/25 summary 200과 queue 0으로 기능 회복만 판단합니다.

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop` 대상)
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?
- [x] Java 코드, API 계약, 기본 executor 20/100 설정을 변경하지 않았는가?

## 📸 스크린샷 (선택)
- 해당 없음

## 💬 리뷰 요구사항(선택)
- `ALLOW_SUMMARY_503`가 overload 측정에서 503만 허용하고 다른 status를 unexpected failure로 유지하는지 확인 부탁드립니다.
- accepted/rejected latency 분리가 빠른 503으로 전체 summary p95가 낮아지는 착시를 방지하는지 확인 부탁드립니다.
- closed-model rejection storm과 로컬 단일 인스턴스 한계를 과장 없이 기술했는지 확인 부탁드립니다.

## ➕ 추후 계획(선택)
- 기본 20/100은 이번 이슈에서 유지합니다. 고정 인스턴스 환경의 arrival RPS, Gemini latency/quota, 허용 대기시간 근거가 생긴 뒤 별도 조정을 검토합니다.
- 실제 client는 503 즉시 재시도 대신 delay/backoff가 필요합니다.
