### PR TITLE
🛡️ [DATA/#210] 기사 URL 중복 정리 및 DB 유일성 보장

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -7,6 +7,18 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## Current Active Work
 
+- 없음
+
+## Recently Completed
+
+### P1. 기사 URL 중복 정리 및 DB 유일성 제약 보강
+
+- 상태: `Done` ([#210](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/210), [PR #211](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/211))
+- AS-IS: #196 이후 수집 로직은 응답 내부와 DB 기존 URL을 제외하지만, 이전에 생성된 초과 중복 39건이 남아 있고 DB 자체 유일성 제약은 없다.
+- TO-BE: 안전한 기존 중복을 V3로 정리하고 generated SHA-256 UNIQUE로 동일 URL 저장을 DB에서 거부한다.
+- 범위: 과거 데이터 정리, DB 제약, Testcontainers 회귀 검증으로 제한한다. 실제 외부 수집, flag 변경, 분산 락·Kafka는 제외한다.
+- 검증: raw SHA-256 hash 기준 중복 정리와 case variant 보존, 삭제 전 canonical schema 검증, 실패·repair·재실행을 포함한 전체 53개 테스트와 Backend CI 통과. 로컬 기사 `9853 → 9814`, 중복 `39 → 0`, scrap/chat/source 행 수 유지.
+
 ### P1. Flyway 기반 스키마 기준선 및 Testcontainers 재현성 확보
 
 - 상태: `Done` ([#208](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/208), [PR #209](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/209))
@@ -14,8 +26,6 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 - TO-BE: V1으로 5개 도메인 테이블을 생성하고 V2로 legacy 객체 이름과 FULLTEXT를 canonical 구조로 수렴시킨 뒤 Hibernate `validate`와 Testcontainers로 자동 검증한다.
 - 범위: 현재 schema 기준선과 비파괴 local baseline으로 제한한다. URL UNIQUE, 중복 정리, 기능 schema 변경, 운영 배포는 제외한다.
 - 검증: 빈 MySQL V1→V2와 legacy baseline 1→V2, invalid index/FK 실패·repair·재실행을 재현했다. 기존 DB의 V2 적용 후 canonical FK·인덱스와 데이터 보존 및 전체 49개 테스트 통과를 확인했다.
-
-## Recently Completed
 
 ### P1. develop PR Gradle·Testcontainers 자동 테스트 및 배포 workflow 분리
 

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -5,15 +5,16 @@
 
 ## Current Active Work
 
-- Issue: [#208](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/208)
-- Branch: `db/#208-flyway-baseline`
-- Status: `Done` ([PR #209](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/209))
-- Scope: manage the five domain tables with Flyway V1 and normalize legacy constraint/index names plus the article FULLTEXT index with V2
-- Safety: existing local data remains intact; V2 changes schema object names and restores a missing FULLTEXT index without rewriting domain rows
-- Test: all 49 local tests passed with `--rerun-tasks` in about 1m 10s; the 6 focused MySQL cases include fresh/legacy success plus invalid index/FK failure-repair-retry paths
-- Boundary: URL uniqueness, duplicate cleanup, feature schema changes, production deployment, and Issue #110 are excluded
+- None
 
 ## Recently Completed
+
+- #210 / PR #211: `Done`
+- Result: Flyway V3 removed 39 safe duplicate article rows and enforces exact URL uniqueness with a generated SHA-256 UNIQUE index; all 53 tests and Backend CI passed
+- Boundary: real News API/RSS E2E, `news-fetch.enabled`, distributed locks, Kafka, multi-instance deployment, and Issue #110 remain excluded
+
+- #208 / PR #209: `Done`
+- Result: Flyway V1/V2 reproduces the five-table schema, canonical constraints/indexes, and FULLTEXT across fresh and legacy databases
 
 - #206 / PR #207: `Done`
 - Result: every `develop` PR and push runs all Gradle tests, including MySQL Testcontainers, in an independent Backend CI workflow

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -5,6 +5,20 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Current Active Work
 
+- 없음
+
+## Recently Completed
+
+### #210 - 기사 URL 중복 정리 및 DB 유일성 제약 보강
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/210
+- 작업 브랜치: `data/#210-article-url-uniqueness`
+- 상태: `Done` ([PR #211](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/211))
+- 기준선: #196 이전 동일 응답 중복 방어가 없던 시기의 흔적으로 기사 9,853건 중 고유 URL은 9,814개이며 38개 URL 그룹에 초과 행 39건이 남아 있었다.
+- 목표: 보존 데이터가 없는 과거 중복만 Flyway V3로 정리하고, `SHA2(url, 256)` generated column UNIQUE로 DB가 URL 유일성을 최종 보장한다.
+- overengineering 판단: 실제 중복이 존재하고 Flyway 기반이 준비돼 DB 제약은 적절하다. 외부 수집 E2E, Redis 분산 락, Kafka, 멀티 인스턴스 구성은 현재 단일 순차 수집 범위에 과해 제외한다.
+- 검증: Testcontainers에서 raw SHA-256 hash 기준 안전 중복 정리와 대소문자 URL 보존, summary/scrap 참조 중복 차단, 잘못된 generated column의 삭제 전 실패·repair·재실행, 동일 URL 동시 INSERT 1건 성공/1건 거부를 확인했다. 집중 테스트 10개와 전체 53개 테스트 및 Backend CI가 통과했다. 로컬 V3 적용 후 기사 9,814건·고유 URL 9,814개·중복 0건이며 scrap 1, chat 4, source 673은 유지됐다.
+
 ### #208 - Flyway 기반 스키마 기준선 및 Testcontainers 재현성 확보
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/208
@@ -14,8 +28,6 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 - 목표: 5개 도메인 테이블을 Flyway V1으로 관리하고, V2에서 legacy constraint/index 이름과 기사 FULLTEXT 인덱스를 canonical 구조로 수렴시킨다. Hibernate는 `ddl-auto=validate`로 migration 결과만 검증한다.
 - overengineering 판단: 현재 스키마를 V1으로 고정하고 재현 테스트만 추가한다. URL UNIQUE, 중복 데이터 정리, 신규 테이블·컬럼, 운영 배포 자동화는 별도 근거가 필요하므로 제외한다.
 - 검증: 빈 MySQL의 V1→V2와 Hibernate식 이름·FULLTEXT 누락 fixture의 baseline 1→V2를 Testcontainers에서 검증했다. 잘못된 canonical index와 `ON DELETE CASCADE` FK는 migration 실패 후 구조 수정·repair·재실행되는 negative test로 고정했다. 기존 로컬 DB에도 V2를 적용해 5개 FK와 주요 인덱스 이름, `FULLTEXT(title, description)`을 canonical 구조로 통일했으며 전후 행 수 `article 9853 / source 673 / users 1 / scrap 1 / chat_history 4`가 동일하다. 전체 49개 테스트가 약 1분 10초에 통과했다.
-
-## Recently Completed
 
 ### #206 - develop PR Gradle·Testcontainers 자동 테스트 및 배포 workflow 분리
 

--- a/docs/backend-improvement/article-url-uniqueness.md
+++ b/docs/backend-improvement/article-url-uniqueness.md
@@ -1,0 +1,69 @@
+# Article URL Uniqueness
+
+## 문제
+
+#196은 News API/RSS 응답 내부의 동일 URL을 `seenUrls`로 제거하고 DB 기존 URL을 일괄 조회해 순차 재실행 중복을 막았다.
+그 이전 데이터에는 동일 응답에서 함께 저장된 것으로 보이는 URL 중복이 남아 있었다.
+
+- 전체 기사: 9,853건
+- 고유 URL: 9,814개
+- 중복 URL 그룹: 38개
+- 초과 중복 행: 39건
+- 삭제 후보의 scrap/chat 참조: 0건
+- 삭제 후보의 summary/crawled content/non-zero view count: 0건
+
+URL과 source 분포에는 연합뉴스, BBC, SCMP, NHK, TechCrunch 등 실제 언론사 도메인이 사용됐고 test/example URL은 0건이었다. 이번 작업에서 `news-fetch.enabled`를 켜거나 외부 API를 다시 호출하지 않았다.
+
+## V3 정책
+
+`V3__enforce_article_url_uniqueness.sql`은 `url_hash`별 가장 큰 `article_id`를 최신 저장 행으로 보고 보존한다. MySQL 기본 collation의 대소문자/악센트 비구분 비교로 서로 다른 URL을 삭제하지 않도록 원문 URL의 SHA-256 hash를 동일성 기준으로 사용한다.
+
+중복 데이터를 변경하기 전에 기존 `url_hash` generated column과 canonical index 구조를 먼저 검증한다. generated expression은 공백과 backtick을 정규화한 뒤 `UNHEX(SHA2(url, 256))`과 정확히 비교하므로, 잘못된 기존 구조에서는 행을 삭제하지 않고 migration이 실패한다.
+
+삭제 후보에 아래 데이터가 하나라도 있으면 자동 삭제하지 않고 migration을 실패시킨다.
+
+- scrap 또는 chat_history 참조
+- summary 또는 crawled_content
+- 0이 아닌 view_count
+
+안전한 중복을 정리한 뒤 다음 generated column과 UNIQUE 인덱스를 추가한다.
+
+```sql
+url_hash BINARY(32)
+    GENERATED ALWAYS AS (UNHEX(SHA2(url, 256))) STORED
+```
+
+```sql
+UNIQUE INDEX uk_article_url_hash (url_hash)
+```
+
+현재 최대 URL 길이 406자를 기준으로 URL을 `VARCHAR`로 축소하거나 prefix UNIQUE를 사용하지 않았다. SHA-256 충돌 가능성은 이론적으로 0이 아니지만, 프로젝트 데이터 규모에서 긴 원문 URL을 보존하면서 고정 길이 인덱스를 사용하는 현실적인 DB 불변식으로 선택했다.
+
+## Testcontainers 검증
+
+- 신규 DB에서 Flyway V1→V2→V3 성공
+- V2 상태의 안전 중복 2건을 V3가 최신 행 1건으로 정리
+- 대소문자만 다른 URL은 서로 다른 hash와 행으로 유지
+- summary 또는 scrap 참조가 있는 삭제 후보에서 V3 실패 및 원본·참조 데이터 유지
+- 잘못된 generated column에서 중복 삭제 전 실패하고, 구조 수정·Flyway repair·재실행 성공
+- V3 이후 동일 URL 동시 INSERT 2건 중 1건 성공, 1건 duplicate key 거부
+- 기존 FK/FULLTEXT/transaction 회귀를 포함한 집중 테스트 10개 통과
+- 전체 Gradle 테스트 53개 통과
+
+## 로컬 DB 적용 결과
+
+- Flyway version 3, type SQL, success 1
+- 기사: 9,853 → 9,814건
+- 고유 URL: 9,814 → 9,814개
+- 초과 중복: 39 → 0건
+- 생성된 url_hash: 9,814개, 고유 hash 9,814개
+- scrap: 1 → 1건
+- chat_history: 4 → 4건
+- source: 673 → 673건
+- migration procedure 잔여물: 0개
+
+## 범위 경계
+
+현재 단일 인스턴스의 수집 loop와 기본 scheduler는 순차 실행되고 #196 이후 응답 내부 중복도 제거된다. 따라서 V3는 현재 동시성 장애를 과장한 해결이 아니라 과거 데이터 정리와 DB 최종 불변식 보강이다.
+
+실제 News API/RSS E2E, `news-fetch.enabled` 변경, Redis 분산 락, Kafka, 멀티 인스턴스 배포는 포함하지 않는다.

--- a/docs/backend-improvement/mysql-testcontainers-integration.md
+++ b/docs/backend-improvement/mysql-testcontainers-integration.md
@@ -47,6 +47,16 @@ mock 단위 테스트나 수동 API 측정만으로는 확인하기 어려운 My
 - 실패 후 구조 수정, Flyway repair, V2 재실행 및 procedure 정리를 확인
 - 집중 테스트 6개와 전체 49개 테스트 통과
 
+### 기사 URL 유일성 V3
+
+- V2 상태의 임시 DB에 동일 URL 기사 2건을 넣고 V3가 최신 `article_id` 1건만 남기는지 확인
+- 대소문자만 다른 URL은 raw SHA-256 hash가 다르므로 별도 행으로 유지되는지 확인
+- 삭제 후보에 summary 또는 scrap 참조가 있으면 V3가 실패하고 원본·참조 데이터를 유지하는지 확인
+- 잘못된 generated column에서는 삭제 전에 실패하고 구조 수정·Flyway repair·재실행이 가능한지 확인
+- V3 적용 후 동일 URL 동시 INSERT 2건 중 1건만 성공하고 최종 1행만 남는지 확인
+- `uk_article_url_hash(url_hash)` UNIQUE와 신규 DB V1→V2→V3 이력 확인
+- 집중 테스트 10개와 전체 53개 테스트 통과
+
 ### 동시 원자 증가
 
 - 같은 기사에 20개 worker가 각각 `incrementViewCount()` 실행

--- a/src/main/resources/db/migration/V3__enforce_article_url_uniqueness.sql
+++ b/src/main/resources/db/migration/V3__enforce_article_url_uniqueness.sql
@@ -1,0 +1,117 @@
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS enforce_article_url_uniqueness$$
+
+CREATE PROCEDURE enforce_article_url_uniqueness()
+BEGIN
+    DECLARE v_unsafe_duplicate_count INT DEFAULT 0;
+    DECLARE v_column_count INT DEFAULT 0;
+    DECLARE v_matching_column_count INT DEFAULT 0;
+    DECLARE v_index_count INT DEFAULT 0;
+    DECLARE v_matching_index_count INT DEFAULT 0;
+
+    SELECT COUNT(*)
+      INTO v_column_count
+      FROM information_schema.columns
+     WHERE table_schema = DATABASE()
+       AND table_name = 'article'
+       AND column_name = 'url_hash';
+
+    SELECT COUNT(*)
+      INTO v_matching_column_count
+      FROM information_schema.columns
+     WHERE table_schema = DATABASE()
+       AND table_name = 'article'
+       AND column_name = 'url_hash'
+       AND data_type = 'binary'
+       AND character_maximum_length = 32
+       AND extra LIKE '%STORED GENERATED%'
+       AND LOWER(REPLACE(REPLACE(generation_expression, '`', ''), ' ', ''))
+           = 'unhex(sha2(url,256))';
+
+    IF v_column_count > 0 AND v_matching_column_count = 0 THEN
+        SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'article.url_hash has an unexpected definition';
+    END IF;
+
+    IF v_column_count = 0 THEN
+        ALTER TABLE article
+            ADD COLUMN url_hash BINARY(32)
+                GENERATED ALWAYS AS (UNHEX(SHA2(url, 256))) STORED;
+    END IF;
+
+    SELECT COUNT(DISTINCT index_name)
+      INTO v_index_count
+      FROM information_schema.statistics
+     WHERE table_schema = DATABASE()
+       AND table_name = 'article'
+       AND index_name = 'uk_article_url_hash';
+
+    SELECT COUNT(*)
+      INTO v_matching_index_count
+      FROM (
+            SELECT index_name,
+                   non_unique,
+                   index_type,
+                   GROUP_CONCAT(column_name ORDER BY seq_in_index) AS indexed_columns
+              FROM information_schema.statistics
+             WHERE table_schema = DATABASE()
+               AND table_name = 'article'
+               AND index_name = 'uk_article_url_hash'
+             GROUP BY index_name, non_unique, index_type
+           ) url_hash_index
+     WHERE non_unique = 0
+       AND index_type = 'BTREE'
+       AND indexed_columns = 'url_hash';
+
+    IF v_index_count > 0 AND v_matching_index_count = 0 THEN
+        SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'article.uk_article_url_hash has an unexpected definition';
+    END IF;
+
+    SELECT COUNT(*)
+      INTO v_unsafe_duplicate_count
+      FROM article duplicate_article
+      JOIN (
+            SELECT url_hash, MAX(article_id) AS survivor_id
+              FROM article
+             GROUP BY url_hash
+            HAVING COUNT(*) > 1
+           ) duplicate_group
+        ON duplicate_group.url_hash = duplicate_article.url_hash
+       AND duplicate_group.survivor_id <> duplicate_article.article_id
+      LEFT JOIN scrap ON scrap.article_id = duplicate_article.article_id
+      LEFT JOIN chat_history ON chat_history.article_id = duplicate_article.article_id
+     WHERE scrap.scrap_id IS NOT NULL
+        OR chat_history.chat_id IS NOT NULL
+        OR duplicate_article.summary IS NOT NULL
+        OR duplicate_article.crawled_content IS NOT NULL
+        OR COALESCE(duplicate_article.view_count, 0) <> 0;
+
+    IF v_unsafe_duplicate_count > 0 THEN
+        SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'Unsafe duplicate article data must be resolved before URL uniqueness migration';
+    END IF;
+
+    DELETE duplicate_article
+      FROM article duplicate_article
+      JOIN (
+            SELECT url_hash, MAX(article_id) AS survivor_id
+              FROM article
+             GROUP BY url_hash
+            HAVING COUNT(*) > 1
+           ) duplicate_group
+        ON duplicate_group.url_hash = duplicate_article.url_hash
+       AND duplicate_group.survivor_id <> duplicate_article.article_id;
+
+    IF v_index_count = 0 THEN
+        ALTER TABLE article
+            ADD UNIQUE INDEX uk_article_url_hash (url_hash);
+    END IF;
+END$$
+
+DELIMITER ;
+
+CALL enforce_article_url_uniqueness();
+
+DROP PROCEDURE enforce_article_url_uniqueness;

--- a/src/test/java/com/example/globalTimes_be/domain/article/repository/ArticleRepositoryIntegrationTest.java
+++ b/src/test/java/com/example/globalTimes_be/domain/article/repository/ArticleRepositoryIntegrationTest.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.jdbc.datasource.init.ScriptUtils;
@@ -77,7 +78,7 @@ class ArticleRepositoryIntegrationTest {
     @Test
     void flywayCreatesBaselineSchemaAndFullTextIndex() {
         Integer migrationCount = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM flyway_schema_history WHERE version IN ('1', '2') AND success = 1",
+                "SELECT COUNT(*) FROM flyway_schema_history WHERE version IN ('1', '2', '3') AND success = 1",
                 Integer.class
         );
         Integer domainTableCount = jdbcTemplate.queryForObject(
@@ -88,7 +89,7 @@ class ArticleRepositoryIntegrationTest {
         );
         List<String> fullTextColumns = fullTextColumns(jdbcTemplate);
 
-        assertThat(migrationCount).isEqualTo(2);
+        assertThat(migrationCount).isEqualTo(3);
         assertThat(domainTableCount).isEqualTo(5);
         assertThat(fullTextColumns).containsExactly("title", "description");
     }
@@ -144,7 +145,7 @@ class ArticleRepositoryIntegrationTest {
             );
             flyway.repair();
 
-            assertThat(flyway.migrate().migrationsExecuted).isEqualTo(1);
+            assertThat(flyway.migrate().migrationsExecuted).isEqualTo(2);
             assertThat(normalizationProcedureCount(legacyJdbcTemplate)).isZero();
             assertThat(schemaObjectNames(legacyJdbcTemplate)).contains("uk_source_name");
         } finally {
@@ -178,10 +179,207 @@ class ArticleRepositoryIntegrationTest {
             );
             flyway.repair();
 
-            assertThat(flyway.migrate().migrationsExecuted).isEqualTo(1);
+            assertThat(flyway.migrate().migrationsExecuted).isEqualTo(2);
             assertThat(normalizationProcedureCount(legacyJdbcTemplate)).isZero();
             assertThat(foreignKeyRules(legacyJdbcTemplate, "fk_article_source"))
                     .isEqualTo("NO ACTION/NO ACTION");
+        } finally {
+            dropDatabase(databaseName);
+        }
+    }
+
+    @Test
+    void flywayV3RemovesSafeDuplicatesAndRejectsFutureDuplicateUrl() throws Exception {
+        String databaseName = "url_uniqueness_baseline";
+        DriverManagerDataSource dataSource = createLegacyDatabase(databaseName);
+        JdbcTemplate targetJdbcTemplate = new JdbcTemplate(dataSource);
+
+        try {
+            flywayAtVersion2(dataSource).migrate();
+            long sourceId = insertSource(targetJdbcTemplate, "URL Unique Source");
+            insertArticle(targetJdbcTemplate, sourceId, "older title", "https://news.example/duplicate", null);
+            insertArticle(targetJdbcTemplate, sourceId, "latest title", "https://news.example/duplicate", null);
+            insertArticle(targetJdbcTemplate, sourceId, "other title", "https://news.example/other", null);
+            insertArticle(targetJdbcTemplate, sourceId, "upper path", "https://news.example/Path", null);
+            insertArticle(targetJdbcTemplate, sourceId, "lower path", "https://news.example/path", null);
+
+            assertThat(baselineFlyway(dataSource).migrate().migrationsExecuted).isEqualTo(1);
+            assertThat(articleCountByExactUrl(targetJdbcTemplate, "https://news.example/duplicate")).isEqualTo(1);
+            assertThat(targetJdbcTemplate.queryForObject(
+                    "SELECT title FROM article WHERE url = ?",
+                    String.class,
+                    "https://news.example/duplicate"
+            )).isEqualTo("latest title");
+            assertThat(articleCountByExactUrl(targetJdbcTemplate, "https://news.example/Path")).isEqualTo(1);
+            assertThat(articleCountByExactUrl(targetJdbcTemplate, "https://news.example/path")).isEqualTo(1);
+            assertThat(targetJdbcTemplate.queryForObject(
+                    "SELECT COUNT(DISTINCT HEX(url_hash)) FROM article " +
+                            "WHERE LOWER(url) = 'https://news.example/path'",
+                    Integer.class
+            )).isEqualTo(2);
+            assertThat(urlHashIndexColumns(targetJdbcTemplate)).containsExactly("url_hash");
+
+            assertThatThrownBy(() -> insertArticle(
+                    targetJdbcTemplate,
+                    sourceId,
+                    "duplicate after V3",
+                    "https://news.example/duplicate",
+                    null
+            )).isInstanceOf(DataIntegrityViolationException.class);
+        } finally {
+            dropDatabase(databaseName);
+        }
+    }
+
+    @Test
+    void flywayV3RejectsDuplicateThatContainsPreservedData() throws Exception {
+        String databaseName = "unsafe_url_duplicate_baseline";
+        DriverManagerDataSource dataSource = createLegacyDatabase(databaseName);
+        JdbcTemplate targetJdbcTemplate = new JdbcTemplate(dataSource);
+
+        try {
+            flywayAtVersion2(dataSource).migrate();
+            long sourceId = insertSource(targetJdbcTemplate, "Unsafe Duplicate Source");
+            insertArticle(
+                    targetJdbcTemplate,
+                    sourceId,
+                    "older enriched title",
+                    "https://news.example/unsafe-duplicate",
+                    "summary to preserve"
+            );
+            insertArticle(
+                    targetJdbcTemplate,
+                    sourceId,
+                    "latest title",
+                    "https://news.example/unsafe-duplicate",
+                    null
+            );
+            long protectedArticleId = targetJdbcTemplate.queryForObject(
+                    "SELECT MIN(article_id) FROM article WHERE url = ?",
+                    Long.class,
+                    "https://news.example/unsafe-duplicate"
+            );
+            long userId = insertUser(targetJdbcTemplate, "unsafe-duplicate-user@example.com");
+            targetJdbcTemplate.update(
+                    "INSERT INTO scrap(created_at, article_id, user_id) VALUES (NOW(6), ?, ?)",
+                    protectedArticleId,
+                    userId
+            );
+
+            Flyway flyway = baselineFlyway(dataSource);
+
+            assertThatThrownBy(flyway::migrate)
+                    .isInstanceOf(FlywayException.class)
+                    .hasRootCauseMessage(
+                            "Unsafe duplicate article data must be resolved before URL uniqueness migration"
+                    );
+            assertThat(articleCountByUrl(
+                    targetJdbcTemplate,
+                    "https://news.example/unsafe-duplicate"
+            )).isEqualTo(2);
+            assertThat(targetJdbcTemplate.queryForObject(
+                    "SELECT COUNT(*) FROM scrap",
+                    Integer.class
+            )).isEqualTo(1);
+
+            targetJdbcTemplate.update("DELETE FROM scrap");
+            targetJdbcTemplate.update(
+                    "UPDATE article SET summary = NULL WHERE article_id = ?",
+                    protectedArticleId
+            );
+            flyway.repair();
+
+            assertThat(flyway.migrate().migrationsExecuted).isEqualTo(1);
+            assertThat(articleCountByExactUrl(
+                    targetJdbcTemplate,
+                    "https://news.example/unsafe-duplicate"
+            )).isEqualTo(1);
+            assertThat(urlUniquenessProcedureCount(targetJdbcTemplate)).isZero();
+        } finally {
+            dropDatabase(databaseName);
+        }
+    }
+
+    @Test
+    void flywayV3ValidatesCanonicalColumnBeforeDeletingDuplicatesAndCanRetry() throws Exception {
+        String databaseName = "invalid_url_hash_baseline";
+        DriverManagerDataSource dataSource = createLegacyDatabase(databaseName);
+        JdbcTemplate targetJdbcTemplate = new JdbcTemplate(dataSource);
+
+        try {
+            flywayAtVersion2(dataSource).migrate();
+            long sourceId = insertSource(targetJdbcTemplate, "Invalid URL Hash Source");
+            insertArticle(targetJdbcTemplate, sourceId, "older title", "https://news.example/schema-error", null);
+            insertArticle(targetJdbcTemplate, sourceId, "latest title", "https://news.example/schema-error", null);
+            targetJdbcTemplate.execute(
+                    "ALTER TABLE article ADD COLUMN url_hash BINARY(32) " +
+                            "GENERATED ALWAYS AS " +
+                            "(UNHEX(SHA2(CONCAT(url, 'wrong'), 256))) STORED"
+            );
+            Flyway flyway = baselineFlyway(dataSource);
+
+            assertThatThrownBy(flyway::migrate)
+                    .isInstanceOf(FlywayException.class)
+                    .hasRootCauseMessage("article.url_hash has an unexpected definition");
+            assertThat(articleCountByExactUrl(
+                    targetJdbcTemplate,
+                    "https://news.example/schema-error"
+            )).isEqualTo(2);
+            assertThat(urlUniquenessProcedureCount(targetJdbcTemplate)).isEqualTo(1);
+
+            targetJdbcTemplate.execute("ALTER TABLE article DROP COLUMN url_hash");
+            flyway.repair();
+
+            assertThat(flyway.migrate().migrationsExecuted).isEqualTo(1);
+            assertThat(articleCountByExactUrl(
+                    targetJdbcTemplate,
+                    "https://news.example/schema-error"
+            )).isEqualTo(1);
+            assertThat(urlUniquenessProcedureCount(targetJdbcTemplate)).isZero();
+        } finally {
+            dropDatabase(databaseName);
+        }
+    }
+
+    @Test
+    void databaseUniqueConstraintAllowsOnlyOneConcurrentInsertPerUrl() throws Exception {
+        String databaseName = "concurrent_url_uniqueness";
+        DriverManagerDataSource dataSource = createLegacyDatabase(databaseName);
+        JdbcTemplate targetJdbcTemplate = new JdbcTemplate(dataSource);
+
+        try {
+            baselineFlyway(dataSource).migrate();
+            long sourceId = insertSource(targetJdbcTemplate, "Concurrent URL Source");
+            String url = "https://news.example/concurrent";
+            ExecutorService executor = Executors.newFixedThreadPool(2);
+            CountDownLatch start = new CountDownLatch(1);
+            List<Future<Boolean>> inserts = new ArrayList<>();
+
+            try {
+                for (int i = 0; i < 2; i++) {
+                    int sequence = i;
+                    inserts.add(executor.submit(() -> {
+                        start.await();
+                        try {
+                            insertArticle(targetJdbcTemplate, sourceId, "title " + sequence, url, null);
+                            return true;
+                        } catch (DataIntegrityViolationException e) {
+                            return false;
+                        }
+                    }));
+                }
+                start.countDown();
+
+                List<Boolean> results = new ArrayList<>();
+                for (Future<Boolean> insert : inserts) {
+                    results.add(insert.get(30, TimeUnit.SECONDS));
+                }
+                assertThat(results).containsExactlyInAnyOrder(true, false);
+            } finally {
+                executor.shutdownNow();
+            }
+
+            assertThat(articleCountByExactUrl(targetJdbcTemplate, url)).isEqualTo(1);
         } finally {
             dropDatabase(databaseName);
         }
@@ -285,6 +483,15 @@ class ArticleRepositoryIntegrationTest {
                 .load();
     }
 
+    private Flyway flywayAtVersion2(DriverManagerDataSource dataSource) {
+        return Flyway.configure()
+                .dataSource(dataSource)
+                .baselineOnMigrate(true)
+                .baselineVersion("1")
+                .target("2")
+                .load();
+    }
+
     private void dropDatabase(String databaseName) {
         jdbcTemplate.execute("DROP DATABASE IF EXISTS " + databaseName);
     }
@@ -338,6 +545,99 @@ class ArticleRepositoryIntegrationTest {
                         "WHERE constraint_schema = DATABASE() AND constraint_name = ?",
                 String.class,
                 constraintName
+        );
+    }
+
+    private long insertSource(JdbcTemplate targetJdbcTemplate, String sourceName) {
+        targetJdbcTemplate.update(
+                "INSERT INTO source(source_api_id, source_name) VALUES (NULL, ?)",
+                sourceName
+        );
+        return targetJdbcTemplate.queryForObject(
+                "SELECT source_id FROM source WHERE source_name = ?",
+                Long.class,
+                sourceName
+        );
+    }
+
+    private void insertArticle(
+            JdbcTemplate targetJdbcTemplate,
+            long sourceId,
+            String title,
+            String url,
+            String summary
+    ) {
+        targetJdbcTemplate.update(
+                "INSERT INTO article(" +
+                        "author, category, content, country, crawled_content, description, " +
+                        "published_at, summary, title, url, url_to_image, view_count, source_id, language" +
+                        ") VALUES (?, ?, ?, ?, NULL, ?, NOW(6), ?, ?, ?, ?, 0, ?, ?)",
+                "author",
+                "general",
+                "content",
+                "us",
+                "description",
+                summary,
+                title,
+                url,
+                "https://news.example/image.jpg",
+                sourceId,
+                "en"
+        );
+    }
+
+    private int articleCountByUrl(JdbcTemplate targetJdbcTemplate, String url) {
+        Integer count = targetJdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM article WHERE url = ?",
+                Integer.class,
+                url
+        );
+        return count == null ? 0 : count;
+    }
+
+    private int articleCountByExactUrl(JdbcTemplate targetJdbcTemplate, String url) {
+        Integer count = targetJdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM article WHERE BINARY url = BINARY ?",
+                Integer.class,
+                url
+        );
+        return count == null ? 0 : count;
+    }
+
+    private long insertUser(JdbcTemplate targetJdbcTemplate, String email) {
+        targetJdbcTemplate.update(
+                "INSERT INTO users(created_at, email, nickname, provider, provider_id) " +
+                        "VALUES (NOW(6), ?, ?, ?, ?)",
+                email,
+                "nickname",
+                "test",
+                email
+        );
+        Long userId = targetJdbcTemplate.queryForObject(
+                "SELECT user_id FROM users WHERE email = ?",
+                Long.class,
+                email
+        );
+        return userId == null ? 0L : userId;
+    }
+
+    private int urlUniquenessProcedureCount(JdbcTemplate targetJdbcTemplate) {
+        Integer count = targetJdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM information_schema.routines " +
+                        "WHERE routine_schema = DATABASE() " +
+                        "AND routine_name = 'enforce_article_url_uniqueness'",
+                Integer.class
+        );
+        return count == null ? 0 : count;
+    }
+
+    private List<String> urlHashIndexColumns(JdbcTemplate targetJdbcTemplate) {
+        return targetJdbcTemplate.queryForList(
+                "SELECT column_name FROM information_schema.statistics " +
+                        "WHERE table_schema = DATABASE() AND table_name = 'article' " +
+                        "AND index_name = 'uk_article_url_hash' AND non_unique = 0 " +
+                        "ORDER BY seq_in_index",
+                String.class
         );
     }
 }


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #210

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)


## 📝 작업 내용
- Flyway V3가 raw SHA-256 `url_hash`별 최신 `article_id`를 남기고 #196 이전 안전한 중복 행을 정리합니다.
- 중복 삭제 전에 기존 generated column과 canonical index 정의를 검증하며, 식이 다르면 데이터를 변경하지 않고 실패합니다.
- 삭제 후보에 scrap/chat 참조, summary, crawled content, non-zero view count가 있으면 migration을 실패시킵니다.
- `SHA2(url, 256)` 기반 `BINARY(32)` stored generated column과 UNIQUE 인덱스로 DB 수준 URL 유일성을 보장합니다.
- Testcontainers에 case variant 보존, malformed schema 실패·repair·재실행, 참조 데이터 보존, 동일 URL 동시 INSERT 검증을 추가했습니다.

## 🔍 기술적 배경
- 현재 단일 인스턴스 순차 수집과 #196의 `seenUrls`/기존 URL 조회는 신규 중복을 방어하지만, 개선 전 생성된 초과 중복 39건이 DB에 남아 있었습니다.
- MySQL 기본 collation의 대소문자·악센트 비구분 비교가 URL path를 합치지 않도록 최종 UNIQUE와 같은 raw SHA-256 hash를 중복 판단 기준으로 사용합니다.
- `url`이 TEXT이므로 길이를 제한하는 VARCHAR 변환이나 prefix UNIQUE 대신 긴 URL 원문을 유지하는 고정 길이 SHA-256 generated column을 선택했습니다.
- 이번 변경은 현재 동시성 장애를 과장한 해결이 아니라 과거 데이터 정리와 애플리케이션 로직 회귀에 대비한 DB 최종 불변식입니다.


## 🧪 테스트/검증 (필수)
- [x] 신규 MySQL에서 Flyway V1→V2→V3와 `uk_article_url_hash(url_hash)`를 확인했습니다.
- [x] V2 상태의 exact duplicate 2건은 최신 행 1건으로 정리되고 대소문자만 다른 URL 2건은 모두 보존되는지 확인했습니다.
- [x] summary 또는 scrap 참조가 있는 삭제 후보에서는 V3가 실패하고 원본·참조 데이터를 유지하는지 확인했습니다.
- [x] 잘못된 generated column에서는 중복 삭제 전에 실패하고, 구조 수정·`flyway.repair()`·V3 재실행 후 procedure가 정리되는지 확인했습니다.
- [x] 동일 URL 동시 INSERT 2건 중 1건 성공, 1건 duplicate key 거부, 최종 1행을 확인했습니다.
- [x] 집중 MySQL 테스트 10개와 `./gradlew test --rerun-tasks` 전체 53개 테스트가 통과했습니다.
- [x] 로컬 V3 repair 후 checksum `863431790`, 기사/정확 URL/hash 9,814개, 중복 그룹 0개, scrap 1, chat 4, source 673, procedure 0개를 확인했습니다.


## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?


## 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
- 중복 그룹과 UNIQUE가 모두 raw SHA-256 기준으로 일치하는지 확인해주세요.
- 기존 generated column/index 검증이 데이터 삭제 전에 수행되고 expression을 정확히 비교하는지 확인해주세요.
- unsafe duplicate 및 malformed schema 실패 후 데이터 보존과 repair·재실행 테스트가 충분한지 확인해주세요.


## ➕ 추후 계획(선택)
- 실제 News API/RSS E2E, `news-fetch.enabled` 변경, 분산 락, Kafka, 멀티 인스턴스 구성은 별도 근거가 있을 때 검토합니다.
