### PR TITLE
🔎 [PERF/#216] 스크랩 목록 projection 일괄 조회 최적화

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -11,6 +11,14 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## Recently Completed
 
+### P1. 스크랩 목록 N+1 및 ID별 반복 조회 제거
+
+- 상태: `Done` ([#216](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/216), [PR #217](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/217))
+- AS-IS: 로그인 목록은 Scrap·Article·Source LAZY 조회가 연쇄되고, 비로그인 호환 목록은 요청 ID마다 article을 개별 조회했다.
+- TO-BE: 동일한 MySQL 100건 fixture에서 projection 일괄 조회로 SQL 증가 구조를 제거하고 기존 응답 의미를 유지한다.
+- 범위: 두 스크랩 조회 query와 Testcontainers 회귀 검증으로 제한했다. pagination, Redis, 신규 schema/index, toggle 동시성은 제외했다.
+- 검증: 로그인 SQL `201 → 1`·entity `300 → 0`, 비로그인 SQL `200 → 1`·entity `200 → 0`; DTO 전체 필드와 최신순·요청순·중복·누락·nullable Source 회귀 및 전체 58개 테스트·Backend CI 통과.
+
 ### P1. 채팅 목록 전체 이력 로딩 및 N+1 제거
 
 - 상태: `Done` ([#214](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/214), [PR #215](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/215))

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -9,6 +9,10 @@
 
 ## Recently Completed
 
+- #216 / PR #217: `Done`
+- Result: projection batch queries reduced authenticated scrap-list SQL from 201 to 1 and legacy ID-list SQL from 200 to 1 on a synthetic 100-row MySQL fixture; all 58 tests and Backend CI passed
+- Boundary: the local database has one scrap row; pagination, Redis, new indexes/Flyway, toggle concurrency, and Issue #110 remain excluded
+
 - #214 / PR #215: `Done`
 - Result: a MySQL 8 window-function projection replaced all-history Java grouping; on a synthetic 5,000-chat/100-article fixture SQL statements changed from 101 to 1, entity loads from 5,100 to 0, and all 55 tests plus Backend CI passed
 - Boundary: the local database has only four chat rows, so pagination, a new index/Flyway migration, Redis, anonymous chat changes, and Issue #110 remain excluded

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -9,6 +9,17 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Recently Completed
 
+### #216 - 스크랩 목록 N+1 및 ID별 반복 조회 제거
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/216
+- 작업 브랜치: `perf/#216-scrap-list-query`
+- 상태: `Done` ([PR #217](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/217))
+- 기준선: 로그인 목록은 `Scrap → Article → Source` LAZY 접근으로 100건에서 SQL 201개·entity load 300개, 비로그인 호환 목록은 article ID별 `findById()` 반복으로 SQL 200개·entity load 200개가 MySQL fixture에서 발생했다.
+- 목표: MySQL 8 Testcontainers의 동일 100건 fixture에서 projection 일괄 조회로 교체하면서 DTO 전체 필드와 최신순·요청순·중복·누락 처리를 유지한다.
+- overengineering 판단: 실제 로컬 스크랩은 1건이라 현재 운영 병목으로 과장하지 않는다. 기존 JPA/MySQL query와 회귀 테스트만 사용했으며 pagination, Redis, 신규 인덱스/Flyway, toggle 동시성 변경은 제외했다.
+- 검증: 서로 다른 Source·Article·Scrap 100건 fixture에서 로그인 SQL `201 → 1`, entity load `300 → 0`, 비로그인 SQL `200 → 1`, entity load `200 → 0`을 확인했다. DTO 전체 필드, 최신순, 요청순, 중복·누락 ID, nullable Source를 회귀 검증했고 전체 58개 테스트와 Backend CI가 통과했다.
+- 측정 문서: `docs/backend-improvement/scrap-list-query-optimization.md`
+
 ### #214 - 채팅 목록 전체 이력 로딩 및 N+1 제거
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/214

--- a/docs/backend-improvement/mysql-testcontainers-integration.md
+++ b/docs/backend-improvement/mysql-testcontainers-integration.md
@@ -72,6 +72,14 @@ mock 단위 테스트나 수동 API 측정만으로는 확인하기 어려운 My
 - fixture는 구조 비교용이며 로컬 DB의 실제 채팅 4건이나 운영 latency를 나타내지 않음
 - 집중 테스트와 전체 55개 회귀 테스트 통과
 
+### 스크랩 목록 projection 일괄 조회
+
+- 사용자 1명, 서로 다른 Source·Article·Scrap 100건의 합성 fixture로 로그인 `Scrap → Article → Source` N+1과 비로그인 ID별 `findById()`를 재현
+- 로그인 SQL `201 → 1`·entity load `300 → 0`, 비로그인 SQL `200 → 1`·entity load `200 → 0` 비교
+- DTO 전체 필드, 로그인 최신순, 비로그인 요청순·중복·누락 ID와 빈 목록 무조회 검증
+- nullable Source를 `LEFT JOIN` projection으로 보존하고 전체 58개 테스트 통과
+- fixture는 구조 비교용이며 로컬 DB의 실제 scrap 1건이나 운영 latency를 나타내지 않음
+
 ### 동시 원자 증가
 
 - 같은 기사에 20개 worker가 각각 `incrementViewCount()` 실행

--- a/docs/backend-improvement/scrap-list-query-optimization.md
+++ b/docs/backend-improvement/scrap-list-query-optimization.md
@@ -1,0 +1,58 @@
+# 스크랩 목록 일괄 조회 최적화
+
+- Issue: [#216](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/216)
+- PR: [#217](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/217)
+- 상태: `Done`
+
+## 문제
+
+스크랩 조회에는 서로 다른 두 경로가 있다.
+
+- 로그인 목록은 모든 `Scrap` entity를 조회한 뒤 DTO 변환 중 `Article`과 `Source` LAZY 연관관계에 접근한다.
+- 비로그인 localStorage 호환 목록은 요청받은 article ID마다 `findById()`를 실행하고 `Source`에 LAZY 접근한다.
+
+따라서 서로 다른 기사와 Source가 `N`개일 때 로그인 목록은 `1 + 2N`, 비로그인 목록은 `2N`개의 SQL을 실행하는 구조였다.
+
+## 검증 조건
+
+- MySQL 8 Testcontainers
+- 사용자 1명
+- 서로 다른 Source 100개와 Article 100개
+- 사용자의 Scrap 100개
+- Hibernate Statistics로 SQL statements와 entity loads 측정
+- 로그인 DTO 7개 필드 전체와 스크랩 최신순 비교
+- 비로그인 DTO 6개 필드 전체, 요청 ID 순서, 중복 ID, 존재하지 않는 ID 제외 비교
+- nullable `Article.source`가 목록에서 누락되지 않는지 확인
+
+이 fixture는 SQL 증가 구조를 통제해 재현하기 위한 합성 데이터다. 측정 시점 로컬 DB의 실제 scrap은 1건이므로 운영 데이터 규모나 운영 latency를 나타내지 않는다.
+
+## 개선
+
+로그인 목록은 `Scrap`, `Article`, `Source`에서 응답에 필요한 컬럼만 interface projection으로 조회한다. `created_at DESC, scrap_id DESC`로 최신순과 timestamp 동률 순서를 결정적으로 유지한다.
+
+비로그인 목록은 중복을 제거한 article ID 목록을 projection query 한 번으로 조회한다. 조회 결과를 ID map으로 만든 뒤 원래 요청 ID를 다시 순회해 요청 순서와 중복을 복원하고 존재하지 않는 ID는 기존처럼 제외한다. 빈 ID 목록은 DB를 호출하지 않는다.
+
+`source_id`는 nullable이므로 두 query 모두 `LEFT JOIN`을 사용해 Source가 없는 Article 자체가 목록에서 사라지지 않게 했다.
+
+## 결과
+
+| 경로 | 지표 | 기존 | 개선 | 변화 |
+| --- | --- | ---: | ---: | ---: |
+| 로그인 | SQL statements | 201 | 1 | 99.5% 감소 |
+| 로그인 | entity loads | 300 | 0 | projection 전환 |
+| 로그인 | service elapsed | 945~1,185ms | 36~87ms | 실행별 92.7~96.2% 감소 |
+| 비로그인 | SQL statements | 200 | 1 | 99.5% 감소 |
+| 비로그인 | entity loads | 200 | 0 | projection 전환 |
+| 비로그인 | service elapsed | 1,130~1,284ms | 40~90ms | 실행별 93.0~96.5% 감소 |
+
+시간은 8GB 로컬 노트북에서 최종 `LEFT JOIN` 구현을 집중·전체 회귀로 실행한 두 관측값이다. JVM warm-up과 DB cache의 영향을 크게 받으므로 구조적으로 반복되는 SQL·entity load 감소를 핵심 결과로 본다.
+
+`EXPLAIN ANALYZE`에서 로그인 query는 100행 정렬과 Article·Source join을 약 `1.50~1.54ms`, 비로그인 query는 100개 ID의 Article·Source left join을 약 `0.33~0.37ms`에 완료했다.
+
+## 적용 범위
+
+- API endpoint와 응답 DTO 필드는 변경하지 않는다.
+- 로그인 목록의 스크랩 최신순과 비로그인 목록의 요청순·중복·누락 처리를 유지한다.
+- 실제 스크랩 1건에서 즉시 필요한 운영 최적화로 과장하지 않는다.
+- pagination, Redis, 신규 인덱스/Flyway, scrap toggle 동시성은 이번 범위에서 제외한다.
+- 요청 ID나 사용자 스크랩 수가 API payload·메모리 문제를 만들 정도로 증가할 때 pagination 또는 요청 개수 제한을 별도로 검토한다.

--- a/src/main/java/com/example/globalTimes_be/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/com/example/globalTimes_be/domain/article/repository/ArticleRepository.java
@@ -27,6 +27,19 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     @Query("SELECT a.url FROM Article a WHERE a.url IN :urls")
     Set<String> findExistingUrls(@Param("urls") List<String> urls);
 
+    @Query("""
+            SELECT article.id AS id,
+                   source.sourceName AS sourceName,
+                   article.title AS title,
+                   article.description AS description,
+                   article.urlToImage AS urlToImage,
+                   article.publishedAt AS publishedAt
+            FROM Article article
+            LEFT JOIN article.source source
+            WHERE article.id IN :ids
+            """)
+    List<ArticleSummaryProjection> findSummariesByIdIn(@Param("ids") List<Long> ids);
+
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Article a SET a.viewCount = a.viewCount + 1 WHERE a.id = :id")
     int incrementViewCount(@Param("id") Long id);

--- a/src/main/java/com/example/globalTimes_be/domain/article/repository/ArticleSummaryProjection.java
+++ b/src/main/java/com/example/globalTimes_be/domain/article/repository/ArticleSummaryProjection.java
@@ -1,0 +1,18 @@
+package com.example.globalTimes_be.domain.article.repository;
+
+import java.time.LocalDateTime;
+
+public interface ArticleSummaryProjection {
+
+    Long getId();
+
+    String getSourceName();
+
+    String getTitle();
+
+    String getDescription();
+
+    String getUrlToImage();
+
+    LocalDateTime getPublishedAt();
+}

--- a/src/main/java/com/example/globalTimes_be/domain/scrap/dto/response/ScrapListResDTO.java
+++ b/src/main/java/com/example/globalTimes_be/domain/scrap/dto/response/ScrapListResDTO.java
@@ -34,14 +34,34 @@ public class ScrapListResDTO {
     private LocalDateTime scrappedAt;
 
     public static ScrapListResDTO from(Scrap scrap) {
+        return from(
+                scrap.getArticle().getId(),
+                scrap.getArticle().getTitle(),
+                scrap.getArticle().getSource().getSourceName(),
+                scrap.getArticle().getUrlToImage(),
+                scrap.getArticle().getDescription(),
+                scrap.getArticle().getPublishedAt(),
+                scrap.getCreatedAt()
+        );
+    }
+
+    public static ScrapListResDTO from(
+            Long articleId,
+            String title,
+            String sourceName,
+            String urlToImage,
+            String description,
+            LocalDateTime publishedAt,
+            LocalDateTime scrappedAt
+    ) {
         return ScrapListResDTO.builder()
-                .articleId(scrap.getArticle().getId())
-                .title(scrap.getArticle().getTitle())
-                .sourceName(scrap.getArticle().getSource().getSourceName())
-                .urlToImage(scrap.getArticle().getUrlToImage())
-                .description(scrap.getArticle().getDescription())
-                .publishedAt(scrap.getArticle().getPublishedAt())
-                .scrappedAt(scrap.getCreatedAt())
+                .articleId(articleId)
+                .title(title)
+                .sourceName(sourceName)
+                .urlToImage(urlToImage)
+                .description(description)
+                .publishedAt(publishedAt)
+                .scrappedAt(scrappedAt)
                 .build();
     }
 }

--- a/src/main/java/com/example/globalTimes_be/domain/scrap/dto/response/ScrapResDTO.java
+++ b/src/main/java/com/example/globalTimes_be/domain/scrap/dto/response/ScrapResDTO.java
@@ -27,4 +27,22 @@ public class ScrapResDTO {
 
     @Schema(description = "작성일", example = "2025-03-27T19:52:00Z")
     private LocalDateTime publishedAt;
+
+    public static ScrapResDTO from(
+            Long id,
+            String sourceName,
+            String title,
+            String description,
+            String urlToImage,
+            LocalDateTime publishedAt
+    ) {
+        return ScrapResDTO.builder()
+                .id(id)
+                .sourceName(sourceName)
+                .title(title)
+                .description(description)
+                .urlToImage(urlToImage)
+                .publishedAt(publishedAt)
+                .build();
+    }
 }

--- a/src/main/java/com/example/globalTimes_be/domain/scrap/repository/ScrapListProjection.java
+++ b/src/main/java/com/example/globalTimes_be/domain/scrap/repository/ScrapListProjection.java
@@ -1,0 +1,20 @@
+package com.example.globalTimes_be.domain.scrap.repository;
+
+import java.time.LocalDateTime;
+
+public interface ScrapListProjection {
+
+    Long getArticleId();
+
+    String getTitle();
+
+    String getSourceName();
+
+    String getUrlToImage();
+
+    String getDescription();
+
+    LocalDateTime getPublishedAt();
+
+    LocalDateTime getScrappedAt();
+}

--- a/src/main/java/com/example/globalTimes_be/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/example/globalTimes_be/domain/scrap/repository/ScrapRepository.java
@@ -2,6 +2,8 @@ package com.example.globalTimes_be.domain.scrap.repository;
 
 import com.example.globalTimes_be.domain.scrap.entity.Scrap;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,8 +15,21 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     // 스크랩 여부 확인
     Optional<Scrap> findByUserIdAndArticleId(Long userId, Long articleId);
 
-    // 사용자 스크랩 목록 (최신순)
-    List<Scrap> findByUserIdOrderByCreatedAtDesc(Long userId);
+    @Query("""
+            SELECT article.id AS articleId,
+                   article.title AS title,
+                   source.sourceName AS sourceName,
+                   article.urlToImage AS urlToImage,
+                   article.description AS description,
+                   article.publishedAt AS publishedAt,
+                   scrap.createdAt AS scrappedAt
+            FROM Scrap scrap
+            JOIN scrap.article article
+            LEFT JOIN article.source source
+            WHERE scrap.user.id = :userId
+            ORDER BY scrap.createdAt DESC, scrap.id DESC
+            """)
+    List<ScrapListProjection> findListByUserId(@Param("userId") Long userId);
 
     // 스크랩 존재 여부 (boolean)
     boolean existsByUserIdAndArticleId(Long userId, Long articleId);

--- a/src/main/java/com/example/globalTimes_be/domain/scrap/service/ScrapService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/scrap/service/ScrapService.java
@@ -2,10 +2,12 @@ package com.example.globalTimes_be.domain.scrap.service;
 
 import com.example.globalTimes_be.domain.article.entity.Article;
 import com.example.globalTimes_be.domain.article.repository.ArticleRepository;
+import com.example.globalTimes_be.domain.article.repository.ArticleSummaryProjection;
 import com.example.globalTimes_be.domain.scrap.dto.response.ScrapListResDTO;
 import com.example.globalTimes_be.domain.scrap.dto.response.ScrapResDTO;
 import com.example.globalTimes_be.domain.scrap.entity.Scrap;
 import com.example.globalTimes_be.domain.scrap.exception.ScrapErrorStatus;
+import com.example.globalTimes_be.domain.scrap.repository.ScrapListProjection;
 import com.example.globalTimes_be.domain.scrap.repository.ScrapRepository;
 import com.example.globalTimes_be.domain.user.entity.User;
 import com.example.globalTimes_be.domain.user.repository.UserRepository;
@@ -15,9 +17,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -32,23 +35,20 @@ public class ScrapService {
     // 기존 API 유지 (localStorage 기반 비로그인 호환)
     @Transactional(readOnly = true)
     public List<ScrapResDTO> getScrap(List<Long> articleIds) {
-        List<ScrapResDTO> scrapResDTOs = new ArrayList<>();
-
-        for (Long articleId : articleIds) {
-            Article article = articleRepository.findById(articleId).orElse(null);
-            if (article == null) continue;
-
-            scrapResDTOs.add(ScrapResDTO.builder()
-                    .id(article.getId())
-                    .sourceName(article.getSource().getSourceName())
-                    .title(article.getTitle())
-                    .description(article.getDescription())
-                    .urlToImage(article.getUrlToImage())
-                    .publishedAt(article.getPublishedAt())
-                    .build());
+        if (articleIds.isEmpty()) {
+            return List.of();
         }
 
-        return scrapResDTOs;
+        List<Long> distinctIds = articleIds.stream().distinct().toList();
+        Map<Long, ArticleSummaryProjection> summariesById = articleRepository.findSummariesByIdIn(distinctIds)
+                .stream()
+                .collect(Collectors.toMap(ArticleSummaryProjection::getId, Function.identity()));
+
+        return articleIds.stream()
+                .map(summariesById::get)
+                .filter(summary -> summary != null)
+                .map(this::toScrapResponse)
+                .toList();
     }
 
     // 스크랩 토글 (추가/취소)
@@ -75,10 +75,33 @@ public class ScrapService {
     // 내 스크랩 목록 조회
     @Transactional(readOnly = true)
     public List<ScrapListResDTO> getScrapList(Long userId) {
-        return scrapRepository.findByUserIdOrderByCreatedAtDesc(userId)
+        return scrapRepository.findListByUserId(userId)
                 .stream()
-                .map(ScrapListResDTO::from)
+                .map(this::toScrapListResponse)
                 .collect(Collectors.toList());
+    }
+
+    private ScrapResDTO toScrapResponse(ArticleSummaryProjection article) {
+        return ScrapResDTO.from(
+                article.getId(),
+                article.getSourceName(),
+                article.getTitle(),
+                article.getDescription(),
+                article.getUrlToImage(),
+                article.getPublishedAt()
+        );
+    }
+
+    private ScrapListResDTO toScrapListResponse(ScrapListProjection scrap) {
+        return ScrapListResDTO.from(
+                scrap.getArticleId(),
+                scrap.getTitle(),
+                scrap.getSourceName(),
+                scrap.getUrlToImage(),
+                scrap.getDescription(),
+                scrap.getPublishedAt(),
+                scrap.getScrappedAt()
+        );
     }
 
     // 특정 기사 스크랩 여부 조회

--- a/src/test/java/com/example/globalTimes_be/domain/scrap/service/ScrapQueryIntegrationTest.java
+++ b/src/test/java/com/example/globalTimes_be/domain/scrap/service/ScrapQueryIntegrationTest.java
@@ -1,0 +1,392 @@
+package com.example.globalTimes_be.domain.scrap.service;
+
+import com.example.globalTimes_be.domain.article.entity.Article;
+import com.example.globalTimes_be.domain.scrap.dto.response.ScrapListResDTO;
+import com.example.globalTimes_be.domain.scrap.dto.response.ScrapResDTO;
+import com.example.globalTimes_be.domain.scrap.entity.Scrap;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@Import(ScrapService.class)
+@TestPropertySource(properties = {
+        "spring.jpa.properties.hibernate.generate_statistics=true",
+        "logging.level.org.hibernate.engine.internal.StatisticalLoggingSessionEventListener=OFF"
+})
+class ScrapQueryIntegrationTest {
+
+    private static final int SCRAP_COUNT = 100;
+
+    @Container
+    @ServiceConnection
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
+            .withUsername("root")
+            .withPassword("test");
+
+    @Autowired
+    private ScrapService scrapService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    private long userId;
+    private List<Long> articleIds;
+    private Statistics statistics;
+    private TransactionTemplate transactionTemplate;
+
+    @BeforeEach
+    void setUpFixture() {
+        List<Long> sourceIds = insertSources();
+        userId = insertUser();
+        articleIds = insertArticles(sourceIds);
+        insertScraps(userId, articleIds);
+
+        statistics = entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+        transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.setReadOnly(true);
+        resetMeasurement();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        jdbcTemplate.update("DELETE FROM scrap");
+        jdbcTemplate.update("DELETE FROM article");
+        jdbcTemplate.update("DELETE FROM users");
+        jdbcTemplate.update("DELETE FROM source");
+    }
+
+    @Test
+    void batchProjectionsReduceStatementsAndPreserveResponses() {
+        long authenticatedStartedAt = System.nanoTime();
+
+        List<ScrapListResDTO> authenticatedBaseline = transactionTemplate.execute(
+                status -> authenticatedBaseline()
+        );
+
+        long authenticatedElapsedMs = elapsedMs(authenticatedStartedAt);
+        System.out.printf(
+                "SCRAP_LIST_BASELINE type=authenticated scraps=%d, result=%d, statements=%d, entities=%d, elapsedMs=%d%n",
+                SCRAP_COUNT,
+                authenticatedBaseline.size(),
+                statistics.getPrepareStatementCount(),
+                statistics.getEntityLoadCount(),
+                authenticatedElapsedMs
+        );
+
+        assertThat(authenticatedBaseline).hasSize(SCRAP_COUNT);
+        assertThat(statistics.getPrepareStatementCount()).isEqualTo(1L + SCRAP_COUNT * 2L);
+        assertThat(statistics.getEntityLoadCount()).isEqualTo(SCRAP_COUNT * 3L);
+
+        resetMeasurement();
+        long authenticatedOptimizedStartedAt = System.nanoTime();
+
+        List<ScrapListResDTO> authenticatedOptimized = scrapService.getScrapList(userId);
+
+        long authenticatedOptimizedElapsedMs = elapsedMs(authenticatedOptimizedStartedAt);
+        printOptimizedMeasurement(
+                "authenticated",
+                authenticatedOptimized.size(),
+                authenticatedOptimizedElapsedMs
+        );
+        assertThat(authenticatedOptimized)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyElementsOf(authenticatedBaseline);
+        assertThat(authenticatedOptimized.get(0).getArticleId()).isEqualTo(articleIds.get(SCRAP_COUNT - 1));
+        assertThat(authenticatedOptimized.get(0).getSourceName()).isEqualTo("Scrap Source 99");
+        assertThat(statistics.getPrepareStatementCount()).isEqualTo(1L);
+        assertThat(statistics.getEntityLoadCount()).isZero();
+        System.out.println("SCRAP_LIST_OPTIMIZED_PLAN type=authenticated " + authenticatedPlan());
+
+        resetMeasurement();
+        long legacyStartedAt = System.nanoTime();
+
+        List<ScrapResDTO> legacyBaseline = transactionTemplate.execute(status -> legacyBaseline(articleIds));
+
+        long legacyElapsedMs = elapsedMs(legacyStartedAt);
+        System.out.printf(
+                "SCRAP_LIST_BASELINE type=legacy ids=%d, result=%d, statements=%d, entities=%d, elapsedMs=%d%n",
+                articleIds.size(),
+                legacyBaseline.size(),
+                statistics.getPrepareStatementCount(),
+                statistics.getEntityLoadCount(),
+                legacyElapsedMs
+        );
+
+        assertThat(legacyBaseline).hasSize(SCRAP_COUNT);
+        assertThat(statistics.getPrepareStatementCount()).isEqualTo(SCRAP_COUNT * 2L);
+        assertThat(statistics.getEntityLoadCount()).isEqualTo(SCRAP_COUNT * 2L);
+
+        resetMeasurement();
+        long legacyOptimizedStartedAt = System.nanoTime();
+
+        List<ScrapResDTO> legacyOptimized = scrapService.getScrap(articleIds);
+
+        long legacyOptimizedElapsedMs = elapsedMs(legacyOptimizedStartedAt);
+        printOptimizedMeasurement("legacy", legacyOptimized.size(), legacyOptimizedElapsedMs);
+        assertThat(legacyOptimized)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyElementsOf(legacyBaseline);
+        assertThat(statistics.getPrepareStatementCount()).isEqualTo(1L);
+        assertThat(statistics.getEntityLoadCount()).isZero();
+        System.out.println("SCRAP_LIST_OPTIMIZED_PLAN type=legacy " + legacyPlan());
+    }
+
+    @Test
+    void legacyBatchQueryPreservesDuplicateOrderAndSkipsMissingIds() {
+        long missingId = articleIds.get(SCRAP_COUNT - 1) + 1_000L;
+        List<Long> requestedIds = List.of(
+                articleIds.get(4),
+                missingId,
+                articleIds.get(1),
+                articleIds.get(4)
+        );
+
+        List<ScrapResDTO> result = scrapService.getScrap(requestedIds);
+
+        assertThat(result).extracting(ScrapResDTO::getId)
+                .containsExactly(articleIds.get(4), articleIds.get(1), articleIds.get(4));
+        assertThat(statistics.getPrepareStatementCount()).isEqualTo(1L);
+        assertThat(statistics.getEntityLoadCount()).isZero();
+
+        resetMeasurement();
+        assertThat(scrapService.getScrap(List.of())).isEmpty();
+        assertThat(statistics.getPrepareStatementCount()).isZero();
+    }
+
+    @Test
+    void batchQueriesKeepArticleWhenSourceIsMissing() {
+        long sourceLessArticleId = insertSourceLessArticle();
+        jdbcTemplate.update(
+                "INSERT INTO scrap(created_at, article_id, user_id) VALUES (?, ?, ?)",
+                Timestamp.valueOf(LocalDateTime.of(2026, 7, 19, 3, 0)),
+                sourceLessArticleId,
+                userId
+        );
+        resetMeasurement();
+
+        List<ScrapListResDTO> authenticated = scrapService.getScrapList(userId);
+        List<ScrapResDTO> legacy = scrapService.getScrap(List.of(sourceLessArticleId));
+
+        assertThat(authenticated.get(0).getArticleId()).isEqualTo(sourceLessArticleId);
+        assertThat(authenticated.get(0).getSourceName()).isNull();
+        assertThat(legacy).singleElement().satisfies(dto -> {
+            assertThat(dto.getId()).isEqualTo(sourceLessArticleId);
+            assertThat(dto.getSourceName()).isNull();
+        });
+    }
+
+    private List<ScrapListResDTO> authenticatedBaseline() {
+        return entityManager.createQuery(
+                        "SELECT scrap FROM Scrap scrap " +
+                                "WHERE scrap.user.id = :userId ORDER BY scrap.createdAt DESC",
+                        Scrap.class
+                )
+                .setParameter("userId", userId)
+                .getResultList()
+                .stream()
+                .map(ScrapListResDTO::from)
+                .toList();
+    }
+
+    private List<ScrapResDTO> legacyBaseline(List<Long> requestedIds) {
+        List<ScrapResDTO> result = new ArrayList<>();
+        for (Long articleId : requestedIds) {
+            Article article = entityManager.find(Article.class, articleId);
+            if (article == null) {
+                continue;
+            }
+            result.add(ScrapResDTO.from(
+                    article.getId(),
+                    article.getSource().getSourceName(),
+                    article.getTitle(),
+                    article.getDescription(),
+                    article.getUrlToImage(),
+                    article.getPublishedAt()
+            ));
+        }
+        return result;
+    }
+
+    private void printOptimizedMeasurement(String type, int resultCount, long elapsedMs) {
+        System.out.printf(
+                "SCRAP_LIST_OPTIMIZED type=%s, result=%d, statements=%d, entities=%d, elapsedMs=%d%n",
+                type,
+                resultCount,
+                statistics.getPrepareStatementCount(),
+                statistics.getEntityLoadCount(),
+                elapsedMs
+        );
+    }
+
+    private String authenticatedPlan() {
+        return jdbcTemplate.queryForObject(
+                "EXPLAIN ANALYZE " +
+                        "SELECT article.article_id, source.source_name " +
+                        "FROM scrap " +
+                        "JOIN article ON article.article_id = scrap.article_id " +
+                        "LEFT JOIN source ON source.source_id = article.source_id " +
+                        "WHERE scrap.user_id = ? " +
+                        "ORDER BY scrap.created_at DESC, scrap.scrap_id DESC",
+                String.class,
+                userId
+        );
+    }
+
+    private String legacyPlan() {
+        String placeholders = String.join(",", Collections.nCopies(articleIds.size(), "?"));
+        return jdbcTemplate.queryForObject(
+                "EXPLAIN ANALYZE " +
+                        "SELECT article.article_id, source.source_name " +
+                        "FROM article " +
+                        "LEFT JOIN source ON source.source_id = article.source_id " +
+                        "WHERE article.article_id IN (" + placeholders + ")",
+                String.class,
+                articleIds.toArray()
+        );
+    }
+
+    private List<Long> insertSources() {
+        List<Object[]> parameters = new ArrayList<>();
+        for (int index = 0; index < SCRAP_COUNT; index++) {
+            parameters.add(new Object[]{"Scrap Source " + index, "scrap-source-" + index});
+        }
+        jdbcTemplate.batchUpdate(
+                "INSERT INTO source(source_name, source_api_id) VALUES (?, ?)",
+                parameters
+        );
+        return jdbcTemplate.queryForList(
+                "SELECT source_id FROM source WHERE source_name LIKE 'Scrap Source %' ORDER BY source_id",
+                Long.class
+        );
+    }
+
+    private long insertUser() {
+        jdbcTemplate.update(
+                "INSERT INTO users(created_at, email, nickname, provider, provider_id) VALUES (NOW(6), ?, ?, ?, ?)",
+                "scrap-query@example.com",
+                "scrap-query-user",
+                "test",
+                "scrap-query-provider-id"
+        );
+        return jdbcTemplate.queryForObject(
+                "SELECT user_id FROM users WHERE email = ?",
+                Long.class,
+                "scrap-query@example.com"
+        );
+    }
+
+    private List<Long> insertArticles(List<Long> sourceIds) {
+        List<Object[]> parameters = new ArrayList<>();
+        LocalDateTime publishedAt = LocalDateTime.of(2026, 7, 19, 1, 0);
+        for (int index = 0; index < SCRAP_COUNT; index++) {
+            parameters.add(new Object[]{
+                    "author",
+                    "general",
+                    "content",
+                    "us",
+                    "Description " + index,
+                    Timestamp.valueOf(publishedAt.plusMinutes(index)),
+                    "Scrap Article " + index,
+                    "https://news.example/scrap-query/" + index,
+                    "https://news.example/scrap-image/" + index + ".jpg",
+                    sourceIds.get(index),
+                    "en"
+            });
+        }
+        jdbcTemplate.batchUpdate(
+                "INSERT INTO article(author, category, content, country, description, published_at, title, url, " +
+                        "url_to_image, view_count, source_id, language) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)",
+                parameters
+        );
+        return jdbcTemplate.queryForList(
+                "SELECT article_id FROM article WHERE url LIKE 'https://news.example/scrap-query/%' ORDER BY article_id",
+                Long.class
+        );
+    }
+
+    private void insertScraps(long targetUserId, List<Long> targetArticleIds) {
+        List<Object[]> parameters = new ArrayList<>();
+        LocalDateTime createdAt = LocalDateTime.of(2026, 7, 19, 2, 0);
+        for (int index = 0; index < targetArticleIds.size(); index++) {
+            parameters.add(new Object[]{
+                    Timestamp.valueOf(createdAt.plusSeconds(index)),
+                    targetArticleIds.get(index),
+                    targetUserId
+            });
+        }
+        jdbcTemplate.batchUpdate(
+                "INSERT INTO scrap(created_at, article_id, user_id) VALUES (?, ?, ?)",
+                parameters
+        );
+    }
+
+    private long insertSourceLessArticle() {
+        jdbcTemplate.update(
+                "INSERT INTO article(author, category, content, country, description, published_at, title, url, " +
+                        "url_to_image, view_count, source_id, language) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, ?)",
+                "author",
+                "general",
+                "content",
+                "us",
+                "Source-less description",
+                Timestamp.valueOf(LocalDateTime.of(2026, 7, 19, 3, 0)),
+                "Source-less article",
+                "https://news.example/scrap-query/source-less",
+                "https://news.example/scrap-image/source-less.jpg",
+                "en"
+        );
+        return jdbcTemplate.queryForObject(
+                "SELECT article_id FROM article WHERE url = ?",
+                Long.class,
+                "https://news.example/scrap-query/source-less"
+        );
+    }
+
+    private void resetMeasurement() {
+        entityManager.clear();
+        statistics.clear();
+    }
+
+    private long elapsedMs(long startedAt) {
+        return (System.nanoTime() - startedAt) / 1_000_000;
+    }
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #216

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [x] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- 로그인 스크랩 목록의 `Scrap → Article → Source` LAZY N+1을 응답 컬럼 projection 단일 조회로 교체했습니다.
- 비로그인 localStorage 호환 목록의 ID별 `findById()`를 article projection 일괄 조회로 교체했습니다.
- 비로그인 요청 ID 순서·중복·누락 ID 제외와 로그인 최신순 및 DTO 전체 필드를 그대로 유지했습니다.
- nullable Article Source가 inner join으로 누락되지 않도록 두 query에 `LEFT JOIN`을 사용했습니다.

## 🔍 기술적 배경
- 사용자 1명, 서로 다른 Source·Article·Scrap 100건의 MySQL fixture에서 로그인 목록은 SQL 201개·entity load 300개, 비로그인 목록은 SQL 200개·entity load 200개를 재현했습니다.
- projection 적용 후 두 경로 모두 SQL 1개·entity load 0개로 감소했습니다.
- 최종 구현의 집중·전체 실행에서 service elapsed는 로그인 92.7~96.2%, 비로그인 93.0~96.5% 감소했지만 환경 편차가 있어 보조 지표로만 기록했습니다.
- 실제 로컬 scrap은 1건이므로 현재 운영 병목이나 운영 latency로 일반화하지 않습니다.

## 🧪 테스트/검증 (필수)
- [x] `./gradlew test --tests "com.example.globalTimes_be.domain.scrap.service.ScrapQueryIntegrationTest" --rerun-tasks`
- [x] `./gradlew test --rerun-tasks` (58 tests, failures 0, errors 0, skipped 0)
- [x] 로그인 DTO 7개 필드와 최신순, 비로그인 DTO 6개 필드와 요청순·중복·누락·빈 목록 무조회 검증
- [x] nullable Source 기사 보존 및 projection getter 매핑을 실제 MySQL에서 검증
- [x] `EXPLAIN ANALYZE`: 로그인 약 1.50~1.54ms, 비로그인 약 0.33~0.37ms

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop` 대상)
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 외부 endpoint·응답 필드와 기존 목록 의미가 동일함을 확인했는가?

## 📸 스크린샷 (선택)
- 해당 없음

## 💬 리뷰 요구사항(선택)
- JPQL alias와 두 interface projection getter가 정확히 매핑되는지 확인해 주세요.
- 로그인 `createdAt DESC, id DESC` 및 비로그인 ID map 재구성이 기존 최신순·요청순·중복·누락 의미를 유지하는지 확인해 주세요.
- nullable Source에 `LEFT JOIN`이 필요한지와 결과 누락 없이 null sourceName이 전달되는지 확인해 주세요.
- 합성 fixture의 구조 개선 수치를 실제 운영 성능으로 과장하지 않았는지 확인해 주세요.

## ➕ 추후 계획(선택)
- 요청 ID나 사용자 스크랩 수가 payload·메모리 문제를 만들 정도로 증가할 때 pagination 또는 요청 개수 제한을 별도 측정합니다.
- scrap toggle 동시성 및 멱등성은 API 의미 결정이 필요한 별도 이슈로 남깁니다.
