### PR TITLE
🛡️ [DATA/#196] RSS/News API 수집 중복 방지 및 재실행 안전성 개선

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -7,15 +7,20 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## Current Active Work
 
+### P1. RSS/News API 수집 중복 방지와 재실행 안전성
+
+- 상태: `Done` ([#196](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/196), [PR #197](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/197))
+- AS-IS: RSS와 News API 수집이 DB의 기존 URL만 사전 조회하므로, 같은 응답 안에서 URL이 반복되면 한 배치에 중복 저장될 수 있다. 로컬 DB에는 중복 URL 행 39건이 존재한다.
+- TO-BE: 응답 내부 URL을 먼저 중복 제거하고 기존 URL 조회와 결합해 단일 인스턴스의 순차 재실행을 안전하게 만든다.
+- 범위: `news-fetch.enabled` 실행 제어는 유지한다. DB 유니크 제약, 기존 데이터 정리, 다중 인스턴스 경쟁은 후속 트랜잭션/정합성 이슈에서 다룬다.
+- 검증: RSS/News API 각각에서 응답 내부 중복, 기존 URL 혼합, 동일 응답 재실행 및 수집 비활성화를 자동 테스트한다.
+
+## Recently Completed
+
 ### P2 follow-up. Mixed API single-instance saturation boundary
 
 - 상태: `Done` ([#194](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/194), [PR #195](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/195))
-- AS-IS: #192에서 60 RPS까지 안정적이었고 MySQL CPU periodic sample만 54.41%까지 상승해 실제 포화 경계와 최초 병목은 아직 확인되지 않았다.
-- TO-BE: 동일한 합성 트래픽을 `80 -> 100 -> 120 RPS`로 점진 실행하고 achieved throughput, p95, dropped iteration과 Tomcat/Hikari/executor/MySQL 지표를 연결한다.
-- 범위: 최초 반복 병목을 찾기 전에는 index, query, cache, pool, executor 또는 인프라를 변경하지 않는다.
 - 검증: 120.07 business RPS까지 dropped/error 없이 처리량이 증가했다. 다만 100/120 RPS에서 Hikari pending 11/18, MySQL CPU periodic sample 152.81%/203.38%, 조회 p95 최대 174.99ms/308.08ms로 DB 자원 압박이 증가했다.
-
-## Recently Completed
 
 ### P2 follow-up. Mixed API constant-arrival-rate single-instance baseline
 

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -5,17 +5,17 @@
 
 ## Current Active Work
 
-- Issue: [#194](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/194)
-- Branch: `perf/#194-mixed-saturation-boundary`
-- Status: `Done` ([PR #195](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/195))
-- Scope: extend the #192 synthetic mix to `80 -> 100 -> 120 RPS` and identify the first throughput, latency, DB, thread, executor, or host saturation signal
-- Safety: stop at the first clear saturation or unsafe-host signal; do not call real external APIs; restore article and Redis fixtures
-- Result: throughput remained stable through 120.07 business RPS with zero drops/errors, while MySQL CPU samples rose to 203.38%, Hikari pending reached 18, and maximum read p95 reached 308.08ms; DB pressure appeared from 100 RPS without a throughput plateau
+- Issue: [#196](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/196)
+- Branch: `data/#196-ingestion-idempotency`
+- Status: `Done` ([PR #197](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/197))
+- Scope: deduplicate URLs within each RSS/News API response and verify single-instance sequential rerun safety without changing the `news-fetch.enabled` collection gate
+- Baseline: local MySQL has 9,853 article rows, 9,814 distinct URLs, and 39 duplicate rows across 38 URL groups
+- Boundary: DB-enforced uniqueness, existing duplicate cleanup, and multi-instance check-then-insert races remain a follow-up transaction/data-consistency issue
 
 ## Recently Completed
 
-- #192 / PR #193: `Done`
-- Result: 60.13 achieved business RPS, zero drops/failures, read p95 at or below 81.59ms, summary p95 3.07s, Tomcat busy 6/10 current, Hikari 5/0, executor 9/0; no saturation boundary through 60 RPS
+- #194 / PR #195: `Done`
+- Result: throughput remained stable through 120.07 business RPS with zero drops/errors; DB CPU and connection pressure appeared from 100 RPS without a throughput plateau
 
 ## Read Order
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -5,27 +5,27 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Current Active Work
 
+### #196 - RSS/News API 수집 중복 방지와 재실행 안전성 개선
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/196
+- 작업 브랜치: `data/#196-ingestion-idempotency`
+- 상태: `Done` ([PR #197](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/197))
+- 주요 파일:
+  - `externalApi/service/NewsApiService.java`
+  - `externalApi/service/RssNewsService.java`
+  - RSS/News API 서비스 단위 테스트
+- 기준선: 로컬 MySQL 기사 9,853건 중 distinct URL은 9,814개이며, 38개 URL 그룹에서 중복 행 39건이 확인됐다. 중복 기사를 참조하는 scrap/chat 행은 없었다.
+- 목표: 한 수집 응답 내부의 URL 중복과 동일 응답의 순차 재실행으로 인한 중복 저장을 막고, `news-fetch.enabled=false` 수집 차단 동작을 회귀 테스트로 고정한다.
+- overengineering 판단: 현재 단일 인스턴스 기본 스케줄러에서 분산 락이나 메시지 큐는 과하다. URL `TEXT` 컬럼의 DB 유니크 제약, 기존 중복 정리, 다중 인스턴스 경쟁은 후속 트랜잭션/데이터 정합성 이슈로 분리한다.
+- 검증: 외부 네트워크 없이 응답 내부 중복, 기존 URL 혼합, 순차 재실행, 수집 플래그 비활성화 시나리오를 단위 테스트로 확인한다.
+
+## Recently Completed
+
 ### #194 - Mixed API single-instance saturation boundary
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/194
-- 작업 브랜치: `perf/#194-mixed-saturation-boundary`
 - 상태: `Done` ([PR #195](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/195))
-- 주요 파일:
-  - `load-tests/k6/mixed-arrival-rate.js`
-  - `docs/backend-improvement/mixed-saturation-boundary.md`
-- 목표: #192와 동일한 합성 트래픽을 `80 -> 100 -> 120 RPS`로 확장해 처리량 plateau와 최초 DB/thread/executor/host 병목 신호를 찾는다.
-- overengineering 판단: 기존 k6/mock/Actuator를 재사용하고 코드·DB·인프라 튜닝은 측정 뒤 별도 승인 이슈로 미룬다.
-- 안전 조건: 첫 명확한 포화, dropped/error, 또는 로컬 자원 압박에서 다음 단계를 중단하고 실제 외부 API와 영구 fixture 변경을 차단한다.
-- Reviewer: 실행 가능한 k6 지원 범위와 측정 안전 절차가 변경되므로 PR diff 검토가 필요하다.
-- 검증 결과:
-  - 80 반복/100/120 target RPS에서 achieved business RPS는 80.13/100.17/120.07이고 dropped/error/summary 503은 모두 0이었다.
-  - 첫 80 RPS는 dropped 7, Hikari pending 19가 발생했지만 회복 후 동일 단계 반복에서는 재현되지 않아 단독 포화 근거로 사용하지 않았다.
-  - Hikari active/pending은 80 반복 5/0, 100 RPS 10/11, 120 RPS 10/18로 증가했다.
-  - MySQL CPU periodic sample은 100.65%/152.81%/203.38%, 조회 API 최대 p95는 106.62ms/174.99ms/308.08ms로 증가했다.
-  - 처리량 plateau는 120 RPS까지 없었고 DB CPU/connection wait 압박이 100 RPS부터 나타난 것으로 판단했다.
-  - 기사 summary/view_count, Redis key, 임시 DB table, backend/mock process를 원복했다.
-
-## Recently Completed
+- 검증 결과: 120.07 business RPS까지 dropped/error 없이 처리량이 증가했으며, 100 RPS부터 MySQL CPU와 Hikari pending 증가로 DB 자원 압박이 확인됐다.
 
 ### #192 - Mixed API constant-arrival-rate single-instance baseline
 

--- a/src/main/java/com/example/globalTimes_be/externalApi/service/NewsApiService.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/service/NewsApiService.java
@@ -181,48 +181,63 @@ public class NewsApiService {
                 return;
             }
 
-            List<NewsApiArticleDto> articles = response.getArticles();
-            int total = articles.size();
-
-            // 기존 URL 조회
-            List<String> urls = articles.stream()
-                    .map(NewsApiArticleDto::getUrl)
-                    .collect(Collectors.toList());
-            Set<String> existingUrls = articleRepository.findExistingUrls(urls);
-
-            // Source 캐시
-            List<String> sourceNames = articles.stream()
-                    .map(NewsApiArticleDto::getSource)
-                    .filter(Objects::nonNull)
-                    .map(NewsApiSourceDto::getName)
-                    .filter(Objects::nonNull)
-                    .distinct()
-                    .collect(Collectors.toList());
-            Map<String, Source> sourceCache = sourceService.preloadSources(sourceNames);
-
-            // 단계별 카운트 집계
-            long invalidCount = articles.stream().filter(this::isInvalid).count();
-            long duplicateCount = articles.stream()
-                    .filter(dto -> !isInvalid(dto) && existingUrls.contains(dto.getUrl()))
-                    .count();
-
-            // 유효성 검증 + 중복 제거 + 저장
-            List<Article> articleList = articles.stream()
-                    .filter(dto -> !isInvalid(dto) && !existingUrls.contains(dto.getUrl()))
-                    .map(dto -> mapDtoToEntity(dto, country, category, sourceCache))
-                    .collect(Collectors.toList());
-
-            if (!articleList.isEmpty()) {
-                articleRepository.saveAll(articleList);
-                totalNewArticles += articleList.size();
-            }
-
-            log.info("[수집 통계] {} | 응답:{}, invalid:{}, 중복:{}, 저장:{}",
-                    label, total, invalidCount, duplicateCount, articleList.size());
+            processArticles(response.getArticles(), country, category);
 
         } catch (Exception e) {
             log.error("[수집 오류] {} 처리 중 오류 발생", label, e);
         }
+    }
+
+    int processArticles(List<NewsApiArticleDto> articles, String country, String category) {
+        Set<String> seenUrls = new HashSet<>();
+        List<NewsApiArticleDto> uniqueValidArticles = new ArrayList<>();
+        int invalidCount = 0;
+        int duplicateCount = 0;
+
+        for (NewsApiArticleDto article : articles) {
+            if (isInvalid(article)) {
+                invalidCount++;
+                continue;
+            }
+            if (!seenUrls.add(article.getUrl())) {
+                duplicateCount++;
+                continue;
+            }
+            uniqueValidArticles.add(article);
+        }
+
+        Set<String> existingUrls = uniqueValidArticles.isEmpty()
+                ? Collections.emptySet()
+                : articleRepository.findExistingUrls(new ArrayList<>(seenUrls));
+        List<NewsApiArticleDto> newArticles = new ArrayList<>();
+        for (NewsApiArticleDto article : uniqueValidArticles) {
+            if (existingUrls.contains(article.getUrl())) {
+                duplicateCount++;
+            } else {
+                newArticles.add(article);
+            }
+        }
+
+        List<String> sourceNames = newArticles.stream()
+                .map(NewsApiArticleDto::getSource)
+                .map(NewsApiSourceDto::getName)
+                .distinct()
+                .collect(Collectors.toList());
+        Map<String, Source> sourceCache = sourceNames.isEmpty()
+                ? new HashMap<>()
+                : sourceService.preloadSources(sourceNames);
+
+        List<Article> articleList = newArticles.stream()
+                .map(dto -> mapDtoToEntity(dto, country, category, sourceCache))
+                .collect(Collectors.toList());
+        if (!articleList.isEmpty()) {
+            articleRepository.saveAll(articleList);
+            totalNewArticles += articleList.size();
+        }
+
+        log.info("[수집 통계] {}/{} | 응답:{}, invalid:{}, 중복:{}, 저장:{}",
+                country, category, articles.size(), invalidCount, duplicateCount, articleList.size());
+        return articleList.size();
     }
 
     private boolean isInvalid(NewsApiArticleDto dto) {
@@ -231,6 +246,7 @@ public class NewsApiService {
                 dto.getDescription() == null ||
                 dto.getContent() == null ||
                 dto.getUrl() == null ||
+                dto.getUrl().isBlank() ||
                 dto.getUrlToImage() == null ||
                 dto.getPublishedAt() == null ||
                 dto.getSource() == null ||

--- a/src/main/java/com/example/globalTimes_be/externalApi/service/RssNewsService.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/service/RssNewsService.java
@@ -21,6 +21,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -96,18 +97,31 @@ public class RssNewsService {
                 return 0;
             }
 
-            // 중복 URL 사전 조회
+            return processItems(feed, items);
+
+        } catch (Exception e) {
+            log.error("[RSS 수집 오류] {} 처리 중 오류 발생", feed.sourceName(), e);
+            return 0;
+        }
+    }
+
+    int processItems(RssFeedConfig.FeedSource feed, Elements items) {
+        try {
             List<String> urls = items.stream()
                     .map(item -> item.select("link").text().trim())
                     .filter(url -> !url.isBlank())
+                    .distinct()
                     .collect(Collectors.toList());
-            Set<String> existingUrls = articleRepository.findExistingUrls(urls);
+            Set<String> existingUrls = urls.isEmpty()
+                    ? Set.of()
+                    : articleRepository.findExistingUrls(urls);
 
             // feed.sourceName()은 하드코딩된 RSS 피드 설정값이므로 null/empty 가능성 없음
             Source source = sourceService.getOrCreateSource(feed.sourceName(), null);
             if (source == null) return 0;
 
             List<Article> toSave = new ArrayList<>();
+            Set<String> seenUrls = new HashSet<>();
             int invalidCount = 0;
             int duplicateCount = 0;
 
@@ -134,7 +148,7 @@ public class RssNewsService {
                 }
 
                 // 중복 체크
-                if (existingUrls.contains(url)) {
+                if (!seenUrls.add(url) || existingUrls.contains(url)) {
                     duplicateCount++;
                     continue;
                 }
@@ -161,7 +175,7 @@ public class RssNewsService {
             return toSave.size();
 
         } catch (Exception e) {
-            log.error("[RSS 수집 오류] {} 처리 중 오류 발생", feed.sourceName(), e);
+            log.error("[RSS 수집 처리 오류] {} 처리 중 오류 발생", feed.sourceName(), e);
             return 0;
         }
     }

--- a/src/test/java/com/example/globalTimes_be/externalApi/service/NewsApiServiceTest.java
+++ b/src/test/java/com/example/globalTimes_be/externalApi/service/NewsApiServiceTest.java
@@ -1,0 +1,111 @@
+package com.example.globalTimes_be.externalApi.service;
+
+import com.example.globalTimes_be.domain.article.entity.Article;
+import com.example.globalTimes_be.domain.article.repository.ArticleRepository;
+import com.example.globalTimes_be.domain.article.service.ArticleService;
+import com.example.globalTimes_be.domain.source.entity.Source;
+import com.example.globalTimes_be.domain.source.repository.SourceRepository;
+import com.example.globalTimes_be.domain.source.service.SourceService;
+import com.example.globalTimes_be.externalApi.config.NewsFetchConfig;
+import com.example.globalTimes_be.externalApi.dto.NewsApiArticleDto;
+import com.example.globalTimes_be.externalApi.dto.NewsApiSourceDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.StreamSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class NewsApiServiceTest {
+
+    private final RestTemplate restTemplate = mock(RestTemplate.class);
+    private final ArticleRepository articleRepository = mock(ArticleRepository.class);
+    private final SourceRepository sourceRepository = mock(SourceRepository.class);
+    private final ArticleService articleService = mock(ArticleService.class);
+    private final SourceService sourceService = mock(SourceService.class);
+    private final NewsFetchConfig newsFetchConfig = mock(NewsFetchConfig.class);
+    private final NewsApiService service = new NewsApiService(
+            restTemplate, articleRepository, sourceRepository, articleService, sourceService, newsFetchConfig
+    );
+
+    @Test
+    void processArticles_savesOneArticleForDuplicateUrlsAndSkipsExistingUrl() {
+        Source source = Source.createSource("Test Source", null);
+        NewsApiArticleDto first = article("https://news.example/new", "new");
+        NewsApiArticleDto repeated = article("https://news.example/new", "repeated");
+        NewsApiArticleDto existing = article("https://news.example/existing", "existing");
+        when(articleRepository.findExistingUrls(anyList()))
+                .thenReturn(Set.of("https://news.example/existing"));
+        when(sourceService.preloadSources(List.of("Test Source")))
+                .thenReturn(Map.of("Test Source", source));
+
+        int saved = service.processArticles(List.of(first, repeated, existing), "us", "general");
+
+        assertThat(saved).isEqualTo(1);
+        verify(articleRepository).saveAll(argThat(articles -> urlsOf(articles)
+                .equals(List.of("https://news.example/new"))));
+    }
+
+    @Test
+    void processArticles_doesNotSaveWhenSameResponseIsProcessedAgain() {
+        Source source = Source.createSource("Test Source", null);
+        NewsApiArticleDto article = article("https://news.example/retry", "retry");
+        when(articleRepository.findExistingUrls(anyList()))
+                .thenReturn(Set.of(), Set.of("https://news.example/retry"));
+        when(sourceService.preloadSources(List.of("Test Source")))
+                .thenReturn(Map.of("Test Source", source));
+
+        int firstSaved = service.processArticles(List.of(article), "us", "general");
+        int secondSaved = service.processArticles(List.of(article), "us", "general");
+
+        assertThat(firstSaved).isEqualTo(1);
+        assertThat(secondSaved).isZero();
+        verify(articleRepository).saveAll(argThat(articles -> urlsOf(articles)
+                .equals(List.of("https://news.example/retry"))));
+    }
+
+    @Test
+    void collectionEntryPoints_doNothingWhenNewsFetchIsDisabled() {
+        ReflectionTestUtils.setField(service, "fetchEnabled", false);
+
+        service.init();
+        service.scheduledTopHeadlines();
+        service.scheduledFetchFixed();
+
+        verifyNoInteractions(restTemplate, articleRepository, sourceService, newsFetchConfig);
+        verify(articleRepository, never()).saveAll(anyList());
+    }
+
+    private NewsApiArticleDto article(String url, String title) {
+        NewsApiSourceDto source = new NewsApiSourceDto();
+        source.setName("Test Source");
+
+        NewsApiArticleDto article = new NewsApiArticleDto();
+        article.setAuthor("author");
+        article.setTitle(title);
+        article.setDescription("description");
+        article.setContent("content");
+        article.setUrl(url);
+        article.setUrlToImage("https://news.example/image.jpg");
+        article.setPublishedAt("2026-07-15T10:00:00Z");
+        article.setSource(source);
+        return article;
+    }
+
+    private List<String> urlsOf(Iterable<Article> articles) {
+        return StreamSupport.stream(articles.spliterator(), false)
+                .map(Article::getUrl)
+                .toList();
+    }
+}

--- a/src/test/java/com/example/globalTimes_be/externalApi/service/RssNewsServiceTest.java
+++ b/src/test/java/com/example/globalTimes_be/externalApi/service/RssNewsServiceTest.java
@@ -1,0 +1,98 @@
+package com.example.globalTimes_be.externalApi.service;
+
+import com.example.globalTimes_be.domain.article.entity.Article;
+import com.example.globalTimes_be.domain.article.repository.ArticleRepository;
+import com.example.globalTimes_be.domain.source.entity.Source;
+import com.example.globalTimes_be.domain.source.service.SourceService;
+import com.example.globalTimes_be.externalApi.config.RssFeedConfig;
+import org.jsoup.Jsoup;
+import org.jsoup.parser.Parser;
+import org.jsoup.select.Elements;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.StreamSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class RssNewsServiceTest {
+
+    private final ArticleRepository articleRepository = mock(ArticleRepository.class);
+    private final SourceService sourceService = mock(SourceService.class);
+    private final RssFeedConfig rssFeedConfig = mock(RssFeedConfig.class);
+    private final RssNewsService service = new RssNewsService(articleRepository, sourceService, rssFeedConfig);
+    private final RssFeedConfig.FeedSource feed = new RssFeedConfig.FeedSource(
+            "https://feed.example/rss", "gb", "en", "Test RSS", "general"
+    );
+
+    @Test
+    void processItems_savesOneArticleForDuplicateUrlsAndSkipsExistingUrl() {
+        Source source = Source.createSource("Test RSS", null);
+        Elements items = items(
+                item("https://news.example/new", "new"),
+                item("https://news.example/new", "repeated"),
+                item("https://news.example/existing", "existing")
+        );
+        when(articleRepository.findExistingUrls(anyList()))
+                .thenReturn(Set.of("https://news.example/existing"));
+        when(sourceService.getOrCreateSource("Test RSS", null)).thenReturn(source);
+
+        int saved = service.processItems(feed, items);
+
+        assertThat(saved).isEqualTo(1);
+        verify(articleRepository).saveAll(argThat(articles -> urlsOf(articles)
+                .equals(List.of("https://news.example/new"))));
+    }
+
+    @Test
+    void processItems_doesNotSaveWhenSameFeedIsProcessedAgain() {
+        Source source = Source.createSource("Test RSS", null);
+        Elements items = items(item("https://news.example/retry", "retry"));
+        when(articleRepository.findExistingUrls(anyList()))
+                .thenReturn(Set.of(), Set.of("https://news.example/retry"));
+        when(sourceService.getOrCreateSource("Test RSS", null)).thenReturn(source);
+
+        int firstSaved = service.processItems(feed, items);
+        int secondSaved = service.processItems(feed, items);
+
+        assertThat(firstSaved).isEqualTo(1);
+        assertThat(secondSaved).isZero();
+        verify(articleRepository).saveAll(argThat(articles -> urlsOf(articles)
+                .equals(List.of("https://news.example/retry"))));
+    }
+
+    @Test
+    void collectionEntryPoints_doNothingWhenNewsFetchIsDisabled() {
+        ReflectionTestUtils.setField(service, "fetchEnabled", false);
+
+        service.init();
+        service.scheduledFetch();
+
+        verifyNoInteractions(articleRepository, sourceService, rssFeedConfig);
+    }
+
+    private Elements items(String... items) {
+        return Jsoup.parse("<rss><channel>" + String.join("", items) + "</channel></rss>", "", Parser.xmlParser())
+                .select("item");
+    }
+
+    private String item(String url, String title) {
+        return "<item><link>" + url + "</link><title>" + title + "</title>"
+                + "<pubDate>Wed, 15 Jul 2026 10:00:00 GMT</pubDate>"
+                + "<description>description</description></item>";
+    }
+
+    private List<String> urlsOf(Iterable<Article> articles) {
+        return StreamSupport.stream(articles.spliterator(), false)
+                .map(Article::getUrl)
+                .toList();
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- closed #196

## 🛠 변경 타입
- [x] ✨ 기능 추가 (FEAT)
- [x] 🐛 버그 수정 (FIX)
- [x] 🧪 테스트/설정 (TEST/CHORE)

## 📌 작업 내용
- RSS 피드와 News API 응답에서 유효한 URL을 배치 내부 기준으로 먼저 중복 제거합니다.
- DB에 이미 저장된 URL과 배치 내부 중복을 각각 제외해 실제 저장 건수와 중복 집계를 일치시킵니다.
- 동일 응답을 순차 재실행할 때 추가 저장되지 않는 시나리오를 검증합니다.
- `news-fetch.enabled=false`에서 초기 및 스케줄 수집이 실행되지 않는 기존 제어를 회귀 테스트로 고정합니다.
- 로컬 DB 중복 기준선과 후속 데이터 정합성 범위를 backend improvement 문서에 기록합니다.

## 🧩 기술적 배경
- 기존 로직은 수집 시작 시 DB에 존재하는 URL만 조회하므로, 같은 API/RSS 응답 안에서 URL이 반복되면 동일한 `saveAll()` 배치에 중복 엔티티가 포함될 수 있었습니다.
- 로컬 MySQL 기사 9,853건에서 distinct URL은 9,814개였고 중복 URL 행 39건이 확인됐습니다.
- 현재 단일 인스턴스 기본 스케줄러 범위에서는 응답 내부 중복 제거와 순차 재실행 검증을 우선 적용합니다.
- URL 컬럼의 DB 유니크 제약, 기존 중복 정리, 다중 인스턴스의 check-then-insert 경쟁은 후속 트랜잭션/데이터 정합성 이슈로 분리합니다.

## 🧪 테스트/검증(필수)
- [x] `./gradlew test --tests "com.example.globalTimes_be.externalApi.service.*"`
- [x] `./gradlew test`
- [x] `git diff --check`

## ✅ 체크 리스트
- [x] Merge 대상 브랜치가 `develop`이다.
- [x] 로컬 전체 테스트가 통과했다.
- [x] 기존 `news-fetch.enabled` 기본값과 실행 제어를 변경하지 않았다.
- [x] 코드, 테스트, 진행 문서를 하나의 이슈 커밋으로 구성했다.

## 👀 리뷰 요구사항
- 배치 내부 중복과 DB 기존 URL이 각각 정확히 한 번씩 중복으로 집계되는지 확인해 주세요.
- `news-fetch.enabled=false`에서 News API와 RSS의 초기/스케줄 진입점이 외부 호출 및 저장을 차단하는지 확인해 주세요.
- 이번 PR이 단일 인스턴스 순차 재실행까지만 보장하며 DB 강제 유니크나 다중 인스턴스 경쟁 대응을 과장하지 않는지 확인해 주세요.

## 📍 추후 계획
- 후속 `트랜잭션 및 데이터 정합성` 이슈에서 기존 중복 데이터 정리와 URL DB 유니크 보장 방식을 별도 조사합니다.
