### PR TITLE
🧪 [TEST/#212] News API 수집 실패 격리 E2E 검증

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -11,6 +11,14 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## Recently Completed
 
+### P1. News API 수집 부분 실패 격리 및 재실행 E2E 검증
+
+- 상태: `Done` ([#212](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/212), [PR #213](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/213))
+- AS-IS: DTO와 mock repository 단위 테스트만 있어 외부 HTTP 일부 실패부터 MySQL 저장까지의 수집 경로가 자동 검증되지 않는다.
+- TO-BE: random-port mock upstream과 MySQL Testcontainers로 200·500·timeout 혼합 수집, 정상 기사 저장, 실패 격리, 재실행 중복 0건을 검증한다.
+- 범위: News API headline 수집 pipeline E2E와 base URL 설정화로 제한한다. 실제 API/RSS, flag 활성화, retry/circuit breaker, 분산 락·Kafka는 제외한다.
+- 검증: 정상 category 2건 저장, 실패 category 2건 격리, 재실행 후 기사 2건·중복 그룹 0건 유지, 전체 54개 테스트와 Backend CI 통과.
+
 ### P1. 기사 URL 중복 정리 및 DB 유일성 제약 보강
 
 - 상태: `Done` ([#210](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/210), [PR #211](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/211))

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -9,6 +9,10 @@
 
 ## Recently Completed
 
+- #212 / PR #213: `Done`
+- Result: a random-port mock upstream and MySQL Testcontainers verify 200/500/timeout isolation, two successful article saves, and zero duplicate URL groups after rerun; all 54 tests and Backend CI passed
+- Boundary: real News API/RSS calls, `news-fetch.enabled=true`, retry/circuit breaker, distributed locks, Kafka, multi-instance deployment, and Issue #110 remain excluded
+
 - #210 / PR #211: `Done`
 - Result: Flyway V3 removed 39 safe duplicate article rows and enforces exact URL uniqueness with a generated SHA-256 UNIQUE index; all 53 tests and Backend CI passed
 - Boundary: real News API/RSS E2E, `news-fetch.enabled`, distributed locks, Kafka, multi-instance deployment, and Issue #110 remain excluded

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -9,6 +9,16 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Recently Completed
 
+### #212 - News API 수집 부분 실패 격리 및 재실행 E2E 검증
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/212
+- 작업 브랜치: `test/#212-news-api-failure-e2e`
+- 상태: `Done` ([PR #213](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/213))
+- 기준선: 기존 테스트는 News API DTO 처리와 mock repository까지만 검증해 HTTP 5xx·timeout이 실제 MySQL 저장과 후속 요청에 미치는 영향을 자동 확인하지 않았다.
+- 목표: local mock upstream의 200·500·timeout 혼합 응답을 실제 RestTemplate과 MySQL Testcontainers로 통과시켜 부분 실패 격리와 재실행 중복 0건을 검증한다.
+- overengineering 판단: 기존 Spring·Testcontainers와 JDK HTTP server만 사용하고 실제 API, RSS, retry/circuit breaker, 분산 락·Kafka는 제외한다.
+- 검증: general/technology 정상 기사 2건은 저장되고 business 500과 science timeout 이후에도 수집이 계속됐다. 같은 4-category 시나리오를 두 번 실행한 뒤 기사 2건과 `url_hash` 중복 그룹 0건이 유지됐으며 전체 54개 테스트와 Backend CI가 통과했다.
+
 ### #210 - 기사 URL 중복 정리 및 DB 유일성 제약 보강
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/210

--- a/docs/backend-improvement/mysql-testcontainers-integration.md
+++ b/docs/backend-improvement/mysql-testcontainers-integration.md
@@ -57,6 +57,13 @@ mock 단위 테스트나 수동 API 측정만으로는 확인하기 어려운 My
 - `uk_article_url_hash(url_hash)` UNIQUE와 신규 DB V1→V2→V3 이력 확인
 - 집중 테스트 10개와 전체 53개 테스트 통과
 
+### News API 수집 부분 실패 E2E
+
+- random-port JDK mock HTTP server에서 headline category별 200, 500, timeout 응답을 통제
+- 실제 RestTemplate, JSON 역직렬화, Source/Article JPA 저장, Flyway V3 URL UNIQUE를 MySQL 8 Testcontainer에서 검증
+- 일부 요청 실패 후에도 정상 기사 2건 저장, 같은 수집 재실행 후 기사 2건과 URL 중복 그룹 0건 유지
+- 기존 compose DB와 8080 서버, 실제 News API key를 사용하지 않으며 전체 54개 테스트 통과
+
 ### 동시 원자 증가
 
 - 같은 기사에 20개 worker가 각각 `incrementViewCount()` 실행

--- a/docs/backend-improvement/news-api-ingestion-failure-e2e.md
+++ b/docs/backend-improvement/news-api-ingestion-failure-e2e.md
@@ -1,0 +1,56 @@
+# News API 수집 실패 격리 E2E
+
+## 목적
+
+#196은 News API 응답 내부와 기존 DB URL을 애플리케이션에서 걸러 재실행 중복을 줄였고, #210은 generated SHA-256 UNIQUE로 동일 URL 저장을 DB에서 최종 거부한다. 그러나 기존 단위 테스트는 DTO 처리와 mock repository까지만 검증해 외부 HTTP 실패가 실제 MySQL 저장 경로에 미치는 영향은 확인하지 않았다.
+
+이 테스트는 일부 News API 요청이 5xx 또는 timeout으로 실패해도 다른 정상 응답의 기사가 저장되고, 같은 수집을 재실행해도 중복이 생기지 않는지를 자동 검증한다.
+
+## 테스트 경계
+
+```text
+JDK local mock HTTP server
+→ RestTemplate
+→ News API JSON 역직렬화
+→ 유효성·응답 내부 중복·기존 URL 검사
+→ Source/Article JPA 저장
+→ Flyway V3가 적용된 MySQL 8 Testcontainers
+```
+
+mock server가 외부 News API 응답만 대신하며 나머지 수집 경로는 실제 애플리케이션 코드를 사용한다. 따라서 이 결과는 `mock upstream 기반 수집 pipeline E2E`이며 실제 News API의 인증, quota, 운영 네트워크, 실제 기사 품질까지 검증한 운영형 E2E로 표현하지 않는다.
+
+## 시나리오와 결과
+
+한 번의 headline 수집에서 네 category를 순서대로 요청한다.
+
+| category | mock 조건 | 기대 결과 |
+| --- | --- | --- |
+| general | HTTP 200, 정상 기사 1건 | 저장 |
+| business | HTTP 500 | 오류 로그 후 다음 요청 계속 |
+| science | client read timeout보다 늦은 응답 | 오류 로그 후 다음 요청 계속 |
+| technology | HTTP 200, 정상 기사 1건 | 저장 |
+
+같은 시나리오를 두 번 실행한 결과는 다음과 같다.
+
+- mock 요청: category별 2회, 총 8회
+- 첫 실행 후 정상 기사: 2건
+- 두 번째 실행 후 정상 기사: 2건 유지
+- `url_hash` 중복 그룹: 0건
+- 500과 timeout은 각각 오류 로그로 구분되고 technology 요청까지 계속 실행
+- 전체 Gradle 테스트: 54개 통과, 약 2분 50초
+
+## 실행 조건
+
+- Docker Desktop/daemon은 MySQL Testcontainers 실행을 위해 필요하다.
+- 기존 Docker Hub MySQL 컨테이너와 8080 백엔드 서버는 필요하지 않다.
+- mock HTTP server는 테스트 프로세스가 임의 포트를 할당하고 종료 시 정리한다.
+- MySQL Testcontainer도 테스트가 자동 생성·삭제하므로 compose DB 데이터를 사용하지 않는다.
+- `news-fetch.enabled=false`를 유지하며 실제 API key와 quota를 소비하지 않는다.
+
+## 운영 동작
+
+`spring.newsapi.base-url`의 기본값은 기존 `https://newsapi.org`다. 테스트만 임의 포트의 local mock URL을 주입하며 운영 기본 endpoint, 스케줄, request limit, delay는 변경하지 않는다.
+
+## 범위 경계
+
+실제 News API/RSS 운영형 E2E, retry, circuit breaker, Redis 분산 락, Kafka, 멀티 인스턴스 수집은 포함하지 않는다. 반복 장애율이나 복구 요구가 확인되기 전에는 현재 요청 단위 실패 격리보다 복잡한 복구 기술을 추가하지 않는다.

--- a/src/main/java/com/example/globalTimes_be/externalApi/service/NewsApiService.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/service/NewsApiService.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.OffsetDateTime;
@@ -36,6 +37,9 @@ public class NewsApiService {
 
     @Value("${spring.newsapi.api-key}")
     private String apiKey;
+
+    @Value("${spring.newsapi.base-url:https://newsapi.org}")
+    private String newsApiBaseUrl;
 
     // false = 로컬 개발 중 스케줄러/초기 적재 비활성화 (API 할당량 절약)
     // 수집 테스트 시 application.yml 에서 news-fetch.enabled: true 로 변경
@@ -108,7 +112,7 @@ public class NewsApiService {
     */
 
     // Country + Category 조합으로 헤드라인 수집 (국가/카테고리는 NewsFetchConfig에서 관리)
-    private void fetchTopHeadlines(boolean isInit) {
+    void fetchTopHeadlines(boolean isInit) {
         outer:
         for (String country : newsFetchConfig.getCountries()) {
             for (String category : newsFetchConfig.getCategories()) {
@@ -117,11 +121,15 @@ public class NewsApiService {
                     break outer;
                 }
                 try {
-                    String apiUrl = "https://newsapi.org/v2/top-headlines?"
-                            + "country=" + country
-                            + "&category=" + category
-                            + "&pageSize=" + newsFetchConfig.getPageSize()
-                            + "&apiKey=" + apiKey;
+                    String apiUrl = UriComponentsBuilder.fromUriString(newsApiBaseUrl)
+                            .path("/v2/top-headlines")
+                            .queryParam("country", country)
+                            .queryParam("category", category)
+                            .queryParam("pageSize", newsFetchConfig.getPageSize())
+                            .queryParam("apiKey", apiKey)
+                            .build()
+                            .encode()
+                            .toUriString();
 
                     requestCount++;
                     processApiRequest(apiUrl, country, category);
@@ -147,10 +155,14 @@ public class NewsApiService {
                 break;
             }
             try {
-                String apiUrl = "https://newsapi.org/v2/everything?"
-                        + "domains=" + domain
-                        + "&pageSize=" + newsFetchConfig.getPageSize()
-                        + "&apiKey=" + apiKey;
+                String apiUrl = UriComponentsBuilder.fromUriString(newsApiBaseUrl)
+                        .path("/v2/everything")
+                        .queryParam("domains", domain)
+                        .queryParam("pageSize", newsFetchConfig.getPageSize())
+                        .queryParam("apiKey", apiKey)
+                        .build()
+                        .encode()
+                        .toUriString();
 
                 requestCount++;
                 // 도메인 기사는 특정 국가에 종속되지 않으므로 "global"로 처리

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,6 +38,7 @@ spring:
   #news
   newsapi:
     api-key: ${NEWS_API_KEY}
+    base-url: ${NEWS_API_BASE_URL:https://newsapi.org}
 
   #google translate
   google:

--- a/src/test/java/com/example/globalTimes_be/externalApi/service/NewsApiCollectionIntegrationTest.java
+++ b/src/test/java/com/example/globalTimes_be/externalApi/service/NewsApiCollectionIntegrationTest.java
@@ -1,0 +1,233 @@
+package com.example.globalTimes_be.externalApi.service;
+
+import com.example.globalTimes_be.domain.article.repository.ArticleRepository;
+import com.example.globalTimes_be.domain.article.service.ArticleService;
+import com.example.globalTimes_be.domain.source.repository.SourceRepository;
+import com.example.globalTimes_be.domain.source.service.SourceService;
+import com.example.globalTimes_be.externalApi.config.NewsFetchConfig;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@ExtendWith(OutputCaptureExtension.class)
+@Import(SourceService.class)
+class NewsApiCollectionIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
+            .withUsername("root")
+            .withPassword("test");
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private SourceRepository sourceRepository;
+
+    @Autowired
+    private SourceService sourceService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private final Map<String, AtomicInteger> requestCounts = new ConcurrentHashMap<>();
+    private HttpServer mockNewsApi;
+    private ExecutorService mockExecutor;
+
+    @BeforeEach
+    void startMockNewsApi() throws IOException {
+        mockNewsApi = HttpServer.create(new InetSocketAddress(0), 0);
+        mockNewsApi.createContext("/v2/top-headlines", this::handleTopHeadlines);
+        mockExecutor = Executors.newCachedThreadPool();
+        mockNewsApi.setExecutor(mockExecutor);
+        mockNewsApi.start();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        if (mockNewsApi != null) {
+            mockNewsApi.stop(0);
+        }
+        if (mockExecutor != null) {
+            mockExecutor.shutdownNow();
+        }
+        jdbcTemplate.update("DELETE FROM article");
+        jdbcTemplate.update("DELETE FROM source");
+        requestCounts.clear();
+    }
+
+    @Test
+    void mixedUpstreamFailuresDoNotBlockSuccessfulArticlesAndRerunIsIdempotent(CapturedOutput output) {
+        NewsApiService service = newsApiService();
+
+        service.fetchTopHeadlines(false);
+
+        assertThat(articleCount()).isEqualTo(2);
+        assertThat(exactUrlCount("https://news.example/general")).isEqualTo(1);
+        assertThat(exactUrlCount("https://news.example/technology")).isEqualTo(1);
+
+        service.fetchTopHeadlines(false);
+
+        assertThat(articleCount()).isEqualTo(2);
+        assertThat(duplicateUrlGroupCount()).isZero();
+        assertThat(requestCounts).containsOnlyKeys("general", "business", "science", "technology");
+        assertThat(requestCounts).allSatisfy((category, count) -> assertThat(count).hasValue(2));
+        assertThat(output).contains("[수집 오류] us/business 처리 중 오류 발생");
+        assertThat(output).contains("[수집 오류] us/science 처리 중 오류 발생");
+    }
+
+    private NewsApiService newsApiService() {
+        NewsFetchConfig config = mock(NewsFetchConfig.class);
+        when(config.getCountries()).thenReturn(List.of("us"));
+        when(config.getCategories()).thenReturn(List.of("general", "business", "science", "technology"));
+        when(config.getPageSize()).thenReturn(10);
+        when(config.getMaxRequestsPerRun()).thenReturn(10);
+        when(config.getRequestDelayMs()).thenReturn(0L);
+
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(1_000);
+        requestFactory.setReadTimeout(500);
+
+        NewsApiService service = new NewsApiService(
+                new RestTemplate(requestFactory),
+                articleRepository,
+                sourceRepository,
+                mock(ArticleService.class),
+                sourceService,
+                config
+        );
+        ReflectionTestUtils.setField(service, "apiKey", "test-api-key");
+        ReflectionTestUtils.setField(service, "newsApiBaseUrl", mockBaseUrl());
+        return service;
+    }
+
+    private void handleTopHeadlines(HttpExchange exchange) throws IOException {
+        String category = queryParameters(exchange).get("category");
+        requestCounts.computeIfAbsent(category, ignored -> new AtomicInteger()).incrementAndGet();
+
+        if ("business".equals(category)) {
+            exchange.sendResponseHeaders(500, -1);
+            exchange.close();
+            return;
+        }
+        if ("science".equals(category)) {
+            try {
+                Thread.sleep(1_000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                exchange.close();
+                return;
+            }
+        }
+
+        byte[] response = newsApiResponse(category).getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, response.length);
+        try {
+            exchange.getResponseBody().write(response);
+        } finally {
+            exchange.close();
+        }
+    }
+
+    private Map<String, String> queryParameters(HttpExchange exchange) {
+        return Arrays.stream(exchange.getRequestURI().getRawQuery().split("&"))
+                .map(parameter -> parameter.split("=", 2))
+                .collect(Collectors.toMap(
+                        pair -> URLDecoder.decode(pair[0], StandardCharsets.UTF_8),
+                        pair -> pair.length == 2
+                                ? URLDecoder.decode(pair[1], StandardCharsets.UTF_8)
+                                : ""
+                ));
+    }
+
+    private String newsApiResponse(String category) {
+        return """
+                {
+                  "status": "ok",
+                  "totalResults": 1,
+                  "articles": [
+                    {
+                      "source": {"id": null, "name": "Mock News"},
+                      "author": "author",
+                      "title": "%s title",
+                      "description": "description",
+                      "url": "https://news.example/%s",
+                      "urlToImage": "https://news.example/image.jpg",
+                      "publishedAt": "2026-07-18T10:00:00Z",
+                      "content": "content"
+                    }
+                  ]
+                }
+                """.formatted(category, category);
+    }
+
+    private String mockBaseUrl() {
+        return "http://127.0.0.1:" + mockNewsApi.getAddress().getPort();
+    }
+
+    private int articleCount() {
+        Integer count = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM article", Integer.class);
+        return count == null ? 0 : count;
+    }
+
+    private int exactUrlCount(String url) {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM article WHERE BINARY url = BINARY ?",
+                Integer.class,
+                url
+        );
+        return count == null ? 0 : count;
+    }
+
+    private int duplicateUrlGroupCount() {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM (" +
+                        "SELECT url_hash FROM article GROUP BY url_hash HAVING COUNT(*) > 1" +
+                        ") duplicate_urls",
+                Integer.class
+        );
+        return count == null ? 0 : count;
+    }
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #212

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)


## 📝 작업 내용
- News API base URL을 `spring.newsapi.base-url`로 설정화하고 기본값은 기존 `https://newsapi.org`로 유지했습니다.
- JDK random-port mock HTTP server에서 headline category별 200, 500, timeout 응답을 재현했습니다.
- 실제 RestTemplate, JSON 역직렬화, JPA 저장, Flyway V3 URL UNIQUE를 MySQL 8 Testcontainers로 검증했습니다.
- 같은 혼합 실패 시나리오를 재실행해 정상 기사 수와 URL 중복 그룹이 변하지 않는지 확인했습니다.

## 🔍 기술적 배경
- 기존 테스트는 News API DTO 처리와 mock repository까지만 검증해 외부 HTTP 일부 실패가 실제 MySQL 저장과 후속 요청에 미치는 영향은 확인하지 않았습니다.
- 실제 News API는 quota, 응답 데이터, 장애 조건을 통제할 수 없어 반복 가능한 자동 회귀 테스트에는 local mock upstream을 사용했습니다.
- mock server는 외부 응답만 대체하며 HTTP 호출부터 MySQL 저장까지는 실제 애플리케이션 경로를 사용합니다.
- `news-fetch.enabled=false`를 유지하고 실제 API key와 quota를 사용하지 않습니다.


## 🧪 테스트/검증 (필수)
- [x] general/technology HTTP 200 응답의 기사 2건이 실제 MySQL에 저장되는지 확인했습니다.
- [x] business HTTP 500과 science read timeout 이후에도 다음 요청이 계속 실행되는지 확인했습니다.
- [x] 동일 시나리오를 두 번 실행한 뒤 기사 2건과 `url_hash` 중복 그룹 0건이 유지되는지 확인했습니다.
- [x] category별 요청 2회, 총 8회와 500/timeout 오류 로그 구분을 확인했습니다.
- [x] `./gradlew test --rerun-tasks` 전체 54개 테스트가 약 2분 50초에 통과했습니다.
- [x] 기존 Docker Hub DB와 8080 서버 없이 random-port mock server와 임시 MySQL Testcontainer만 사용했습니다.


## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가?


## 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
- mock upstream이 실제 News API를 호출하지 않으면서 HTTP→파싱→MySQL 저장 경로를 충분히 검증하는지 확인해주세요.
- 5xx·timeout 실패가 후속 정상 요청 저장을 막지 않는지 확인해주세요.
- 운영 기본 URL, request limit/delay, `news-fetch.enabled` 동작이 유지되는지 확인해주세요.
- 테스트용 timeout과 random-port server 정리가 CI에서 안정적인지 확인해주세요.


## ➕ 추후 계획(선택)
- 실제 News API/RSS 운영형 E2E, retry, circuit breaker, Redis 분산 락, Kafka, 멀티 인스턴스 수집은 반복 장애 근거가 있을 때 별도 검토합니다.
