### PR TITLE
📊 [PERF/#192] 주요 API 혼합 arrival-rate 단일 인스턴스 기준선

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -5,6 +5,16 @@
 GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까지 추적 가능하게 관리한다.
 각 항목은 GitHub Issue, 작업 브랜치, PR, 테스트 및 측정 결과로 연결한다.
 
+## Current Active Work
+
+### P2 follow-up. Mixed API constant-arrival-rate single-instance baseline
+
+- 상태: `In Progress` ([#192](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/192))
+- AS-IS: 기존 기준선은 popular 조회 또는 Gemini summary 포화를 격리 측정했지만, DB 조회·FULLTEXT 검색·상세 조회 쓰기·mock 외부 호출이 한 인스턴스에서 경쟁하는 형태는 확인하지 않았다.
+- TO-BE: `latest/popular/detail/search/summary` 합성 트래픽을 `20 -> 40 -> 60 RPS`로 실행하고 endpoint p95/실패율을 Tomcat, Hikari, AI executor 지표와 함께 기록한다.
+- 범위: OAuth, scrap 쓰기, 실제 외부 API, 인프라 확장 및 근거 없는 튜닝은 제외한다. 반복 관측된 병목만 후속 구현 이슈로 전환한다.
+- 검증: 20/40/60 RPS 모두 목표율을 달성했고 dropped/error는 0이었다. 60 RPS 조회 p95 최대 81.59ms, Hikari pending 0, executor queue 0으로 현재 범위에서는 병목이 확인되지 않았다.
+
 ## 운영 규칙
 
 - 모든 변경은 `Issue → Branch → PR → Merge` 순서를 따른다.

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -3,6 +3,15 @@
 이 문서는 새 Codex 세션이 `WORK_PROGRESS.md` 전체를 읽기 전에 현재 상태를 빠르게 복원하기 위한 짧은 handoff 문서다.
 상세한 이력과 근거는 `WORK_PROGRESS.md`, `BACKLOG.md`, 개별 측정 문서를 기준으로 확인한다.
 
+## Current Active Work
+
+- Issue: [#192](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/192)
+- Branch: `perf/#192-mixed-arrival-rate-baseline`
+- Status: `In Progress` (20/40/60 RPS verification complete; PR pending)
+- Scope: synthetic `latest/popular/detail/search/mock-summary` traffic at `20 -> 40 -> 60 RPS`, correlated with Tomcat, Hikari, and AI executor Actuator metrics
+- Safety: do not call real Google Translate or Gemini APIs; restore the selected article summary and view count after measurement
+- Result: 60.13 achieved business RPS, zero drops/failures, read p95 at or below 81.59ms, summary p95 3.07s, Tomcat busy 6/10 current, Hikari 5/0, executor 9/0; no saturation boundary through 60 RPS
+
 ## Read Order
 
 1. `docs/backend-improvement/NEXT_AGENT_BRIEF.md`

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -3,6 +3,27 @@
 이 문서는 GlobalTimes 백엔드 개선 작업을 장기적으로 이어가기 위한 작업 진척 노트다.
 Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 할 때, 이 문서를 기준으로 현재까지의 의사결정, 완료 작업, 다음 작업을 복원한다.
 
+## Current Active Work
+
+### #192 - Mixed API constant-arrival-rate single-instance baseline
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/192
+- 작업 브랜치: `perf/#192-mixed-arrival-rate-baseline`
+- 상태: `In Progress` (implementation and local verification complete; PR pending)
+- 주요 파일:
+  - `load-tests/k6/mixed-arrival-rate.js`
+  - `docs/backend-improvement/mixed-arrival-rate-baseline.md`
+- 목표: 한 로컬 Spring Boot 인스턴스에 합성 API 트래픽 `20 -> 40 -> 60 RPS`를 실행하고 endpoint별 p95/실패/달성 RPS를 Tomcat, Hikari, AI executor 지표와 함께 기록한다.
+- overengineering 판단: 기존 k6, mock Gemini, Actuator만 재사용한다. 실제 외부 API, OAuth/scrap, 다중 인스턴스 추정, 측정 전 설정 튜닝 및 #110은 제외한다.
+- 안전 조건: Redis 번역 캐시 사전 주입, summary 저장 비활성화, 기사 summary/view count 백업 및 복원, 예상 외 오류·dropped iteration·로컬 자원 압박 발생 시 다음 단계를 중단한다.
+- Reviewer: 실행 가능한 k6 시나리오와 안전 장치가 변경되므로 PR diff 검토가 필요하다.
+- 검증 결과:
+  - 20/40/60 target RPS에서 business achieved RPS는 각각 20.13/40.17/60.13이었고 dropped iteration과 실패는 모두 0이었다.
+  - 60 RPS에서도 조회 API p95는 최대 81.59ms, summary accepted p95는 3.07초였다.
+  - Tomcat busy 최대 6/10 current, Hikari active/pending 최대 5/0, executor active/queued 최대 9/0으로 관측 범위에서 포화되지 않았다.
+  - 60 RPS MySQL CPU point sample은 최대 54.41%였지만 p95 상승이나 connection pending이 없어 즉시 DB 튜닝 근거로 사용하지 않는다.
+  - 테스트 기사 summary/view count를 원복하고 임시 DB backup table, Redis 테스트 key, backend/mock 프로세스를 제거했다.
+
 ## 1. 운영 원칙
 
 ### 기본 개발 흐름

--- a/docs/backend-improvement/mixed-arrival-rate-baseline.md
+++ b/docs/backend-improvement/mixed-arrival-rate-baseline.md
@@ -1,0 +1,159 @@
+# Mixed API constant-arrival-rate baseline
+
+## Status
+
+Issue #192 is in progress. The local 20/40/60 RPS measurement is complete and awaits PR review.
+
+## Purpose
+
+This baseline measures a synthetic mix of public API traffic against one local Spring Boot instance. It combines k6 results with Spring Boot Actuator signals so latency can be correlated with servlet threads, DB connections, or the bounded AI executor.
+
+This is a local bottleneck investigation on an 8GB laptop. It is not a production traffic model, SLA, or multi-Pod capacity claim.
+
+## Overengineering guardrail
+
+Chosen:
+
+- existing k6, mock Gemini, and Actuator tooling
+- one local Spring Boot process with Docker MySQL and Redis
+- short `20 -> 40 -> 60 RPS` stages
+- measurement before tuning
+
+Not chosen:
+
+- OAuth, social-login, or authenticated scrap traffic
+- real Gemini or Google Translate calls
+- distributed load generation, EC2, or Kubernetes
+- index, cache, pool, or executor tuning without evidence
+
+The ratio is synthetic and repeatable. It must not be presented as observed production behavior.
+
+## Traffic model
+
+Use `load-tests/k6/mixed-arrival-rate.js`.
+
+| Endpoint | Ratio | 20 RPS | 40 RPS | 60 RPS |
+| --- | ---: | ---: | ---: | ---: |
+| latest | 35% | 7 | 14 | 21 |
+| popular | 25% | 5 | 10 | 15 |
+| detail | 20% | 4 | 8 | 12 |
+| search | 15% | 3 | 6 | 9 |
+| mock summary | 5% | 1 | 2 | 3 |
+
+Actuator runs as a separate telemetry scenario every five seconds. Its requests are excluded from target business RPS.
+
+## Controlled prerequisites
+
+- Use an article with `crawled_content` and no saved summary so summary reaches mock Gemini.
+- Back up the article summary and view count, then restore both after testing.
+- Disable summary persistence and use a fixed three-second mock response.
+- Seed `translation:war` in Redis so search cannot call Google Translate.
+- Expose Actuator health/metrics only for this local run.
+
+```powershell
+docker exec globaltimes_beside-redis-1 redis-cli SETEX translation:war 86400 war
+
+$env:MOCK_GEMINI_PORT = "9090"
+$env:MOCK_GEMINI_DELAY_MS = "3000"
+$env:MOCK_GEMINI_STATUS = "200"
+node .\load-tests\mock-gemini-server.js
+```
+
+Backend overrides:
+
+```powershell
+$env:GEMINI_BASE_URL = "http://localhost:9090"
+$env:AI_SUMMARY_SAVE_ENABLED = "false"
+$env:MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE = "health,metrics"
+$env:SERVER_TOMCAT_MBEANREGISTRY_ENABLED = "true"
+.\gradlew.bat bootRun
+```
+
+## Execution
+
+Run each stage separately and continue only when the previous stage has no unexpected status, no dropped iterations, and no unsafe memory pressure.
+
+```powershell
+$env:BASE_URL = "http://localhost:8080"
+$env:ARTICLE_ID = "7366"
+$env:SEARCH_TEXT = "war"
+$env:DURATION = "30s"
+$env:METRICS_INTERVAL_SECONDS = "5"
+
+$env:TOTAL_RPS = "20"
+k6 run .\load-tests\k6\mixed-arrival-rate.js
+
+$env:TOTAL_RPS = "40"
+k6 run .\load-tests\k6\mixed-arrival-rate.js
+
+$env:TOTAL_RPS = "60"
+k6 run .\load-tests\k6\mixed-arrival-rate.js
+```
+
+Stop escalation when unexpected errors occur, dropped iterations are nonzero, the host becomes unresponsive, or p95 rises sharply without additional achieved throughput.
+
+Summary HTTP 503 is an expected bounded-overload response. Record it separately instead of hiding it in aggregate latency or treating it as an unexpected status.
+
+## Metrics
+
+- scheduled and achieved RPS, count, p95, and failure rate per endpoint
+- summary 200/503/unexpected counts and accepted/rejected p95
+- `dropped_iterations`
+- Tomcat busy/current threads
+- Hikari active/pending connections
+- AI executor active/queued tasks
+- application, MySQL, and Redis resource snapshots
+
+## Results
+
+| Target RPS | Achieved business RPS | Dropped | Latest p95 | Popular p95 | Detail p95 | Search p95 | Summary 200/503 | Summary accepted p95 | Tomcat busy peak | Hikari active/pending peak | Executor active/queued peak |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 20 | 20.13 | 0 | 46.04ms | 70.84ms | 53.34ms | 78.01ms | 30/0 | 3.08s | 6/10 current | 5/0 | 3/0 |
+| 40 | 40.17 | 0 | 35.43ms | 59.75ms | 41.30ms | 63.99ms | 61/0 | 3.06s | 6/10 current | 5/0 | 6/0 |
+| 60 | 60.13 | 0 | 45.08ms | 75.90ms | 54.92ms | 81.59ms | 91/0 | 3.07s | 6/10 current | 5/0 | 9/0 |
+
+### Measurement environment
+
+| Item | Value |
+| --- | --- |
+| Date | 2026-07-15 |
+| Application | one local `bootRun` process on port 8080 |
+| DB/cache | Docker MySQL 8.0 and Redis 7 |
+| Gemini | local mock on port 9090, fixed 3-second HTTP 200 |
+| Summary persistence | disabled |
+| Search translation | Redis-seeded `translation:war=war` |
+| Test article | 7366; summary and view count restored after all runs |
+| Actuator interval | six metric requests about every five seconds |
+
+`Achieved business RPS` is the sum of the five endpoint request counters divided by the 30-second arrival window. It excludes Actuator requests. The aggregate k6 `http_reqs/s` is lower because its denominator includes summary graceful completion after arrivals stop, and its numerator includes telemetry requests.
+
+Business request counts were 604, 1,205, and 1,804. Every read request returned HTTP 200, every summary request returned HTTP 200, unexpected status was zero, and all k6 thresholds passed.
+
+### Resource samples
+
+The following values are the highest periodic samples observed during each run. They are not continuous profilers or guaranteed absolute peaks.
+
+| Target RPS | App working set | MySQL CPU sample | MySQL memory | Redis memory |
+| ---: | ---: | ---: | ---: | ---: |
+| 20 | 380.8MiB | 20.99% | 449.0MiB | 11.64MiB |
+| 40 | 394.0MiB | 37.96% | 449.2MiB | 11.58MiB |
+| 60 | 395.4MiB | 54.41% | 451.4MiB | 11.70MiB |
+
+### Result interpretation
+
+- All three stages achieved the requested business arrival rate without dropped iterations or failures.
+- Read p95 did not rise monotonically and stayed below 82ms, so this range does not show read-path saturation.
+- Summary accepted p95 stayed near the controlled three-second upstream delay. Executor active tasks scaled from 3 to 9 without queueing or 503 responses.
+- Tomcat busy stayed at or below 6 of 10 current threads, and Hikari pending stayed zero. Neither servlet threads nor DB connection acquisition was the first bottleneck.
+- MySQL CPU samples rose with arrival rate while memory remained stable. This is a utilization trend, not enough evidence for an index or Hikari change because p95 and pending connections remained stable.
+- The first saturation boundary is above 60 RPS for this synthetic local mix. A future step should repeat the same environment at a cautiously higher rate or use a fixed container CPU/memory limit before selecting an implementation technology.
+
+## Interpretation rules
+
+- Rising Hikari pending connections with API p95 supports a DB connection-wait investigation.
+- Stable Hikari metrics with high Tomcat busy threads supports thread, CPU, or serialization investigation.
+- A full AI queue plus fast 503 responses confirms intentional overload protection, not higher throughput.
+- Low internal metrics with high client p95 requires checking host contention and application logs before changing indexes.
+- Do not multiply one local result directly into a multi-Pod production capacity promise.
+
+Select the next implementation issue from the first repeated bottleneck signal, not from a preferred technology.

--- a/load-tests/k6/mixed-arrival-rate.js
+++ b/load-tests/k6/mixed-arrival-rate.js
@@ -1,0 +1,204 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Counter, Gauge, Rate, Trend } from 'k6/metrics';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const ARTICLE_ID = __ENV.ARTICLE_ID || '7366';
+const SEARCH_TEXT = __ENV.SEARCH_TEXT || 'war';
+const LANGUAGE = __ENV.LANGUAGE || 'English';
+const DURATION = __ENV.DURATION || '30s';
+const TOTAL_RPS = Number(__ENV.TOTAL_RPS || 20);
+const METRICS_INTERVAL_SECONDS = Number(__ENV.METRICS_INTERVAL_SECONDS || 5);
+
+const SUPPORTED_TOTAL_RPS = [20, 40, 60];
+if (!SUPPORTED_TOTAL_RPS.includes(TOTAL_RPS)) {
+  throw new Error(`TOTAL_RPS must be one of ${SUPPORTED_TOTAL_RPS.join(', ')}`);
+}
+
+const rates = {
+  latest: TOTAL_RPS * 0.35,
+  popular: TOTAL_RPS * 0.25,
+  detail: TOTAL_RPS * 0.20,
+  search: TOTAL_RPS * 0.15,
+  summary: TOTAL_RPS * 0.05,
+};
+
+export const latestRequests = new Counter('latest_requests');
+export const latestFailures = new Rate('latest_failures');
+export const latestDuration = new Trend('latest_duration', true);
+export const popularRequests = new Counter('popular_requests');
+export const popularFailures = new Rate('popular_failures');
+export const popularDuration = new Trend('popular_duration', true);
+export const detailRequests = new Counter('detail_requests');
+export const detailFailures = new Rate('detail_failures');
+export const detailDuration = new Trend('detail_duration', true);
+export const searchRequests = new Counter('search_requests');
+export const searchFailures = new Rate('search_failures');
+export const searchDuration = new Trend('search_duration', true);
+export const summaryRequests = new Counter('summary_requests');
+export const summaryResponses200 = new Counter('summary_responses_200');
+export const summaryResponses503 = new Counter('summary_responses_503');
+export const summaryResponsesUnexpected = new Counter('summary_responses_unexpected');
+export const summaryUnexpectedFailures = new Rate('summary_unexpected_failures');
+export const summaryAcceptedDuration = new Trend('summary_accepted_duration', true);
+export const summaryRejectedDuration = new Trend('summary_rejected_duration', true);
+export const tomcatThreadsBusy = new Gauge('tomcat_threads_busy');
+export const tomcatThreadsCurrent = new Gauge('tomcat_threads_current');
+export const hikariConnectionsActive = new Gauge('hikari_connections_active');
+export const hikariConnectionsPending = new Gauge('hikari_connections_pending');
+export const asyncExecutorActive = new Gauge('async_executor_active');
+export const asyncExecutorQueued = new Gauge('async_executor_queued');
+export const metricsFailures = new Rate('mixed_metrics_failures');
+
+function regularVuBudget(rate) {
+  const preAllocatedVUs = Math.max(2, Math.ceil(rate / 2));
+  return { preAllocatedVUs, maxVUs: Math.max(preAllocatedVUs, Math.ceil(rate)) };
+}
+
+function summaryVuBudget(rate) {
+  const preAllocatedVUs = Math.max(5, Math.ceil(rate * 4));
+  return { preAllocatedVUs, maxVUs: Math.max(preAllocatedVUs + 5, Math.ceil(rate * 10)) };
+}
+
+function arrivalScenario(exec, rate, vuBudget) {
+  return {
+    executor: 'constant-arrival-rate',
+    exec,
+    rate,
+    timeUnit: '1s',
+    duration: DURATION,
+    preAllocatedVUs: vuBudget.preAllocatedVUs,
+    maxVUs: vuBudget.maxVUs,
+    gracefulStop: '20s',
+  };
+}
+
+export const options = {
+  scenarios: {
+    latest_arrivals: arrivalScenario('latestLoad', rates.latest, regularVuBudget(rates.latest)),
+    popular_arrivals: arrivalScenario('popularLoad', rates.popular, regularVuBudget(rates.popular)),
+    detail_arrivals: arrivalScenario('detailLoad', rates.detail, regularVuBudget(rates.detail)),
+    search_arrivals: arrivalScenario('searchLoad', rates.search, regularVuBudget(rates.search)),
+    summary_arrivals: arrivalScenario('summaryLoad', rates.summary, summaryVuBudget(rates.summary)),
+    server_metrics: {
+      executor: 'constant-vus',
+      exec: 'serverMetrics',
+      vus: 1,
+      startTime: '2s',
+      duration: DURATION,
+      gracefulStop: '5s',
+    },
+  },
+  thresholds: {
+    dropped_iterations: ['count==0'],
+    latest_failures: ['rate<0.05'],
+    popular_failures: ['rate<0.05'],
+    detail_failures: ['rate<0.05'],
+    search_failures: ['rate<0.05'],
+    summary_unexpected_failures: ['rate==0'],
+    mixed_metrics_failures: ['rate==0'],
+    'http_req_duration{endpoint:latest}': ['p(95)<1500'],
+    'http_req_duration{endpoint:popular}': ['p(95)<1500'],
+    'http_req_duration{endpoint:detail}': ['p(95)<2000'],
+    'http_req_duration{endpoint:search}': ['p(95)<2000'],
+    summary_accepted_duration: ['p(95)<15000'],
+  },
+};
+
+function recordRead(res, name, requests, failures, duration) {
+  const failed = res.status !== 200;
+  requests.add(1);
+  failures.add(failed);
+  duration.add(res.timings.duration);
+  check(res, { [`${name} status is 200`]: () => !failed });
+}
+
+export function latestLoad() {
+  const res = http.get(`${BASE_URL}/api/articles/latest?page=0&size=20`, {
+    tags: { api: 'mixed_arrival', endpoint: 'latest' },
+  });
+  recordRead(res, 'latest', latestRequests, latestFailures, latestDuration);
+}
+
+export function popularLoad() {
+  const res = http.get(`${BASE_URL}/api/articles/popular?page=0&size=20`, {
+    tags: { api: 'mixed_arrival', endpoint: 'popular' },
+  });
+  recordRead(res, 'popular', popularRequests, popularFailures, popularDuration);
+}
+
+export function detailLoad() {
+  const res = http.get(`${BASE_URL}/api/news/detail?id=${encodeURIComponent(ARTICLE_ID)}`, {
+    tags: { api: 'mixed_arrival', endpoint: 'detail' },
+  });
+  recordRead(res, 'detail', detailRequests, detailFailures, detailDuration);
+}
+
+export function searchLoad() {
+  const res = http.get(`${BASE_URL}/api/search?text=${encodeURIComponent(SEARCH_TEXT)}`, {
+    tags: { api: 'mixed_arrival', endpoint: 'search' },
+  });
+  recordRead(res, 'search', searchRequests, searchFailures, searchDuration);
+}
+
+export function summaryLoad() {
+  const res = http.get(
+    `${BASE_URL}/api/ai/${encodeURIComponent(ARTICLE_ID)}/summary?language=${encodeURIComponent(LANGUAGE)}`,
+    { tags: { api: 'mixed_arrival', endpoint: 'summary' } },
+  );
+
+  const accepted = res.status === 200;
+  const rejected = res.status === 503;
+  const unexpected = !accepted && !rejected;
+  summaryRequests.add(1);
+  if (accepted) {
+    summaryResponses200.add(1);
+    summaryAcceptedDuration.add(res.timings.duration);
+  }
+  if (rejected) {
+    summaryResponses503.add(1);
+    summaryRejectedDuration.add(res.timings.duration);
+  }
+  if (unexpected) summaryResponsesUnexpected.add(1);
+  summaryUnexpectedFailures.add(unexpected);
+  check(res, { 'summary status is 200 or 503': () => accepted || rejected });
+}
+
+function metricValue(name, query = '') {
+  const res = http.get(`${BASE_URL}/actuator/metrics/${name}${query}`, {
+    tags: { api: 'mixed_arrival_metrics', endpoint: 'metrics', metric: name },
+  });
+
+  let value = null;
+  try {
+    const body = res.json();
+    value = body && body.measurements && body.measurements.length > 0
+      ? Number(body.measurements[0].value)
+      : null;
+  } catch (e) {
+    value = null;
+  }
+
+  const failed = res.status !== 200 || value === null || Number.isNaN(value);
+  metricsFailures.add(failed, { metric: name });
+  check(res, { [`${name} metric is available`]: () => !failed });
+  return failed ? null : value;
+}
+
+export function serverMetrics() {
+  const tomcatBusy = metricValue('tomcat.threads.busy');
+  const tomcatCurrent = metricValue('tomcat.threads.current');
+  const hikariActive = metricValue('hikaricp.connections.active');
+  const hikariPending = metricValue('hikaricp.connections.pending');
+  const executorQuery = '?tag=name:aiSummaryExecutor';
+  const executorActive = metricValue('executor.active', executorQuery);
+  const executorQueued = metricValue('executor.queued', executorQuery);
+
+  if (tomcatBusy !== null) tomcatThreadsBusy.add(tomcatBusy);
+  if (tomcatCurrent !== null) tomcatThreadsCurrent.add(tomcatCurrent);
+  if (hikariActive !== null) hikariConnectionsActive.add(hikariActive);
+  if (hikariPending !== null) hikariConnectionsPending.add(hikariPending);
+  if (executorActive !== null) asyncExecutorActive.add(executorActive);
+  if (executorQueued !== null) asyncExecutorQueued.add(executorQueued);
+  sleep(METRICS_INTERVAL_SECONDS);
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #192

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- `latest/popular/detail/search/mock-summary`를 35/25/20/15/5 비율로 호출하는 constant-arrival-rate k6 시나리오를 추가했습니다.
- 20/40/60 RPS를 로컬 단일 인스턴스에서 점진 실행하고 endpoint별 p95, 실패, dropped iteration과 Actuator 지표를 기록했습니다.
- `NEXT_AGENT_BRIEF.md`, `WORK_PROGRESS.md`, `BACKLOG.md`에 #192 진행 상태와 측정 결과를 같은 커밋으로 반영했습니다.

## 🔍 기술적 배경
- 기존 부하 테스트는 popular 또는 Gemini summary를 격리했기 때문에 여러 자원 경로가 동시에 경쟁할 때의 단일 인스턴스 상태를 설명하기 어려웠습니다.
- k6의 외부 지표와 Tomcat/Hikari/AI executor Actuator 지표를 같은 실행 구간에서 수집해 병목 후보를 근거로 좁히도록 구성했습니다.
- 실제 Google Translate/Gemini 호출은 Redis 사전 seed와 3초 mock으로 차단했으며, endpoint 비율은 운영 트래픽이 아닌 반복 가능한 합성 모델로 한정했습니다.

## 🧪 테스트/검증 (필수)
- [x] `node --check load-tests/k6/mixed-arrival-rate.js`
- [x] `k6 inspect load-tests/k6/mixed-arrival-rate.js`
- [x] `git diff --check`
- [x] 20/40/60 RPS 각 30초 실행: achieved business RPS 20.13/40.17/60.13, dropped/error 0
- [x] 60 RPS: read p95 최대 81.59ms, summary accepted p95 3.07s, Tomcat busy 6/10 current, Hikari 5/0, executor 9/0
- [x] 기사 7366 summary/view_count 원복, 임시 DB table·Redis key·backend/mock process 제거 확인

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop` 대상)
- [x] 로컬에서 실행했을 때 에러가 발생하지 않았는가?
- [x] production 코드, API 응답, DB schema/index, cache/pool 기본 설정을 변경하지 않았는가?

## 📸 스크린샷 (선택)
- 해당 없음

## 💬 리뷰 요구사항(선택)
- endpoint별 arrival-rate 계산과 VU 상한이 의도한 비율 및 8GB 로컬 안전 범위에 맞는지 확인 부탁드립니다.
- summary 200/503/unexpected 분류와 accepted-only p95 threshold가 fast rejection을 숨기지 않는지 확인 부탁드립니다.
- Actuator telemetry가 business RPS 계산에서 분리되고 결과가 production capacity로 과장되지 않았는지 확인 부탁드립니다.

## ➕ 추후 계획(선택)
- 이번 범위에서는 60 RPS까지 포화가 확인되지 않았습니다. 동일 환경의 신중한 상위 RPS 반복 또는 고정 container CPU/memory 조건 측정 후 첫 반복 병목을 별도 이슈로 전환합니다.
