### PR TITLE
🔐 [SECURITY/#204] SSE query token 허용 경로 제한

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -7,6 +7,16 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## Current Active Work
 
+### P1. SSE query token 허용 경로 제한
+
+- 상태: `Done` ([#204](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/204), [PR #205](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/205))
+- AS-IS: JWT 필터가 모든 요청의 `token` 쿼리 파라미터를 인증 수단으로 허용해 EventSource와 무관한 URL까지 JWT 노출 범위가 넓다.
+- TO-BE: Bearer JWT는 기존처럼 전역에서 허용하고, query JWT는 `GET /api/ai/{id}/ask`에서만 인증에 사용한다.
+- 범위: 필터 토큰 추출 조건과 허용·차단·Bearer 회귀 테스트로 제한하며 OAuth, JWT 구조, API 응답은 변경하지 않는다.
+- 검증: 허용 경로·차단 경로·Bearer 우선순위 테스트와 Testcontainers를 포함한 전체 45개 테스트가 통과했다.
+
+## Recently Completed
+
 ### P1. MySQL Testcontainers 통합 테스트 및 트랜잭션 회귀
 
 - 상태: `Done` ([#202](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/202), [PR #203](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/203))
@@ -14,8 +24,6 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 - TO-BE: 테스트 전용 MySQL 8에서 20개 동시 증가와 실패 transaction rollback을 자동 검증한다.
 - 범위: Repository slice로 제한하고 개발 DB, 전체 E2E, Redis/Kafka container는 제외한다.
 - 검증: viewCount가 동시 UPDATE 수 20과 일치하고 실패 transaction은 0으로 rollback되며 임시 container가 자동 정리돼야 한다.
-
-## Recently Completed
 
 ### P1. 보호 API matcher 및 사용자 데이터 접근 통제
 

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -5,17 +5,17 @@
 
 ## Current Active Work
 
-- Issue: [#202](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/202)
-- Branch: `test/#202-mysql-integration`
-- Status: `Done` ([PR #203](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/203))
-- Scope: add a MySQL 8 Testcontainers Repository slice for concurrent atomic view-count updates and transaction rollback
-- Result: 20 concurrent UPDATE transactions produced viewCount 20, and a forced exception rolled the increment back to 0
-- Isolation: dynamic JDBC connection through `@ServiceConnection`; temporary schema and fixtures do not touch the compose MySQL
-- Runtime: the cached focused run completed in about 42 seconds and automatically removed MySQLContainer/Ryuk
-- Boundary: full application E2E, Redis/Kafka containers, H2 substitution, and broad conversion of unit tests are excluded
+- Issue: [#204](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/204)
+- Branch: `security/#204-sse-query-token-scope`
+- Status: `Done` ([PR #205](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/205))
+- Scope: keep Bearer JWT behavior unchanged while accepting query JWT only on `GET /api/ai/{id}/ask`
+- Test: focused security tests and the full 45-test suite pass; ask SSE query authentication, ignored query tokens elsewhere, and Bearer priority are verified
+- Boundary: OAuth redirect, JWT contents, authorization rules, SSE response behavior, and Issue #110 are excluded
 
 ## Recently Completed
 
+- #202 / PR #203: `Done`
+- Result: MySQL 8 Testcontainers verifies 20 concurrent atomic increments and transaction rollback without touching the compose database
 - #200 / PR #201: `Done`
 - Result: protected user/scrap/chat requests now return 401 without authentication while valid JWT subjects own service access
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -5,6 +5,18 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Current Active Work
 
+### #204 - SSE query token 허용 경로 제한
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/204
+- 작업 브랜치: `security/#204-sse-query-token-scope`
+- 상태: `Done` ([PR #205](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/205))
+- 기준선: `JwtAuthenticationFilter`가 EventSource 지원을 위해 모든 요청에서 `token` 쿼리 파라미터를 JWT로 해석해, SSE와 무관한 URL까지 인증정보 노출 범위가 넓다.
+- 목표: Bearer JWT 동작은 유지하면서 query JWT를 로그인 사용자의 대화 저장에 인증 정보가 필요한 `GET /api/ai/{id}/ask`에서만 허용한다.
+- overengineering 판단: 인증 모델, JWT 구조, OAuth redirect, SSE 구현은 바꾸지 않는다. 기존 필터의 토큰 추출 조건과 회귀 테스트만 다루는 작은 보안 변경이 적절하다.
+- 검증: ask SSE query token 허용, 일반 API·summary SSE·비-GET ask의 query token 무시, 모든 경로의 Bearer JWT 유지 및 우선순위를 자동 테스트했다. 집중 보안 테스트와 Testcontainers를 포함한 전체 45개 테스트가 통과했다.
+
+## Recently Completed
+
 ### #202 - MySQL Testcontainers 통합 테스트 및 트랜잭션 회귀 검증
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/202
@@ -18,8 +30,6 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 - 목표: 테스트 전용 MySQL 8과 Repository slice에서 20개 동시 증가 및 예외 rollback을 검증하고 개발 DB와 테스트 데이터를 분리한다.
 - overengineering 판단: 전체 SpringBootTest, API E2E, Redis/Kafka는 제외한다. MySQL 고유 트랜잭션 동작만 실제 DB로 검증하는 작은 slice가 적절하다.
 - 검증: 동시 UPDATE 20건 후 viewCount 20, 강제 예외 transaction 후 viewCount 0, 종료 후 임시 MySQL/Ryuk 자동 제거, compose DB 비변경을 확인했다.
-
-## Recently Completed
 
 ### #200 - 보호 API matcher 순서 수정 및 사용자 데이터 접근 통제 테스트
 

--- a/src/main/java/com/example/globalTimes_be/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/globalTimes_be/global/security/JwtAuthenticationFilter.java
@@ -13,10 +13,13 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.regex.Pattern;
 
 @Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final Pattern AI_ASK_SSE_PATH = Pattern.compile("^/api/ai/[^/]+/ask/?$");
 
     private final JwtUtil jwtUtil;
 
@@ -46,11 +49,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(bearer) && bearer.startsWith("Bearer ")) {
             return bearer.substring(7);
         }
-        // EventSource는 커스텀 헤더를 지원하지 않으므로 SSE 요청에서는 쿼리 파라미터로 토큰 전달
-        String queryToken = request.getParameter("token");
-        if (StringUtils.hasText(queryToken)) {
-            return queryToken;
+        // EventSource가 사용하는 기사 질의 SSE 요청에서만 query token을 허용한다.
+        if (isAiAskSseRequest(request)) {
+            String queryToken = request.getParameter("token");
+            if (StringUtils.hasText(queryToken)) {
+                return queryToken;
+            }
         }
         return null;
+    }
+
+    private boolean isAiAskSseRequest(HttpServletRequest request) {
+        return "GET".equalsIgnoreCase(request.getMethod())
+                && AI_ASK_SSE_PATH.matcher(request.getRequestURI()).matches();
     }
 }

--- a/src/test/java/com/example/globalTimes_be/global/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/example/globalTimes_be/global/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,96 @@
+package com.example.globalTimes_be.global.security;
+
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class JwtAuthenticationFilterTest {
+
+    private final JwtUtil jwtUtil = mock(JwtUtil.class);
+    private final JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil);
+    private final FilterChain filterChain = mock(FilterChain.class);
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void queryTokenAuthenticatesAiAskSseRequest() throws Exception {
+        authenticateAs("query-token", 42L);
+        MockHttpServletRequest request = request("GET", "/api/ai/7/ask");
+        request.setParameter("token", "query-token");
+
+        filter.doFilter(request, new MockHttpServletResponse(), filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication().getPrincipal()).isEqualTo(42L);
+        verify(jwtUtil).validate("query-token");
+    }
+
+    @Test
+    void queryTokenIsIgnoredOutsideAiAskSseRequest() throws Exception {
+        MockHttpServletRequest protectedRequest = request("GET", "/api/user/scraps");
+        protectedRequest.setParameter("token", "query-token");
+
+        filter.doFilter(protectedRequest, new MockHttpServletResponse(), filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(jwtUtil, never()).validate("query-token");
+    }
+
+    @Test
+    void queryTokenIsIgnoredForSummarySseRequest() throws Exception {
+        MockHttpServletRequest request = request("GET", "/api/ai/7/summary/sse");
+        request.setParameter("token", "query-token");
+
+        filter.doFilter(request, new MockHttpServletResponse(), filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(jwtUtil, never()).validate("query-token");
+    }
+
+    @Test
+    void queryTokenIsIgnoredForNonGetAiAskRequest() throws Exception {
+        MockHttpServletRequest request = request("POST", "/api/ai/7/ask");
+        request.setParameter("token", "query-token");
+
+        filter.doFilter(request, new MockHttpServletResponse(), filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(jwtUtil, never()).validate("query-token");
+    }
+
+    @Test
+    void bearerTokenRemainsAvailableOnEveryPathAndTakesPriority() throws Exception {
+        authenticateAs("bearer-token", 99L);
+        MockHttpServletRequest request = request("GET", "/api/ai/7/ask");
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer bearer-token");
+        request.setParameter("token", "query-token");
+
+        filter.doFilter(request, new MockHttpServletResponse(), filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication().getPrincipal()).isEqualTo(99L);
+        verify(jwtUtil).validate("bearer-token");
+        verify(jwtUtil, never()).validate("query-token");
+    }
+
+    private void authenticateAs(String token, Long userId) {
+        when(jwtUtil.validate(token)).thenReturn(true);
+        when(jwtUtil.getUserId(token)).thenReturn(userId);
+        when(jwtUtil.getEmail(token)).thenReturn("user@example.com");
+    }
+
+    private MockHttpServletRequest request(String method, String path) {
+        return new MockHttpServletRequest(method, path);
+    }
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #204

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [x] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- 모든 요청에서 허용되던 `token` 쿼리 JWT를 `GET /api/ai/{id}/ask` 경로로 제한했습니다.
- `Authorization: Bearer` JWT는 기존처럼 모든 경로에서 우선 처리합니다.
- 일반 API, summary SSE, 비-GET ask 요청에서는 query token을 인증에 사용하지 않습니다.
- #204 진행 상태와 검증 결과를 `NEXT_AGENT_BRIEF.md`, `WORK_PROGRESS.md`, `BACKLOG.md`에 같은 커밋으로 기록했습니다.

## 🔍 기술적 배경
- EventSource는 커스텀 요청 헤더를 직접 설정하기 어려워 기사 질의 SSE에서 query JWT가 필요합니다.
- 기존 필터는 SSE 여부와 관계없이 모든 URL의 `token` 파라미터를 인증에 사용해 URL 기반 JWT 노출 범위가 불필요하게 넓었습니다.
- 인증 모델이나 JWT 구조는 변경하지 않고 HTTP method와 controller path 형태로 query token 진입 범위만 제한했습니다.

## 🧪 테스트/검증 (필수)
- [x] `GET /api/ai/{id}/ask`의 valid query JWT가 principal을 구성하는지 검증
- [x] 일반 API, summary SSE, 비-GET ask의 query token이 무시되는지 검증
- [x] Bearer JWT가 모든 경로에서 유지되고 query token보다 우선하는지 검증
- [x] `./gradlew test`: 45 tests, failures 0, errors 0, skipped 0

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop` 대상)
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 기존 Bearer 인증과 API 응답 동작이 유지되는가?

## 📸 스크린샷 (선택)
- 해당 없음

## 💬 리뷰 요구사항(선택)
- query token 허용 조건이 `GET /api/ai/{id}/ask`로 충분히 제한되는지 확인해주세요.
- Bearer 우선순위와 다른 API의 query token 차단 테스트가 회귀 위험을 충분히 다루는지 확인해주세요.
- JWT 값이나 사용자 질문 등 민감 정보가 새 로그에 노출되지 않는지 확인해주세요.

## ➕ 추후 계획(선택)
- OAuth redirect, JWT 구조 변경, SSE 전송 방식 변경은 이번 범위에서 제외했습니다.
- 장기 troubleshooting Issue #110은 다루지 않았습니다.
