### PR TITLE
🔒 [DATA/#198] 기사 조회수 lost update 원자 증가로 개선

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -7,15 +7,20 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## Current Active Work
 
+### P1. 기사 상세 동시 조회 viewCount 원자 증가
+
+- 상태: `Done` ([#198](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/198), [PR #199](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/199))
+- AS-IS: 상세 조회가 Article 엔티티를 읽고 `viewCount++` 후 저장해 동시 성공 요청 20건 중 18건의 증가가 유실됐다.
+- TO-BE: DB 원자 UPDATE로 조회수를 증가시키고, 상세 응답에는 증가 완료된 값을 반환한다.
+- 범위: 정합성 검증에 집중하며 최대 TPS, Redis counter, 비관적/낙관적 락 도입은 제외한다.
+- 검증: 동일한 20 VU·20요청에서 성공 20건과 실제 증가량 20이 일치하고 테스트 데이터가 원복돼야 한다.
+
+## Recently Completed
+
 ### P1. RSS/News API 수집 중복 방지와 재실행 안전성
 
 - 상태: `Done` ([#196](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/196), [PR #197](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/197))
-- AS-IS: RSS와 News API 수집이 DB의 기존 URL만 사전 조회하므로, 같은 응답 안에서 URL이 반복되면 한 배치에 중복 저장될 수 있다. 로컬 DB에는 중복 URL 행 39건이 존재한다.
-- TO-BE: 응답 내부 URL을 먼저 중복 제거하고 기존 URL 조회와 결합해 단일 인스턴스의 순차 재실행을 안전하게 만든다.
-- 범위: `news-fetch.enabled` 실행 제어는 유지한다. DB 유니크 제약, 기존 데이터 정리, 다중 인스턴스 경쟁은 후속 트랜잭션/정합성 이슈에서 다룬다.
-- 검증: RSS/News API 각각에서 응답 내부 중복, 기존 URL 혼합, 동일 응답 재실행 및 수집 비활성화를 자동 테스트한다.
-
-## Recently Completed
+- 검증: RSS/News API 응답 내부 URL 중복 제거와 단일 인스턴스 순차 재실행을 자동 테스트로 고정했다.
 
 ### P2 follow-up. Mixed API single-instance saturation boundary
 

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -5,17 +5,18 @@
 
 ## Current Active Work
 
-- Issue: [#196](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/196)
-- Branch: `data/#196-ingestion-idempotency`
-- Status: `Done` ([PR #197](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/197))
-- Scope: deduplicate URLs within each RSS/News API response and verify single-instance sequential rerun safety without changing the `news-fetch.enabled` collection gate
-- Baseline: local MySQL has 9,853 article rows, 9,814 distinct URLs, and 39 duplicate rows across 38 URL groups
-- Boundary: DB-enforced uniqueness, existing duplicate cleanup, and multi-instance check-then-insert races remain a follow-up transaction/data-consistency issue
+- Issue: [#198](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/198)
+- Branch: `data/#198-atomic-view-count`
+- Status: `Done` ([PR #199](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/199))
+- Scope: replace article detail read-modify-write view count updates with a DB atomic increment and return the incremented value
+- Baseline: 20 concurrent successful detail requests increased `view_count` by only 2, losing 18 increments
+- Result: the same 20 VU and 20 requests increased `view_count` by exactly 20 after the atomic UPDATE; test data was restored
+- Boundary: this is a consistency check, not a maximum throughput claim; Redis counters and lock-based designs remain deferred
 
 ## Recently Completed
 
-- #194 / PR #195: `Done`
-- Result: throughput remained stable through 120.07 business RPS with zero drops/errors; DB CPU and connection pressure appeared from 100 RPS without a throughput plateau
+- #196 / PR #197: `Done`
+- Result: RSS/News API response-level URL deduplication and single-instance sequential rerun safety are covered; DB uniqueness remains a follow-up
 
 ## Read Order
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -5,21 +5,28 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Current Active Work
 
+### #198 - 기사 상세 동시 조회 viewCount lost update 원자 증가 개선
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/198
+- 작업 브랜치: `data/#198-atomic-view-count`
+- 상태: `Done` ([PR #199](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/199))
+- 주요 파일:
+  - `domain/article/repository/ArticleRepository.java`
+  - `domain/detail/service/DetailService.java`
+  - `load-tests/k6/view-count-consistency.js`
+  - `docs/backend-improvement/atomic-view-count-consistency.md`
+- 기준선: 20 VU가 같은 기사 상세 API를 총 20회 호출해 모두 성공했지만 `view_count`는 2건만 증가해 18건이 유실됐다.
+- 목표: `view_count = view_count + 1` 원자 UPDATE로 성공 요청 수와 조회수 증가량을 일치시키고 증가 완료 값을 응답한다.
+- overengineering 판단: 단일 숫자 증가에 Redis counter, 비관적 락, 낙관적 락 재시도는 과하다. 단일 DB UPDATE가 현재 규모에서 가장 작은 해법이다.
+- 검증: 동일한 20 VU·20요청에서 20건 모두 성공하고 조회수도 정확히 20 증가했다. 측정 전후 테스트 기사 조회수는 기준값 0으로 복원했다.
+
+## Recently Completed
+
 ### #196 - RSS/News API 수집 중복 방지와 재실행 안전성 개선
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/196
-- 작업 브랜치: `data/#196-ingestion-idempotency`
 - 상태: `Done` ([PR #197](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/197))
-- 주요 파일:
-  - `externalApi/service/NewsApiService.java`
-  - `externalApi/service/RssNewsService.java`
-  - RSS/News API 서비스 단위 테스트
-- 기준선: 로컬 MySQL 기사 9,853건 중 distinct URL은 9,814개이며, 38개 URL 그룹에서 중복 행 39건이 확인됐다. 중복 기사를 참조하는 scrap/chat 행은 없었다.
-- 목표: 한 수집 응답 내부의 URL 중복과 동일 응답의 순차 재실행으로 인한 중복 저장을 막고, `news-fetch.enabled=false` 수집 차단 동작을 회귀 테스트로 고정한다.
-- overengineering 판단: 현재 단일 인스턴스 기본 스케줄러에서 분산 락이나 메시지 큐는 과하다. URL `TEXT` 컬럼의 DB 유니크 제약, 기존 중복 정리, 다중 인스턴스 경쟁은 후속 트랜잭션/데이터 정합성 이슈로 분리한다.
-- 검증: 외부 네트워크 없이 응답 내부 중복, 기존 URL 혼합, 순차 재실행, 수집 플래그 비활성화 시나리오를 단위 테스트로 확인한다.
-
-## Recently Completed
+- 검증 결과: 응답 내부 URL 중복과 동일 응답의 단일 인스턴스 순차 재실행을 자동 테스트로 고정했다.
 
 ### #194 - Mixed API single-instance saturation boundary
 

--- a/docs/backend-improvement/atomic-view-count-consistency.md
+++ b/docs/backend-improvement/atomic-view-count-consistency.md
@@ -1,0 +1,57 @@
+# Atomic View Count Consistency
+
+## 목적
+
+기사 상세 API에 동시에 들어온 성공 요청 수와 `article.view_count` 증가량이 일치하는지 확인하고, JPA read-modify-write에서 발생하는 lost update를 DB 원자 UPDATE로 개선한다.
+
+## 환경과 조건
+
+- 로컬 Spring Boot 단일 인스턴스: `localhost:8080`
+- MySQL 8 Docker, transaction isolation: `REPEATABLE-READ`
+- k6 `shared-iterations`: 20 VU, 총 20 요청
+- 테스트 기사: 다른 도메인 데이터에서 참조되지 않는 기사 사용
+- 각 측정 전 조회수를 백업하고 측정 후 원래 값으로 복원
+
+```powershell
+$env:BASE_URL='http://127.0.0.1:8080'
+$env:ARTICLE_ID='<test-article-id>'
+$env:VUS='20'
+$env:REQUESTS='20'
+k6 run --quiet load-tests/k6/view-count-consistency.js
+```
+
+## 개선 전
+
+`DetailService.getNewsDetail()`은 기사를 조회한 뒤 엔티티의 `viewCount`를 증가시키고 저장했다. 동시 요청이 같은 이전 값을 읽으면 마지막 UPDATE들이 서로의 증가분을 덮어쓸 수 있다.
+
+| 성공 요청 | 기대 증가량 | 실제 증가량 | 유실 |
+| ---: | ---: | ---: | ---: |
+| 20 | 20 | 2 | 18 |
+
+HTTP 요청은 20건 모두 성공했지만 조회수는 2건만 증가했다.
+
+## 개선
+
+Repository가 다음 의미의 단일 UPDATE를 실행하게 변경했다.
+
+```sql
+UPDATE article
+SET view_count = view_count + 1
+WHERE article_id = ?;
+```
+
+UPDATE 영향 행이 0이면 기존 기사 없음 오류를 반환하고, 성공하면 기사를 다시 조회해 증가 완료된 조회수를 응답에 포함한다.
+
+## 개선 후
+
+| 성공 요청 | 기대 증가량 | 실제 증가량 | 유실 |
+| ---: | ---: | ---: | ---: |
+| 20 | 20 | 20 | 0 |
+
+동일한 20 VU·20요청에서 모든 요청이 성공했고 조회수 증가량도 20과 일치했다. 테스트 기사 조회수는 측정 후 기준값으로 복원했다.
+
+## 판단과 한계
+
+- 조회수처럼 단일 숫자를 증가시키는 쓰기에는 비관적 락이나 낙관적 락 재시도보다 DB 원자 UPDATE가 단순하다.
+- 이 결과는 로컬 단일 인스턴스의 정합성 검증이며 최대 처리량 측정이 아니다.
+- 인기 기사 한 행에 훨씬 높은 쓰기 경합이 확인되기 전에는 Redis counter나 비동기 집계를 도입하지 않는다.

--- a/load-tests/k6/view-count-consistency.js
+++ b/load-tests/k6/view-count-consistency.js
@@ -1,0 +1,33 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+const baseUrl = __ENV.BASE_URL || 'http://127.0.0.1:8080';
+const articleId = __ENV.ARTICLE_ID;
+const vus = Number(__ENV.VUS || 20);
+const requests = Number(__ENV.REQUESTS || 20);
+
+if (!articleId) {
+  throw new Error('ARTICLE_ID is required');
+}
+
+export const options = {
+  scenarios: {
+    concurrentDetail: {
+      executor: 'shared-iterations',
+      vus,
+      iterations: requests,
+      maxDuration: '30s',
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate==0'],
+    checks: ['rate==1'],
+  },
+};
+
+export default function () {
+  const response = http.get(`${baseUrl}/api/news/detail?id=${articleId}`);
+  check(response, {
+    'detail status is 200': (res) => res.status === 200,
+  });
+}

--- a/src/main/java/com/example/globalTimes_be/domain/article/entity/Article.java
+++ b/src/main/java/com/example/globalTimes_be/domain/article/entity/Article.java
@@ -135,11 +135,6 @@ public class Article {
         this.summary = summary;
     }
 
-    // get/{id} 와 같이 특정 뉴스 조회시 viewCount 증가
-    public void increaseViewCount() {
-        this.viewCount++;
-    }
-
     public void updateCountryAndCategory(String countryCode, String category) {
         this.country = countryCode;
         this.category = category == null ? "general" : category;

--- a/src/main/java/com/example/globalTimes_be/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/com/example/globalTimes_be/domain/article/repository/ArticleRepository.java
@@ -4,6 +4,7 @@ import com.example.globalTimes_be.domain.article.entity.Article;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -25,6 +26,10 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 
     @Query("SELECT a.url FROM Article a WHERE a.url IN :urls")
     Set<String> findExistingUrls(@Param("urls") List<String> urls);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Article a SET a.viewCount = a.viewCount + 1 WHERE a.id = :id")
+    int incrementViewCount(@Param("id") Long id);
 
     // 특정 id를 제외한 최신기사 20개 조회
     List<Article> findTop20ByIdNotOrderByPublishedAtDesc(Long id);

--- a/src/main/java/com/example/globalTimes_be/domain/detail/service/DetailService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/detail/service/DetailService.java
@@ -25,11 +25,13 @@ public class DetailService {
 
     @Transactional
     public DetailResDTO getNewsDetail(Long id) {
+        int updatedRows = articleRepository.incrementViewCount(id);
+        if (updatedRows == 0) {
+            throw new BaseException(DetailErrorStatus._EMPTY_NEWS_DATA.getResponse());
+        }
+
         Article article = articleRepository.findById(id)
                 .orElseThrow(() -> new BaseException(DetailErrorStatus._EMPTY_NEWS_DATA.getResponse()));
-
-        article.increaseViewCount();
-        articleRepository.save(article);
 
         DetailResponseDTO detailResponseDTO = DetailResponseDTO.builder()
                 .sourceName(article.getSource().getSourceName())

--- a/src/test/java/com/example/globalTimes_be/domain/detail/service/DetailServiceTest.java
+++ b/src/test/java/com/example/globalTimes_be/domain/detail/service/DetailServiceTest.java
@@ -1,12 +1,21 @@
 package com.example.globalTimes_be.domain.detail.service;
 
+import com.example.globalTimes_be.domain.article.entity.Article;
 import com.example.globalTimes_be.domain.article.repository.ArticleRepository;
+import com.example.globalTimes_be.domain.detail.dto.response.DetailResDTO;
+import com.example.globalTimes_be.domain.source.entity.Source;
 import com.example.globalTimes_be.global.crawler.ArticleCrawler;
+import com.example.globalTimes_be.global.exception.BaseException;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -22,6 +31,32 @@ class DetailServiceTest {
             articleCrawler,
             articleCrawlContentService
     );
+
+    @Test
+    void getNewsDetail_incrementsViewCountBeforeReadingUpdatedArticle() {
+        Article article = articleWithViewCountOne();
+        when(articleRepository.incrementViewCount(1L)).thenReturn(1);
+        when(articleRepository.findById(1L)).thenReturn(Optional.of(article));
+        when(articleRepository.findTop20ByIdNotOrderByPublishedAtDesc(1L)).thenReturn(List.of());
+
+        DetailResDTO result = detailService.getNewsDetail(1L);
+
+        assertThat(result.getNewsDetail().getViewCount()).isEqualTo(1L);
+        InOrder inOrder = inOrder(articleRepository);
+        inOrder.verify(articleRepository).incrementViewCount(1L);
+        inOrder.verify(articleRepository).findById(1L);
+        verify(articleRepository, never()).save(article);
+    }
+
+    @Test
+    void getNewsDetail_throwsWhenAtomicUpdateFindsNoArticle() {
+        when(articleRepository.incrementViewCount(99L)).thenReturn(0);
+
+        assertThatThrownBy(() -> detailService.getNewsDetail(99L))
+                .isInstanceOf(BaseException.class);
+
+        verify(articleRepository, never()).findById(99L);
+    }
 
     @Test
     void getArticleCrawledContent_returnsCachedContentWithoutCrawling() {
@@ -59,5 +94,22 @@ class DetailServiceTest {
 
         assertThat(result).isEqualTo("crawled");
         verify(articleCrawlContentService).saveCrawledContent(1L, "crawled");
+    }
+
+    private Article articleWithViewCountOne() {
+        Article article = Article.createArticle(
+                Source.createSource("Test Source", null),
+                "author",
+                "title",
+                "description",
+                "content",
+                "https://news.example/1",
+                "https://news.example/image.jpg",
+                "2026-07-15T10:00:00Z",
+                "us",
+                "general"
+        );
+        ReflectionTestUtils.setField(article, "viewCount", 1L);
+        return article;
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- closed #198

## 🛠 변경 타입
- [x] 🐛 버그 수정 (FIX)
- [x] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/설정 (TEST/CHORE)

## 📌 작업 내용
- 기사 상세 조회의 JPA read-modify-write 조회수 갱신을 DB 원자 UPDATE로 교체했습니다.
- UPDATE 영향 행이 0이면 기존 기사 없음 오류를 반환하고, 성공 후 다시 조회한 증가 완료 값을 응답합니다.
- 정상 증가 순서와 기사 없음 처리를 DetailService 단위 테스트로 고정했습니다.
- 동시 요청 정합성 검증용 k6 스크립트와 개선 전후 측정 문서를 추가했습니다.

## 🧩 기술적 배경
- 기존 `조회 → viewCount++ → save` 흐름은 동시 요청들이 같은 이전 값을 읽을 때 마지막 UPDATE가 앞선 증가분을 덮어쓰는 lost update가 발생할 수 있습니다.
- 로컬 MySQL `REPEATABLE-READ`, 20 VU·20 성공 요청에서 실제 조회수는 2건만 증가해 18건이 유실됐습니다.
- `view_count = view_count + 1` 단일 UPDATE 적용 후 동일 조건에서 20건 모두 성공하고 조회수도 정확히 20 증가했습니다.
- 테스트 기사의 조회수는 각 측정 후 기준값 0으로 복원했고 Spring Boot 측정 프로세스도 종료했습니다.

## 🧪 테스트/검증(필수)
- [x] `./gradlew test --tests "com.example.globalTimes_be.domain.detail.service.DetailServiceTest"`
- [x] `./gradlew test`
- [x] `k6 run --quiet load-tests/k6/view-count-consistency.js`와 DB 증가량 개선 전후 비교
- [x] `git diff --check`

## ✅ 체크 리스트
- [x] Merge 대상 브랜치가 `develop`이다.
- [x] 요청 성공 건수와 개선 후 조회수 증가량이 일치한다.
- [x] 존재하지 않는 기사 오류 동작을 유지한다.
- [x] 코드, 테스트, 측정 문서와 진행 기록을 하나의 이슈 커밋으로 구성했다.

## 👀 리뷰 요구사항
- `@Modifying` 원자 UPDATE가 서비스 트랜잭션 안에서 실행되고 lost update를 방지하는지 확인해 주세요.
- UPDATE 후 조회가 증가 완료된 값을 반환하며 기사 없음 동작을 유지하는지 확인해 주세요.
- 20 VU 측정을 최대 처리량이 아닌 정합성 재현으로 제한해 설명하는지 확인해 주세요.
- Redis counter나 비관적/낙관적 락을 도입하지 않은 판단이 현재 범위에 적절한지 확인해 주세요.

## 📍 추후 계획
- #196에서 남긴 수집 URL DB 유니크 제약과 다중 인스턴스 저장 경쟁은 별도 데이터 정합성 후보로 유지합니다.
