### PR TITLE
🔎 [PERF/#214] 채팅 목록 latest-per-article 조회 최적화

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -11,6 +11,14 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## Recently Completed
 
+### P1. 채팅 목록 전체 이력 로딩 및 N+1 제거
+
+- 상태: `Done` ([#214](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/214), [PR #215](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/215))
+- AS-IS: 사용자 전체 채팅을 entity로 적재해 Java에서 기사별 최신 행을 고르고, LAZY article 접근으로 기사 수만큼 추가 SQL을 실행했다.
+- TO-BE: MySQL 8 window 함수와 projection으로 사용자·기사별 최신 대화 1건만 단일 SQL로 조회하고 기존 DTO·정렬 의미를 유지한다.
+- 범위: 채팅 팝업 목록 query와 MySQL Testcontainers 회귀 검증으로 제한했다. pagination, 신규 인덱스/Flyway, Redis, 익명 채팅은 제외했다.
+- 검증: 5,000개 합성 채팅·100개 기사에서 SQL `101 → 1`, entity load `5,100 → 0`, 두 로컬 실행의 service elapsed `83.0~86.8%` 감소; 전체 55개 테스트와 Backend CI 통과.
+
 ### P1. News API 수집 부분 실패 격리 및 재실행 E2E 검증
 
 - 상태: `Done` ([#212](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/212), [PR #213](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/213))

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -9,6 +9,10 @@
 
 ## Recently Completed
 
+- #214 / PR #215: `Done`
+- Result: a MySQL 8 window-function projection replaced all-history Java grouping; on a synthetic 5,000-chat/100-article fixture SQL statements changed from 101 to 1, entity loads from 5,100 to 0, and all 55 tests plus Backend CI passed
+- Boundary: the local database has only four chat rows, so pagination, a new index/Flyway migration, Redis, anonymous chat changes, and Issue #110 remain excluded
+
 - #212 / PR #213: `Done`
 - Result: a random-port mock upstream and MySQL Testcontainers verify 200/500/timeout isolation, two successful article saves, and zero duplicate URL groups after rerun; all 54 tests and Backend CI passed
 - Boundary: real News API/RSS calls, `news-fetch.enabled=true`, retry/circuit breaker, distributed locks, Kafka, multi-instance deployment, and Issue #110 remain excluded

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -9,6 +9,17 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Recently Completed
 
+### #214 - 채팅 목록 전체 이력 로딩 및 N+1 제거
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/214
+- 작업 브랜치: `perf/#214-chat-latest-per-article`
+- 상태: `Done` ([PR #215](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/215))
+- 기준선: 사용자 채팅 5,000건·기사 100개 fixture에서 전체 `ChatHistory`를 적재하고 Java로 기사별 최신 행을 선택해 SQL 101개와 entity load 5,100개가 발생했다.
+- 목표: MySQL 8 `ROW_NUMBER()`와 interface projection으로 사용자·기사별 최신 대화만 한 번에 조회하면서 목록 순서, 동률 처리, 답변 미리보기를 유지한다.
+- overengineering 판단: 로컬 실제 채팅은 4건뿐이지만 전체 이력 로딩과 N+1은 데이터 증가에 선형으로 악화되는 명확한 구조 문제다. 기존 MySQL/JPA 안에서 쿼리와 회귀 테스트만 바꾸고 근거가 부족한 신규 인덱스·Flyway·pagination·Redis는 제외했다.
+- 검증: 합성 fixture의 집중·전체 회귀 실행에서 SQL `101 → 1`, entity load `5,100 → 0`, service elapsed 실행별 `83.0~86.8%` 감소를 관측했다. 실행 계획은 대상 5,000행을 한 번 materialize해 100행을 반환했고 사용자 격리, `created_at` 동률 시 큰 `chat_id`, 100자 미리보기 규칙을 확인했다. 전체 55개 테스트와 Backend CI가 통과했다.
+- 측정 문서: `docs/backend-improvement/chat-history-latest-query.md`
+
 ### #212 - News API 수집 부분 실패 격리 및 재실행 E2E 검증
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/212

--- a/docs/backend-improvement/chat-history-latest-query.md
+++ b/docs/backend-improvement/chat-history-latest-query.md
@@ -1,0 +1,56 @@
+# 채팅 목록 latest-per-article 조회 최적화
+
+- Issue: [#214](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/214)
+- PR: [#215](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/215)
+- 상태: `Done`
+
+## 문제
+
+채팅 팝업 목록은 사용자별로 기사마다 마지막 대화 한 건만 반환한다. 기존 구현은 사용자의 모든 `ChatHistory`를 최신순으로 조회한 뒤 Java의 `LinkedHashMap`으로 기사별 첫 행을 선택했다.
+
+`ChatHistory.article`은 `LAZY @ManyToOne`이므로 DTO가 기사 제목과 썸네일을 읽을 때 기사별 추가 조회도 발생했다. 사용자 한 명에게 채팅 이력 `N`건과 서로 다른 기사 `A`개가 있으면 목록 100개를 만들기 위해 채팅 `N`건을 entity로 적재하고 SQL `1 + A`개를 실행하는 구조였다.
+
+## 검증 조건
+
+- MySQL 8 Testcontainers
+- 대상 사용자 1명
+- 기사 100개
+- 기사별 채팅 50개, 총 5,000개
+- 다른 사용자의 더 최신 채팅 1개를 추가해 사용자 격리 검증
+- 같은 `created_at`을 가진 마지막 두 채팅을 추가해 `chat_id DESC` 동률 처리 검증
+- 응답 개수, 순서, 마지막 질문, 100자 답변 미리보기 규칙 유지
+
+이 fixture는 쿼리 증가 양상을 재현하기 위한 합성 데이터다. 측정 시점 로컬 DB의 실제 `chat_history`는 4건이므로 아래 시간은 운영 성능이나 현재 사용자 규모를 나타내지 않는다.
+
+## 후보 비교
+
+처음 검토한 JPQL correlated `NOT EXISTS` 후보는 SQL 수를 1개로 줄였지만, `EXPLAIN ANALYZE`에서 외부 5,000행마다 후속 인덱스 조회를 반복하는 antijoin이 약 448ms 걸렸다.
+
+최종 후보는 MySQL 8의 `ROW_NUMBER()`를 사용한다.
+
+1. 대상 사용자의 채팅을 기사별로 나눈다.
+2. `created_at DESC, chat_id DESC` 순으로 순번을 부여한다.
+3. 순번 1인 행만 기사와 조인한다.
+4. interface projection으로 응답에 필요한 컬럼만 읽는다.
+
+## 결과
+
+| 지표 | 기존 전체 이력 + Java 그룹화 | `ROW_NUMBER()` projection | 변화 |
+| --- | ---: | ---: | ---: |
+| 조회 대상 채팅 | 5,000 | 5,000 | 동일 fixture |
+| 반환 목록 | 100 | 100 | 응답 의미 유지 |
+| SQL statements | 101 | 1 | 99.0% 감소 |
+| Hibernate entity loads | 5,100 | 0 | projection 전환 |
+| service elapsed | 741~1,786ms | 126~235ms | 실행별 83.0~86.8% 감소, 약 5.9~7.6배 |
+
+시간은 8GB 로컬 노트북의 동일 Testcontainers 테스트를 집중·전체 회귀로 두 번 실행해 관측한 범위다. 환경과 JVM warm-up에 따라 변할 수 있으므로 구조적으로 재현 가능한 SQL 수와 entity load 감소를 핵심 결과로 본다.
+
+최종 `EXPLAIN ANALYZE`에서는 `chat_history` 5,001행을 한 번 scan하고 대상 5,000행에 window 함수를 적용해 100행을 반환했다. 실행 계획의 최상위 sort 완료 시점은 약 17.6ms였으며 correlated antijoin의 반복 lookup은 사라졌다.
+
+## 적용 범위
+
+- 채팅 목록 API의 응답 필드와 최신순 정렬을 유지한다.
+- 동일 시각에는 더 큰 `chat_id`를 최신 대화로 선택해 결과를 결정적으로 만든다.
+- 상세 페이지의 기사별 전체 대화 조회는 변경하지 않는다.
+- 현재 실제 데이터 규모에서 근거가 부족한 신규 인덱스, Flyway migration, pagination, Redis cache는 추가하지 않는다.
+- 데이터가 증가해 실행 계획이나 목록 응답 크기가 다시 문제가 될 때 pagination과 복합 인덱스를 별도 측정한다.

--- a/docs/backend-improvement/mysql-testcontainers-integration.md
+++ b/docs/backend-improvement/mysql-testcontainers-integration.md
@@ -64,6 +64,14 @@ mock 단위 테스트나 수동 API 측정만으로는 확인하기 어려운 My
 - 일부 요청 실패 후에도 정상 기사 2건 저장, 같은 수집 재실행 후 기사 2건과 URL 중복 그룹 0건 유지
 - 기존 compose DB와 8080 서버, 실제 News API key를 사용하지 않으며 전체 54개 테스트 통과
 
+### 채팅 목록 latest-per-article 조회
+
+- 사용자 1명, 기사 100개, 기사별 채팅 50개의 합성 fixture로 전체 이력 로딩과 `LAZY article` N+1을 재현
+- 기존 Java 그룹화의 SQL 101개·entity load 5,100개와 MySQL 8 `ROW_NUMBER()` projection의 SQL 1개·entity load 0개를 같은 테스트에서 비교
+- 다른 사용자의 더 최신 채팅 격리, 같은 `created_at`의 `chat_id DESC` 동률 처리, 목록 순서와 100자 답변 미리보기 유지 검증
+- fixture는 구조 비교용이며 로컬 DB의 실제 채팅 4건이나 운영 latency를 나타내지 않음
+- 집중 테스트와 전체 55개 회귀 테스트 통과
+
 ### 동시 원자 증가
 
 - 같은 기사에 20개 worker가 각각 `incrementViewCount()` 실행

--- a/src/main/java/com/example/globalTimes_be/domain/chat/dto/ChatHistoryListResDTO.java
+++ b/src/main/java/com/example/globalTimes_be/domain/chat/dto/ChatHistoryListResDTO.java
@@ -22,18 +22,31 @@ public class ChatHistoryListResDTO {
     private static final int PREVIEW_MAX_LENGTH = 100;
 
     public static ChatHistoryListResDTO from(ChatHistory latestChat) {
-        String answer = latestChat.getAnswer();
-        String preview = answer.length() > PREVIEW_MAX_LENGTH
-                ? answer.substring(0, PREVIEW_MAX_LENGTH) + "..."
-                : answer;
+        return from(
+                latestChat.getArticle().getId(),
+                latestChat.getArticle().getTitle(),
+                latestChat.getArticle().getUrlToImage(),
+                latestChat.getQuestion(),
+                latestChat.getAnswer(),
+                latestChat.getCreatedAt()
+        );
+    }
 
+    public static ChatHistoryListResDTO from(
+            Long articleId,
+            String articleTitle,
+            String thumbnailUrl,
+            String lastQuestion,
+            String lastAnswer,
+            LocalDateTime lastChatAt
+    ) {
         return ChatHistoryListResDTO.builder()
-                .articleId(latestChat.getArticle().getId())
-                .articleTitle(latestChat.getArticle().getTitle())
-                .thumbnailUrl(latestChat.getArticle().getUrlToImage())
-                .lastQuestion(latestChat.getQuestion())
-                .lastAnswerPreview(preview)
-                .lastChatAt(latestChat.getCreatedAt())
+                .articleId(articleId)
+                .articleTitle(articleTitle)
+                .thumbnailUrl(thumbnailUrl)
+                .lastQuestion(lastQuestion)
+                .lastAnswerPreview(preview(lastAnswer))
+                .lastChatAt(lastChatAt)
                 .build();
     }
 
@@ -44,18 +57,20 @@ public class ChatHistoryListResDTO {
             String lastAnswer,
             LocalDateTime lastChatAt
     ) {
-        String answer = lastAnswer != null ? lastAnswer : "";
-        String preview = answer.length() > PREVIEW_MAX_LENGTH
-                ? answer.substring(0, PREVIEW_MAX_LENGTH) + "..."
-                : answer;
-
         return ChatHistoryListResDTO.builder()
                 .articleId(article.getId())
                 .articleTitle(article.getTitle())
                 .thumbnailUrl(article.getUrlToImage())
                 .lastQuestion(lastQuestion != null ? lastQuestion : "")
-                .lastAnswerPreview(preview)
+                .lastAnswerPreview(preview(lastAnswer))
                 .lastChatAt(lastChatAt)
                 .build();
+    }
+
+    private static String preview(String answer) {
+        String safeAnswer = answer != null ? answer : "";
+        return safeAnswer.length() > PREVIEW_MAX_LENGTH
+                ? safeAnswer.substring(0, PREVIEW_MAX_LENGTH) + "..."
+                : safeAnswer;
     }
 }

--- a/src/main/java/com/example/globalTimes_be/domain/chat/repository/ChatHistoryRepository.java
+++ b/src/main/java/com/example/globalTimes_be/domain/chat/repository/ChatHistoryRepository.java
@@ -3,6 +3,8 @@ package com.example.globalTimes_be.domain.chat.repository;
 import com.example.globalTimes_be.domain.chat.entity.ChatHistory;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,8 +12,31 @@ import java.util.List;
 @Repository
 public interface ChatHistoryRepository extends JpaRepository<ChatHistory, Long> {
 
-    // 사용자의 전체 히스토리 (최신순) - 팝업 목록용
-    List<ChatHistory> findByUserIdOrderByCreatedAtDesc(Long userId);
+    @Query(value = """
+            SELECT ranked.article_id AS articleId,
+                   article.title AS articleTitle,
+                   article.url_to_image AS thumbnailUrl,
+                   ranked.question AS lastQuestion,
+                   ranked.answer AS lastAnswer,
+                   ranked.created_at AS lastChatAt
+            FROM (
+                SELECT chat.article_id,
+                       chat.chat_id,
+                       chat.question,
+                       chat.answer,
+                       chat.created_at,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY chat.article_id
+                           ORDER BY chat.created_at DESC, chat.chat_id DESC
+                       ) AS rn
+                FROM chat_history chat
+                WHERE chat.user_id = :userId
+            ) ranked
+            JOIN article ON article.article_id = ranked.article_id
+            WHERE ranked.rn = 1
+            ORDER BY ranked.created_at DESC, ranked.chat_id DESC
+            """, nativeQuery = true)
+    List<LatestChatHistoryProjection> findLatestPerArticleByUserId(@Param("userId") Long userId);
 
     // 특정 기사의 사용자 히스토리 (오래된순) - 상세 페이지 대화 흐름용
     List<ChatHistory> findByUserIdAndArticleIdOrderByCreatedAtAsc(Long userId, Long articleId);

--- a/src/main/java/com/example/globalTimes_be/domain/chat/repository/LatestChatHistoryProjection.java
+++ b/src/main/java/com/example/globalTimes_be/domain/chat/repository/LatestChatHistoryProjection.java
@@ -1,0 +1,18 @@
+package com.example.globalTimes_be.domain.chat.repository;
+
+import java.time.LocalDateTime;
+
+public interface LatestChatHistoryProjection {
+
+    Long getArticleId();
+
+    String getArticleTitle();
+
+    String getThumbnailUrl();
+
+    String getLastQuestion();
+
+    String getLastAnswer();
+
+    LocalDateTime getLastChatAt();
+}

--- a/src/main/java/com/example/globalTimes_be/domain/chat/service/ChatHistoryService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/chat/service/ChatHistoryService.java
@@ -5,6 +5,7 @@ import com.example.globalTimes_be.domain.article.repository.ArticleRepository;
 import com.example.globalTimes_be.domain.chat.dto.ChatHistoryListResDTO;
 import com.example.globalTimes_be.domain.chat.dto.ChatHistoryResDTO;
 import com.example.globalTimes_be.domain.chat.entity.ChatHistory;
+import com.example.globalTimes_be.domain.chat.repository.LatestChatHistoryProjection;
 import com.example.globalTimes_be.domain.chat.repository.ChatHistoryRepository;
 import com.example.globalTimes_be.domain.user.entity.User;
 import com.example.globalTimes_be.domain.user.repository.UserRepository;
@@ -18,9 +19,7 @@ import org.springframework.data.domain.Sort;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -51,17 +50,20 @@ public class ChatHistoryService {
     // 팝업 목록용: 사용자의 기사별 마지막 대화 미리보기
     @Transactional(readOnly = true)
     public List<ChatHistoryListResDTO> getChatList(Long userId) {
-        List<ChatHistory> all = chatHistoryRepository.findByUserIdOrderByCreatedAtDesc(userId);
-
-        // 기사별로 가장 최신 채팅 1건만 추출 (이미 최신순 정렬이므로 첫 번째가 최신)
-        Map<Long, ChatHistory> latestPerArticle = new LinkedHashMap<>();
-        for (ChatHistory chat : all) {
-            latestPerArticle.putIfAbsent(chat.getArticle().getId(), chat);
-        }
-
-        return latestPerArticle.values().stream()
-                .map(ChatHistoryListResDTO::from)
+        return chatHistoryRepository.findLatestPerArticleByUserId(userId).stream()
+                .map(this::toChatHistoryListResponse)
                 .collect(Collectors.toList());
+    }
+
+    private ChatHistoryListResDTO toChatHistoryListResponse(LatestChatHistoryProjection latestChat) {
+        return ChatHistoryListResDTO.from(
+                latestChat.getArticleId(),
+                latestChat.getArticleTitle(),
+                latestChat.getThumbnailUrl(),
+                latestChat.getLastQuestion(),
+                latestChat.getLastAnswer(),
+                latestChat.getLastChatAt()
+        );
     }
 
     // 상세 페이지용: 특정 기사의 전체 대화 내역

--- a/src/test/java/com/example/globalTimes_be/domain/chat/service/ChatHistoryQueryIntegrationTest.java
+++ b/src/test/java/com/example/globalTimes_be/domain/chat/service/ChatHistoryQueryIntegrationTest.java
@@ -1,0 +1,291 @@
+package com.example.globalTimes_be.domain.chat.service;
+
+import com.example.globalTimes_be.domain.chat.dto.ChatHistoryListResDTO;
+import com.example.globalTimes_be.domain.chat.entity.ChatHistory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@Import(ChatHistoryService.class)
+@TestPropertySource(properties = {
+        "spring.jpa.properties.hibernate.generate_statistics=true",
+        "logging.level.org.hibernate.engine.internal.StatisticalLoggingSessionEventListener=OFF"
+})
+class ChatHistoryQueryIntegrationTest {
+
+    private static final int ARTICLE_COUNT = 100;
+    private static final int CHATS_PER_ARTICLE = 50;
+
+    @Container
+    @ServiceConnection
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
+            .withUsername("root")
+            .withPassword("test");
+
+    @Autowired
+    private ChatHistoryService chatHistoryService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    private long userId;
+    private Statistics statistics;
+    private TransactionTemplate transactionTemplate;
+
+    @BeforeEach
+    void setUpFixture() {
+        long sourceId = insertSource();
+        userId = insertUser();
+        List<Long> articleIds = insertArticles(sourceId);
+        insertChats(articleIds, userId);
+        insertOtherUserChat(articleIds.get(0));
+
+        statistics = entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+        transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.setReadOnly(true);
+        entityManager.clear();
+        statistics.clear();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        jdbcTemplate.update("DELETE FROM chat_history");
+        jdbcTemplate.update("DELETE FROM article");
+        jdbcTemplate.update("DELETE FROM users");
+        jdbcTemplate.update("DELETE FROM source");
+    }
+
+    @Test
+    void latestPerArticleQueryReducesLoadedRowsAndStatements() {
+        long baselineStartedAt = System.nanoTime();
+
+        List<ChatHistoryListResDTO> baseline = transactionTemplate.execute(status -> baselineChatList());
+
+        long baselineElapsedMs = (System.nanoTime() - baselineStartedAt) / 1_000_000;
+        System.out.printf(
+                "CHAT_LIST_BASELINE histories=%d, result=%d, statements=%d, entities=%d, elapsedMs=%d%n",
+                ARTICLE_COUNT * CHATS_PER_ARTICLE,
+                baseline.size(),
+                statistics.getPrepareStatementCount(),
+                statistics.getEntityLoadCount(),
+                baselineElapsedMs
+        );
+
+        assertThat(baseline).hasSize(ARTICLE_COUNT);
+        assertThat(statistics.getPrepareStatementCount()).isEqualTo(ARTICLE_COUNT + 1L);
+        assertThat(statistics.getEntityLoadCount())
+                .isEqualTo(ARTICLE_COUNT * CHATS_PER_ARTICLE + ARTICLE_COUNT);
+
+        entityManager.clear();
+        statistics.clear();
+        long optimizedStartedAt = System.nanoTime();
+
+        List<ChatHistoryListResDTO> optimized = chatHistoryService.getChatList(userId);
+
+        long optimizedElapsedMs = (System.nanoTime() - optimizedStartedAt) / 1_000_000;
+        System.out.printf(
+                "CHAT_LIST_OPTIMIZED histories=%d, result=%d, statements=%d, entities=%d, elapsedMs=%d%n",
+                ARTICLE_COUNT * CHATS_PER_ARTICLE,
+                optimized.size(),
+                statistics.getPrepareStatementCount(),
+                statistics.getEntityLoadCount(),
+                optimizedElapsedMs
+        );
+
+        assertThat(optimized).hasSize(ARTICLE_COUNT);
+        assertThat(optimized).extracting(ChatHistoryListResDTO::getArticleId)
+                .containsExactlyElementsOf(baseline.stream()
+                        .map(ChatHistoryListResDTO::getArticleId)
+                        .toList());
+        assertThat(optimized).allSatisfy(dto -> assertThat(dto.getLastQuestion()).endsWith("-49"));
+        assertThat(optimized.get(0).getLastAnswerPreview())
+                .isEqualTo("x".repeat(100) + "...");
+        assertThat(statistics.getPrepareStatementCount()).isEqualTo(1L);
+        assertThat(statistics.getEntityLoadCount()).isZero();
+
+        String explainPlan = jdbcTemplate.queryForObject(
+                "EXPLAIN ANALYZE " +
+                        "SELECT ranked.chat_id " +
+                        "FROM (" +
+                        "SELECT chat.chat_id, chat.article_id, chat.created_at, " +
+                        "ROW_NUMBER() OVER (" +
+                        "PARTITION BY chat.article_id " +
+                        "ORDER BY chat.created_at DESC, chat.chat_id DESC" +
+                        ") rn " +
+                        "FROM chat_history chat WHERE chat.user_id = ?" +
+                        ") ranked " +
+                        "JOIN article ON article.article_id = ranked.article_id " +
+                        "WHERE ranked.rn = 1 " +
+                        "ORDER BY ranked.created_at DESC, ranked.chat_id DESC",
+                String.class,
+                userId
+        );
+        System.out.println("CHAT_LIST_OPTIMIZED_PLAN " + explainPlan);
+    }
+
+    private List<ChatHistoryListResDTO> baselineChatList() {
+        List<ChatHistory> all = entityManager.createQuery(
+                        "SELECT chat FROM ChatHistory chat " +
+                                "WHERE chat.user.id = :userId ORDER BY chat.createdAt DESC",
+                        ChatHistory.class
+                )
+                .setParameter("userId", userId)
+                .getResultList();
+
+        Map<Long, ChatHistory> latestPerArticle = new LinkedHashMap<>();
+        for (ChatHistory chat : all) {
+            latestPerArticle.putIfAbsent(chat.getArticle().getId(), chat);
+        }
+        return latestPerArticle.values().stream()
+                .map(ChatHistoryListResDTO::from)
+                .toList();
+    }
+
+    private long insertSource() {
+        jdbcTemplate.update(
+                "INSERT INTO source(source_name, source_api_id) VALUES (?, ?)",
+                "Chat Query Source",
+                "chat-query-source"
+        );
+        return jdbcTemplate.queryForObject(
+                "SELECT source_id FROM source WHERE source_name = ?",
+                Long.class,
+                "Chat Query Source"
+        );
+    }
+
+    private long insertUser() {
+        jdbcTemplate.update(
+                "INSERT INTO users(created_at, email, nickname, provider, provider_id) " +
+                        "VALUES (NOW(6), ?, ?, ?, ?)",
+                "chat-query@example.com",
+                "chat-query-user",
+                "test",
+                "chat-query-provider-id"
+        );
+        return jdbcTemplate.queryForObject(
+                "SELECT user_id FROM users WHERE email = ?",
+                Long.class,
+                "chat-query@example.com"
+        );
+    }
+
+    private List<Long> insertArticles(long sourceId) {
+        List<Object[]> parameters = new ArrayList<>();
+        for (int index = 0; index < ARTICLE_COUNT; index++) {
+            parameters.add(new Object[]{
+                    "author",
+                    "general",
+                    "content",
+                    "us",
+                    "description",
+                    Timestamp.valueOf(LocalDateTime.of(2026, 7, 19, 0, 0).plusMinutes(index)),
+                    "Article " + index,
+                    "https://news.example/chat-query/" + index,
+                    "https://news.example/image/" + index + ".jpg",
+                    sourceId,
+                    "en"
+            });
+        }
+        jdbcTemplate.batchUpdate(
+                "INSERT INTO article(author, category, content, country, description, published_at, title, url, " +
+                        "url_to_image, view_count, source_id, language) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)",
+                parameters
+        );
+        return jdbcTemplate.queryForList(
+                "SELECT article_id FROM article WHERE source_id = ? ORDER BY article_id",
+                Long.class,
+                sourceId
+        );
+    }
+
+    private void insertChats(List<Long> articleIds, long targetUserId) {
+        List<Object[]> parameters = new ArrayList<>();
+        LocalDateTime baseTime = LocalDateTime.of(2026, 7, 19, 1, 0);
+        for (int articleIndex = 0; articleIndex < articleIds.size(); articleIndex++) {
+            for (int chatIndex = 0; chatIndex < CHATS_PER_ARTICLE; chatIndex++) {
+                int timeSequence = chatIndex == CHATS_PER_ARTICLE - 1 ? chatIndex - 1 : chatIndex;
+                String answer = articleIndex == ARTICLE_COUNT - 1 && chatIndex == CHATS_PER_ARTICLE - 1
+                        ? "x".repeat(120)
+                        : "answer " + articleIndex + "-" + chatIndex;
+                parameters.add(new Object[]{
+                        answer,
+                        Timestamp.valueOf(baseTime.plusMinutes(articleIndex).plusSeconds(timeSequence)),
+                        "question " + articleIndex + "-" + chatIndex,
+                        articleIds.get(articleIndex),
+                        targetUserId
+                });
+            }
+        }
+        jdbcTemplate.batchUpdate(
+                "INSERT INTO chat_history(answer, created_at, question, article_id, user_id) " +
+                        "VALUES (?, ?, ?, ?, ?)",
+                parameters
+        );
+    }
+
+    private void insertOtherUserChat(long articleId) {
+        jdbcTemplate.update(
+                "INSERT INTO users(created_at, email, nickname, provider, provider_id) " +
+                        "VALUES (NOW(6), ?, ?, ?, ?)",
+                "other-chat-query@example.com",
+                "other-chat-query-user",
+                "test",
+                "other-chat-query-provider-id"
+        );
+        Long otherUserId = jdbcTemplate.queryForObject(
+                "SELECT user_id FROM users WHERE email = ?",
+                Long.class,
+                "other-chat-query@example.com"
+        );
+        jdbcTemplate.update(
+                "INSERT INTO chat_history(answer, created_at, question, article_id, user_id) " +
+                        "VALUES (?, ?, ?, ?, ?)",
+                "other answer",
+                Timestamp.valueOf(LocalDateTime.of(2030, 1, 1, 0, 0)),
+                "other question",
+                articleId,
+                otherUserId
+        );
+    }
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #214

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [x] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- 사용자 전체 채팅을 읽어 Java에서 기사별 최신 대화를 고르던 로직을 MySQL 8 `ROW_NUMBER()` 단일 조회로 교체했습니다.
- interface projection으로 목록 응답에 필요한 기사·채팅 컬럼만 조회해 LAZY Article N+1과 entity 적재를 제거했습니다.
- 사용자 격리, 최신순, timestamp 동률 시 `chat_id DESC`, 답변 100자 미리보기를 MySQL Testcontainers 회귀 테스트로 고정했습니다.
- 측정 결과와 실제 로컬 데이터 4건이라는 해석 경계를 backend improvement 문서에 함께 기록했습니다.

## 🔍 기술적 배경
- 기존 경로는 사용자 채팅 `N`건을 모두 entity로 적재하고 서로 다른 기사 `A`개에 대해 추가 SQL을 실행하는 `1 + A` 구조였습니다.
- 사용자 1명·기사 100개·기사별 채팅 50개의 합성 fixture에서 기존 SQL 101개와 entity load 5,100개를 재현했습니다.
- window projection은 SQL 1개와 entity load 0개를 유지했고, 집중·전체 실행의 service elapsed는 실행별 83.0~86.8% 감소했습니다.
- 시간은 8GB 로컬 환경의 관측 범위이며 운영 성능으로 일반화하지 않습니다. 신규 인덱스·Flyway·pagination·Redis는 현재 근거가 부족해 제외했습니다.

## 🧪 테스트/검증 (필수)
- [x] `./gradlew test --tests "com.example.globalTimes_be.domain.chat.service.ChatHistoryQueryIntegrationTest" --rerun-tasks`
- [x] `./gradlew test --rerun-tasks` (55 tests, failures 0, errors 0, skipped 0)
- [x] `EXPLAIN ANALYZE`에서 대상 5,000행을 한 번 materialize하고 100행을 반환하며 correlated antijoin 반복 lookup이 없음을 확인
- [x] SQL `101 → 1`, Hibernate entity loads `5,100 → 0`

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop` 대상)
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 외부 응답 필드·기사별 최신순·미리보기 동작이 동일함을 확인했는가?

## 📸 스크린샷 (선택)
- 해당 없음

## 💬 리뷰 요구사항(선택)
- native query alias가 interface projection getter와 정확히 매핑되는지 확인해 주세요.
- 사용자별·기사별 최신 1건과 `created_at DESC, chat_id DESC` 동률 기준이 모든 경우에 유지되는지 확인해 주세요.
- 합성 fixture 수치를 실제 운영 데이터나 latency로 과장하지 않았는지 확인해 주세요.

## ➕ 추후 계획(선택)
- 실제 채팅 데이터와 응답 크기가 증가해 근거가 생기면 pagination과 복합 인덱스를 별도 측정합니다.
