### PR TITLE
🧪 [TEST/#202] MySQL 트랜잭션 통합 테스트 기반 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
 
 	//test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.testcontainers:mysql'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -7,15 +7,20 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## Current Active Work
 
+### P1. MySQL Testcontainers 통합 테스트 및 트랜잭션 회귀
+
+- 상태: `Done` ([#202](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/202), [PR #203](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/203))
+- AS-IS: MySQL 원자 UPDATE와 rollback은 수동 측정 또는 mock 테스트만 있어 실제 DB 회귀를 자동으로 감지하지 못한다.
+- TO-BE: 테스트 전용 MySQL 8에서 20개 동시 증가와 실패 transaction rollback을 자동 검증한다.
+- 범위: Repository slice로 제한하고 개발 DB, 전체 E2E, Redis/Kafka container는 제외한다.
+- 검증: viewCount가 동시 UPDATE 수 20과 일치하고 실패 transaction은 0으로 rollback되며 임시 container가 자동 정리돼야 한다.
+
+## Recently Completed
+
 ### P1. 보호 API matcher 및 사용자 데이터 접근 통제
 
 - 상태: `Done` ([#200](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/200), [PR #201](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/201))
-- AS-IS: `/api/**.permitAll()`이 보호 matcher보다 먼저 적용돼 미인증 요청이 사용자 스크랩·채팅 컨트롤러까지 진입하고 500을 반환한다.
-- TO-BE: 구체적인 인증 matcher를 먼저 적용해 미인증 요청을 401로 차단하고 JWT principal의 userId만 서비스에 전달한다.
-- 범위: HTTP matcher와 소유권 회귀 테스트에 집중하며 RBAC, ACL, 관리자 역할, 메서드 보안은 제외한다.
-- 검증: 미인증·invalid JWT는 401, valid JWT는 자신의 userId로 200, 공개 API는 비로그인 접근을 유지해야 한다.
-
-## Recently Completed
+- 검증: 보호 API의 미인증 요청은 401, valid JWT는 token subject userId로 접근하며 공개 API는 비로그인 접근을 유지했다.
 
 ### P1. 기사 상세 동시 조회 viewCount 원자 증가
 

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -5,18 +5,19 @@
 
 ## Current Active Work
 
-- Issue: [#200](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/200)
-- Branch: `security/#200-protected-api-matchers`
-- Status: `Done` ([PR #201](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/201))
-- Scope: place authenticated user/scrap/chat matchers before the broad `/api/**` permit rule and verify JWT principal ownership at the HTTP security boundary
-- Baseline: unauthenticated and invalid-JWT protected requests reached controllers through `/api/**.permitAll()` and returned 500 instead of being rejected
-- Result: protected requests now stop at the Security filter with 401, valid JWT subject user IDs reach scrap/chat services, and the public scrap lookup remains accessible
-- Boundary: RBAC, ACL tables, admin roles, method security, and global query-token restrictions are excluded
+- Issue: [#202](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/202)
+- Branch: `test/#202-mysql-integration`
+- Status: `Done` ([PR #203](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/203))
+- Scope: add a MySQL 8 Testcontainers Repository slice for concurrent atomic view-count updates and transaction rollback
+- Result: 20 concurrent UPDATE transactions produced viewCount 20, and a forced exception rolled the increment back to 0
+- Isolation: dynamic JDBC connection through `@ServiceConnection`; temporary schema and fixtures do not touch the compose MySQL
+- Runtime: the cached focused run completed in about 42 seconds and automatically removed MySQLContainer/Ryuk
+- Boundary: full application E2E, Redis/Kafka containers, H2 substitution, and broad conversion of unit tests are excluded
 
 ## Recently Completed
 
-- #198 / PR #199: `Done`
-- Result: 20 concurrent successful detail requests changed from 18 lost view-count increments to zero through a DB atomic UPDATE
+- #200 / PR #201: `Done`
+- Result: protected user/scrap/chat requests now return 401 without authentication while valid JWT subjects own service access
 
 ## Read Order
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -5,20 +5,27 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Current Active Work
 
+### #202 - MySQL Testcontainers 통합 테스트 및 트랜잭션 회귀 검증
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/202
+- 작업 브랜치: `test/#202-mysql-integration`
+- 상태: `Done` ([PR #203](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/203))
+- 주요 파일:
+  - `build.gradle`
+  - `domain/article/repository/ArticleRepositoryIntegrationTest.java`
+  - `docs/backend-improvement/mysql-testcontainers-integration.md`
+- 기준선: 기존 자동 테스트는 mock/WebMvc 단위에 집중되어 #198 원자 UPDATE의 실제 MySQL 동시성·rollback 동작을 자동 회귀 검증하지 못했다.
+- 목표: 테스트 전용 MySQL 8과 Repository slice에서 20개 동시 증가 및 예외 rollback을 검증하고 개발 DB와 테스트 데이터를 분리한다.
+- overengineering 판단: 전체 SpringBootTest, API E2E, Redis/Kafka는 제외한다. MySQL 고유 트랜잭션 동작만 실제 DB로 검증하는 작은 slice가 적절하다.
+- 검증: 동시 UPDATE 20건 후 viewCount 20, 강제 예외 transaction 후 viewCount 0, 종료 후 임시 MySQL/Ryuk 자동 제거, compose DB 비변경을 확인했다.
+
+## Recently Completed
+
 ### #200 - 보호 API matcher 순서 수정 및 사용자 데이터 접근 통제 테스트
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/200
-- 작업 브랜치: `security/#200-protected-api-matchers`
 - 상태: `Done` ([PR #201](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/201))
-- 주요 파일:
-  - `global/config/SecurityConfig.java`
-  - `global/config/SecurityConfigTest.java`
-- 기준선: `/api/**.permitAll()`이 구체적인 인증 matcher보다 먼저 선언되어 미인증·잘못된 JWT 요청이 스크랩/채팅 컨트롤러까지 진입하고 500을 반환했다.
-- 목표: 보호 matcher를 먼저 평가해 미인증 요청을 401로 차단하고, 유효 JWT subject의 userId만 사용자 소유 데이터 서비스에 전달한다.
-- overengineering 판단: 컨트롤러는 이미 request userId가 아닌 Authentication principal을 사용한다. RBAC, ACL 테이블, 관리자 역할, 메서드 보안은 추가하지 않고 HTTP 보안 경계와 소유권 회귀 테스트에 집중한다.
-- 검증: 미인증 및 invalid JWT 보호 API는 401, valid JWT의 userId=42는 scrap/chat 서비스에 전달, 공개 `/api/scrap`은 비로그인 200을 유지한다.
-
-## Recently Completed
+- 검증 결과: 보호 API의 미인증·invalid JWT는 401, valid JWT principal은 사용자 소유 서비스에 전달되고 공개 API는 비로그인 접근을 유지했다.
 
 ### #198 - 기사 상세 동시 조회 viewCount lost update 원자 증가 개선
 

--- a/docs/backend-improvement/mysql-testcontainers-integration.md
+++ b/docs/backend-improvement/mysql-testcontainers-integration.md
@@ -1,0 +1,56 @@
+# MySQL Testcontainers Integration Test
+
+## 목적
+
+mock 단위 테스트나 수동 API 측정만으로는 확인하기 어려운 MySQL 트랜잭션 동작을 테스트 전용 실제 MySQL에서 자동 검증한다.
+
+첫 적용 대상은 #198에서 도입한 기사 조회수 원자 증가다.
+
+## 실행 조건
+
+- Docker Engine이 실행 중이어야 한다.
+- 개발용 MySQL/Redis compose container는 실행하지 않아도 된다.
+- 첫 실행은 Testcontainers 의존성과 image 준비로 이후 실행보다 오래 걸릴 수 있다.
+
+```powershell
+./gradlew test --tests "com.example.globalTimes_be.domain.article.repository.ArticleRepositoryIntegrationTest"
+```
+
+## 테스트 구조
+
+- `@DataJpaTest`: Repository와 JPA 관련 bean만 로드
+- `MySQLContainer("mysql:8.0")`: 테스트 전용 임시 MySQL 사용
+- `@ServiceConnection`: 동적 JDBC URL과 인증 정보를 Spring Boot에 자동 연결
+- `ddl-auto=create`: 임시 database에 schema 생성
+- `TransactionTemplate`: worker별 독립 transaction과 rollback 경계 구성
+
+개발용 `application.yml`의 datasource URL이나 로컬 MySQL 계정을 테스트에 복사하지 않는다.
+컨테이너가 제거될 때 database도 함께 폐기되므로 종료 시 `create-drop` DDL은 실행하지 않는다.
+
+## 검증 결과
+
+### 동시 원자 증가
+
+- 같은 기사에 20개 worker가 각각 `incrementViewCount()` 실행
+- 각 UPDATE 영향 행: 1
+- 기대 조회수: 20
+- 실제 조회수: 20
+
+### 실패 rollback
+
+- transaction 안에서 조회수 원자 증가 후 강제 예외 발생
+- transaction 종료 후 기대 조회수: 0
+- 실제 조회수: 0
+
+## 격리와 정리
+
+- fixture는 임시 MySQL에만 저장한다.
+- 각 테스트 후 article/source fixture를 정리한다.
+- 테스트 종료 후 MySQLContainer와 Ryuk가 자동 제거되는 것을 확인했다.
+- 기존 `globaltimes_beside-mysql-1`, `globaltimes_beside-redis-1`에는 변경이 없다.
+
+## 범위와 후속 기준
+
+- 전체 `@SpringBootTest`, API E2E, Redis/Kafka container는 이번 범위에서 제외한다.
+- MySQL 고유 query, DB constraint, transaction rollback처럼 mock이나 H2로 의미가 약한 경로부터 통합 테스트를 추가한다.
+- 모든 서비스 단위 테스트를 container 테스트로 바꾸지 않는다.

--- a/src/test/java/com/example/globalTimes_be/domain/article/repository/ArticleRepositoryIntegrationTest.java
+++ b/src/test/java/com/example/globalTimes_be/domain/article/repository/ArticleRepositoryIntegrationTest.java
@@ -1,0 +1,132 @@
+package com.example.globalTimes_be.domain.article.repository;
+
+import com.example.globalTimes_be.domain.article.entity.Article;
+import com.example.globalTimes_be.domain.source.entity.Source;
+import com.example.globalTimes_be.domain.source.repository.SourceRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class ArticleRepositoryIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0");
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private SourceRepository sourceRepository;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    private TransactionTemplate transactionTemplate;
+
+    @BeforeEach
+    void setUp() {
+        transactionTemplate = new TransactionTemplate(transactionManager);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        transactionTemplate.executeWithoutResult(status -> {
+            articleRepository.deleteAll();
+            sourceRepository.deleteAll();
+        });
+    }
+
+    @Test
+    void atomicIncrementKeepsAllConcurrentUpdates() throws Exception {
+        Long articleId = createArticle();
+        int requestCount = 20;
+        ExecutorService executor = Executors.newFixedThreadPool(requestCount);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<Integer>> updates = new ArrayList<>();
+
+        try {
+            for (int i = 0; i < requestCount; i++) {
+                updates.add(executor.submit(() -> {
+                    start.await();
+                    return transactionTemplate.execute(
+                            status -> articleRepository.incrementViewCount(articleId)
+                    );
+                }));
+            }
+
+            start.countDown();
+
+            for (Future<Integer> update : updates) {
+                assertThat(update.get(30, TimeUnit.SECONDS)).isEqualTo(1);
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(currentViewCount(articleId)).isEqualTo(requestCount);
+    }
+
+    @Test
+    void atomicIncrementRollsBackWhenTransactionFails() {
+        Long articleId = createArticle();
+
+        assertThatThrownBy(() -> transactionTemplate.executeWithoutResult(status -> {
+            articleRepository.incrementViewCount(articleId);
+            throw new IllegalStateException("force rollback");
+        })).isInstanceOf(IllegalStateException.class);
+
+        assertThat(currentViewCount(articleId)).isZero();
+    }
+
+    private Long createArticle() {
+        return transactionTemplate.execute(status -> {
+            Source source = sourceRepository.saveAndFlush(Source.createSource("Integration Source", null));
+            Article article = Article.createArticle(
+                    source,
+                    "author",
+                    "title",
+                    "description",
+                    "content",
+                    "https://news.example/integration",
+                    "https://news.example/image.jpg",
+                    "2026-07-15T10:00:00Z",
+                    "us",
+                    "general"
+            );
+            return articleRepository.saveAndFlush(article).getId();
+        });
+    }
+
+    private long currentViewCount(Long articleId) {
+        return transactionTemplate.execute(status -> articleRepository.findById(articleId)
+                .orElseThrow()
+                .getViewCount());
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- closed #202

## 🛠 변경 타입
- [x] 🧪 테스트/설정 (TEST/CHORE)

## 📌 작업 내용
- Spring Boot Testcontainers, JUnit Jupiter, MySQL Testcontainers 의존성을 테스트 범위로 추가했습니다.
- `@DataJpaTest`와 `@ServiceConnection`으로 테스트 전용 MySQL 8 Repository slice를 구성했습니다.
- 기사 조회수 원자 UPDATE를 20개 독립 transaction에서 동시에 실행해 모든 증가가 보존되는지 검증했습니다.
- 원자 증가 직후 강제 예외가 발생하면 transaction이 rollback되는지 검증했습니다.
- Docker 실행 조건, 테스트 격리와 자동 정리 방식을 backend improvement 문서에 기록했습니다.

## 🧩 기술적 배경
- #198의 원자 UPDATE는 mock 단위 테스트와 로컬 수동 k6 측정으로 검증됐지만, 실제 MySQL 동시성·rollback 동작을 자동 회귀 검증하지는 못했습니다.
- H2 대신 production과 같은 MySQL 8을 임시 container로 사용하고 동적 JDBC 정보를 `@ServiceConnection`으로 주입합니다.
- container 자체가 database를 폐기하므로 `ddl-auto=create`를 사용해 container 종료 뒤 `create-drop`이 연결을 재요청하는 문제를 피했습니다.
- 전체 Spring Context가 아닌 Repository slice만 로드하고 Redis/Kafka container는 추가하지 않았습니다.

## 🧪 테스트/검증(필수)
- [x] `./gradlew test --tests "com.example.globalTimes_be.domain.article.repository.ArticleRepositoryIntegrationTest" --no-daemon`
- [x] `./gradlew test --no-daemon`
- [x] `git diff --check`

검증 결과:
- 20개 동시 UPDATE 영향 행: 모두 1
- 기대/실제 viewCount: 20/20
- 강제 예외 transaction 이후 기대/실제 viewCount: 0/0
- cached focused test: 약 42초
- 전체 suite: 2분 49초
- 테스트 종료 후 임시 MySQL/Ryuk 자동 제거
- 개발 MySQL 기사 행: 기존과 동일한 9,853건

## ✅ 체크 리스트
- [x] Merge 대상 브랜치가 `develop`이다.
- [x] 테스트 fixture가 개발용 MySQL에 저장되지 않는다.
- [x] 테스트 종료 후 임시 container가 자동 정리된다.
- [x] 테스트, 의존성, 문서와 진행 기록을 하나의 이슈 커밋으로 구성했다.

## 👀 리뷰 요구사항
- worker별 `TransactionTemplate`이 독립 transaction을 만들고 실제 동시 UPDATE를 검증하는지 확인해 주세요.
- 강제 예외가 transaction 밖으로 전파되며 증가값이 rollback되는지 확인해 주세요.
- `@DataJpaTest`, `@ServiceConnection`, `AutoConfigureTestDatabase.Replace.NONE` 조합이 개발 DB를 차단하는지 확인해 주세요.
- `ddl-auto=create`와 임시 container 자동 폐기 수명주기가 적절한지 확인해 주세요.
- 8GB 로컬 환경에서 전체 E2E 대신 Repository slice로 제한한 범위가 적절한지 확인해 주세요.

## 📍 추후 계획
- MySQL 고유 query, DB constraint, transaction rollback처럼 mock으로 검증하기 어려운 경로만 같은 기반에 선택적으로 추가합니다.
