### PR TITLE
🔐 [SECURITY/#200] 보호 API matcher 및 사용자 접근 통제 개선

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -7,15 +7,20 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## Current Active Work
 
+### P1. 보호 API matcher 및 사용자 데이터 접근 통제
+
+- 상태: `Done` ([#200](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/200), [PR #201](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/201))
+- AS-IS: `/api/**.permitAll()`이 보호 matcher보다 먼저 적용돼 미인증 요청이 사용자 스크랩·채팅 컨트롤러까지 진입하고 500을 반환한다.
+- TO-BE: 구체적인 인증 matcher를 먼저 적용해 미인증 요청을 401로 차단하고 JWT principal의 userId만 서비스에 전달한다.
+- 범위: HTTP matcher와 소유권 회귀 테스트에 집중하며 RBAC, ACL, 관리자 역할, 메서드 보안은 제외한다.
+- 검증: 미인증·invalid JWT는 401, valid JWT는 자신의 userId로 200, 공개 API는 비로그인 접근을 유지해야 한다.
+
+## Recently Completed
+
 ### P1. 기사 상세 동시 조회 viewCount 원자 증가
 
 - 상태: `Done` ([#198](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/198), [PR #199](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/199))
-- AS-IS: 상세 조회가 Article 엔티티를 읽고 `viewCount++` 후 저장해 동시 성공 요청 20건 중 18건의 증가가 유실됐다.
-- TO-BE: DB 원자 UPDATE로 조회수를 증가시키고, 상세 응답에는 증가 완료된 값을 반환한다.
-- 범위: 정합성 검증에 집중하며 최대 TPS, Redis counter, 비관적/낙관적 락 도입은 제외한다.
-- 검증: 동일한 20 VU·20요청에서 성공 20건과 실제 증가량 20이 일치하고 테스트 데이터가 원복돼야 한다.
-
-## Recently Completed
+- 검증: 동일한 20 VU·20요청에서 성공 요청 수와 실제 조회수 증가량이 20으로 일치했다.
 
 ### P1. RSS/News API 수집 중복 방지와 재실행 안전성
 

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -5,18 +5,18 @@
 
 ## Current Active Work
 
-- Issue: [#198](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/198)
-- Branch: `data/#198-atomic-view-count`
-- Status: `Done` ([PR #199](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/199))
-- Scope: replace article detail read-modify-write view count updates with a DB atomic increment and return the incremented value
-- Baseline: 20 concurrent successful detail requests increased `view_count` by only 2, losing 18 increments
-- Result: the same 20 VU and 20 requests increased `view_count` by exactly 20 after the atomic UPDATE; test data was restored
-- Boundary: this is a consistency check, not a maximum throughput claim; Redis counters and lock-based designs remain deferred
+- Issue: [#200](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/200)
+- Branch: `security/#200-protected-api-matchers`
+- Status: `Done` ([PR #201](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/201))
+- Scope: place authenticated user/scrap/chat matchers before the broad `/api/**` permit rule and verify JWT principal ownership at the HTTP security boundary
+- Baseline: unauthenticated and invalid-JWT protected requests reached controllers through `/api/**.permitAll()` and returned 500 instead of being rejected
+- Result: protected requests now stop at the Security filter with 401, valid JWT subject user IDs reach scrap/chat services, and the public scrap lookup remains accessible
+- Boundary: RBAC, ACL tables, admin roles, method security, and global query-token restrictions are excluded
 
 ## Recently Completed
 
-- #196 / PR #197: `Done`
-- Result: RSS/News API response-level URL deduplication and single-instance sequential rerun safety are covered; DB uniqueness remains a follow-up
+- #198 / PR #199: `Done`
+- Result: 20 concurrent successful detail requests changed from 18 lost view-count increments to zero through a DB atomic UPDATE
 
 ## Read Order
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -5,22 +5,26 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Current Active Work
 
+### #200 - 보호 API matcher 순서 수정 및 사용자 데이터 접근 통제 테스트
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/200
+- 작업 브랜치: `security/#200-protected-api-matchers`
+- 상태: `Done` ([PR #201](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/201))
+- 주요 파일:
+  - `global/config/SecurityConfig.java`
+  - `global/config/SecurityConfigTest.java`
+- 기준선: `/api/**.permitAll()`이 구체적인 인증 matcher보다 먼저 선언되어 미인증·잘못된 JWT 요청이 스크랩/채팅 컨트롤러까지 진입하고 500을 반환했다.
+- 목표: 보호 matcher를 먼저 평가해 미인증 요청을 401로 차단하고, 유효 JWT subject의 userId만 사용자 소유 데이터 서비스에 전달한다.
+- overengineering 판단: 컨트롤러는 이미 request userId가 아닌 Authentication principal을 사용한다. RBAC, ACL 테이블, 관리자 역할, 메서드 보안은 추가하지 않고 HTTP 보안 경계와 소유권 회귀 테스트에 집중한다.
+- 검증: 미인증 및 invalid JWT 보호 API는 401, valid JWT의 userId=42는 scrap/chat 서비스에 전달, 공개 `/api/scrap`은 비로그인 200을 유지한다.
+
+## Recently Completed
+
 ### #198 - 기사 상세 동시 조회 viewCount lost update 원자 증가 개선
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/198
-- 작업 브랜치: `data/#198-atomic-view-count`
 - 상태: `Done` ([PR #199](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/199))
-- 주요 파일:
-  - `domain/article/repository/ArticleRepository.java`
-  - `domain/detail/service/DetailService.java`
-  - `load-tests/k6/view-count-consistency.js`
-  - `docs/backend-improvement/atomic-view-count-consistency.md`
-- 기준선: 20 VU가 같은 기사 상세 API를 총 20회 호출해 모두 성공했지만 `view_count`는 2건만 증가해 18건이 유실됐다.
-- 목표: `view_count = view_count + 1` 원자 UPDATE로 성공 요청 수와 조회수 증가량을 일치시키고 증가 완료 값을 응답한다.
-- overengineering 판단: 단일 숫자 증가에 Redis counter, 비관적 락, 낙관적 락 재시도는 과하다. 단일 DB UPDATE가 현재 규모에서 가장 작은 해법이다.
-- 검증: 동일한 20 VU·20요청에서 20건 모두 성공하고 조회수도 정확히 20 증가했다. 측정 전후 테스트 기사 조회수는 기준값 0으로 복원했다.
-
-## Recently Completed
+- 검증 결과: 20개 성공 요청의 조회수 증가량이 개선 전 2건에서 DB 원자 UPDATE 적용 후 20건으로 일치했다.
 
 ### #196 - RSS/News API 수집 중복 방지와 재실행 안전성 개선
 

--- a/src/main/java/com/example/globalTimes_be/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/globalTimes_be/global/config/SecurityConfig.java
@@ -7,12 +7,14 @@ import com.example.globalTimes_be.global.security.oauth2.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -36,8 +38,15 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)))
                 .authorizeHttpRequests(auth -> auth
-                        // 인증 불필요 (기존 API 전체 허용)
+                        // 사용자 소유 데이터 API는 광범위한 /api/** 허용 규칙보다 먼저 선언한다.
+                        .requestMatchers("/api/user/**").authenticated()
+                        .requestMatchers("/api/articles/*/chat-history").authenticated()
+                        .requestMatchers("/api/articles/*/scrap").authenticated()
+                        .requestMatchers("/api/articles/*/scrap/status").authenticated()
+                        // 인증 불필요
                         .requestMatchers(
                                 "/api/**",
                                 "/oauth2/**",
@@ -46,12 +55,6 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/error"
                         ).permitAll()
-                        // 사용자 정보 및 채팅 히스토리는 인증 필요
-                        .requestMatchers("/api/user/**").authenticated()
-                        .requestMatchers("/api/articles/*/chat-history").authenticated()
-                        // 스크랩 토글 및 상태 조회는 인증 필요
-                        .requestMatchers("/api/articles/*/scrap").authenticated()
-                        .requestMatchers("/api/articles/*/scrap/status").authenticated()
                         .anyRequest().permitAll()
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/src/test/java/com/example/globalTimes_be/global/config/SecurityConfigTest.java
+++ b/src/test/java/com/example/globalTimes_be/global/config/SecurityConfigTest.java
@@ -1,0 +1,104 @@
+package com.example.globalTimes_be.global.config;
+
+import com.example.globalTimes_be.domain.chat.controller.ChatHistoryController;
+import com.example.globalTimes_be.domain.chat.service.ChatHistoryService;
+import com.example.globalTimes_be.domain.scrap.controller.ScrapController;
+import com.example.globalTimes_be.domain.scrap.service.ScrapService;
+import com.example.globalTimes_be.global.security.JwtUtil;
+import com.example.globalTimes_be.global.security.oauth2.CustomOAuth2UserService;
+import com.example.globalTimes_be.global.security.oauth2.OAuth2SuccessHandler;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = {ScrapController.class, ChatHistoryController.class})
+@Import(SecurityConfig.class)
+class SecurityConfigTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtUtil jwtUtil;
+    @MockBean
+    private CustomOAuth2UserService customOAuth2UserService;
+    @MockBean
+    private OAuth2SuccessHandler oAuth2SuccessHandler;
+    @MockBean
+    private ScrapService scrapService;
+    @MockBean
+    private ChatHistoryService chatHistoryService;
+
+    @Test
+    void protectedUserApiRejectsUnauthenticatedRequest() throws Exception {
+        mockMvc.perform(get("/api/user/scraps"))
+                .andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/articles/1/chat-history"))
+                .andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/articles/1/scrap/status"))
+                .andExpect(status().isUnauthorized());
+
+        verify(scrapService, never()).getScrapList(org.mockito.ArgumentMatchers.anyLong());
+        verify(chatHistoryService, never()).getChatsByArticle(
+                org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong());
+        verify(scrapService, never()).isScrapped(
+                org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    void protectedScrapApiRejectsInvalidJwt() throws Exception {
+        when(jwtUtil.validate("invalid-token")).thenReturn(false);
+
+        mockMvc.perform(post("/api/articles/1/scrap")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer invalid-token"))
+                .andExpect(status().isUnauthorized());
+
+        verify(scrapService, never()).toggle(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    void validJwtPrincipalOwnsScrapAndChatQueries() throws Exception {
+        authenticateAs(42L);
+        when(scrapService.getScrapList(42L)).thenReturn(List.of());
+        when(chatHistoryService.getChatsByArticle(42L, 7L)).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/user/scraps")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token"))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/articles/7/chat-history")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token"))
+                .andExpect(status().isOk());
+
+        verify(scrapService).getScrapList(42L);
+        verify(chatHistoryService).getChatsByArticle(42L, 7L);
+    }
+
+    @Test
+    void publicScrapLookupRemainsAccessibleWithoutJwt() throws Exception {
+        when(scrapService.getScrap(List.of(1L))).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/scrap").param("id", "1"))
+                .andExpect(status().isOk());
+
+        verify(scrapService).getScrap(List.of(1L));
+    }
+
+    private void authenticateAs(Long userId) {
+        when(jwtUtil.validate("valid-token")).thenReturn(true);
+        when(jwtUtil.getUserId("valid-token")).thenReturn(userId);
+        when(jwtUtil.getEmail("valid-token")).thenReturn("user@example.com");
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- closed #200

## 🛠 변경 타입
- [x] 🐛 버그 수정 (FIX)
- [x] 🧪 테스트/설정 (TEST/CHORE)

## 📌 작업 내용
- `/api/user/**`, 채팅 히스토리, 스크랩 API의 `authenticated()` matcher를 광범위한 `/api/**.permitAll()`보다 먼저 배치했습니다.
- 인증되지 않은 보호 API 요청이 Controller까지 진입하지 않고 401을 반환하도록 authentication entry point를 명시했습니다.
- 유효 JWT subject의 userId가 스크랩·채팅 서비스에 전달되는지 MockMvc로 검증했습니다.
- 공개 `/api/scrap` 조회가 인증 없이 계속 접근 가능한지 회귀 테스트로 고정했습니다.

## 🧩 기술적 배경
- Spring Security authorization matcher는 선언 순서대로 평가하고 첫 번째 일치 규칙을 적용합니다.
- 기존에는 `/api/**.permitAll()`이 먼저 일치해 뒤의 사용자·스크랩·채팅 `authenticated()` 규칙이 실행되지 않았습니다.
- 기준선 테스트에서 미인증 및 잘못된 JWT 요청은 Controller까지 들어가 `Authentication` null로 500을 반환했습니다.
- 수정 후 같은 요청은 Security 필터에서 401로 종료되고 서비스와 상호작용하지 않습니다.

## 🧪 테스트/검증(필수)
- [x] `./gradlew test --tests "com.example.globalTimes_be.global.config.SecurityConfigTest"`
- [x] `./gradlew test`
- [x] `git diff --check`

검증 시나리오:
- 미인증 `/api/user/scraps`, chat-history, scrap status 요청: 401
- invalid JWT 스크랩 토글 요청: 401
- valid JWT `userId=42`: scrap/chat 서비스에 42 전달 및 200
- 공개 `/api/scrap`: 비로그인 200 유지

## ✅ 체크 리스트
- [x] Merge 대상 브랜치가 `develop`이다.
- [x] Controller가 요청 userId가 아닌 Authentication principal을 사용한다.
- [x] 보호 API의 미인증 요청이 서비스에 도달하지 않는다.
- [x] 코드, 테스트와 진행 문서를 하나의 이슈 커밋으로 구성했다.

## 👀 리뷰 요구사항
- 구체적인 보호 matcher가 `/api/**.permitAll()`보다 먼저 평가되는지 확인해 주세요.
- 401 entry point가 보호 API의 미인증 의미에 적절하고 공개/OAuth 경로를 방해하지 않는지 확인해 주세요.
- 유효 JWT subject의 userId만 스크랩·채팅 서비스에 전달되는지 확인해 주세요.
- RBAC, ACL, 관리자 역할을 제외한 범위가 현재 프로젝트 단계에 적절한지 확인해 주세요.

## 📍 추후 계획
- 모든 API에서 query-string JWT를 허용하는 현재 필터는 SSE 경로 요구사항을 확인한 뒤 별도 보안 후보로 검토합니다.
