### PR TITLE
🐛 [FIX/#221] 익명 채팅 Redis 동시 요청 데이터 유실 방지

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -11,6 +11,14 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## Recently Completed
 
+### P1. 익명 채팅 Redis 동시 요청 데이터 유실 방지 및 회귀 검증
+
+- 상태: `Done` ([#221](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/221), [PR #222](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/222))
+- AS-IS: 세션·기사별 대화와 세션별 최근 기사 인덱스를 String JSON으로 조회·수정·재저장해 동시 갱신이 서로를 덮어쓸 수 있었다.
+- TO-BE: Redis List·Sorted Set의 개별 추가 명령으로 전체 JSON 덮어쓰기를 제거하고 `ZADD GT`로 지연된 과거 최근 활동 score의 역전 갱신을 차단했다.
+- 범위: 익명 채팅 Redis 저장 경로와 Redis Testcontainers 회귀 테스트로 제한했다. Lua, MULTI/EXEC, 분산 락, Kafka, Gemini 호출, 로그인 MySQL 채팅은 제외했다.
+- 검증: 동시 20건에서 기존 JSON 1건·List 20건 보존, 서로 다른 기사 인덱스 20/20건 보존을 각각 3회 확인했다. score 200 이후 도착한 score 100을 거부했고 Redis 집중 테스트 9개·전체 67개 테스트·Backend CI가 통과했다.
+
 ### P1. 백엔드 개선 정량 결과 인덱스 정리
 
 - 상태: `Done` ([#218](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/218), [PR #220](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/220))

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -9,6 +9,10 @@
 
 ## Recently Completed
 
+- #221 / PR #222: `Done`
+- Result: Redis List append preserved 20/20 concurrent anonymous chat turns instead of 1/20, Sorted Set preserved 20/20 article entries, and `ZADD GT` prevented delayed older activity scores from replacing newer scores; all 67 tests and Backend CI passed
+- Boundary: Redis List, Sorted Set, basic Spring Data Redis commands, and Redis Testcontainers only; no Lua, MULTI/EXEC, distributed lock, Kafka, Gemini call, logged-in MySQL chat change, or Issue #110 work
+
 - #218 / PR #220: `Done`
 - Result: consolidated domain problems, changes, quantitative outcomes, validation tools, and source evidence across k6, mock, Testcontainers, EXPLAIN, and Actuator work
 - Boundary: documentation-only evidence indexing; no new measurements, production code, test, load script, technology adoption, or Issue #110 work

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -9,6 +9,17 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Recently Completed
 
+### #221 - 익명 채팅 Redis 동시 요청 데이터 유실 방지 및 회귀 검증
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/221
+- 작업 브랜치: `fix/#221-anonymous-chat-redis-concurrency`
+- 상태: `Done` ([PR #222](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/222))
+- 기준선: 익명 대화와 최근 기사 인덱스가 Redis String JSON의 read-modify-write로 저장되어 동일 세션의 동시 SSE 완료 시 마지막 SET이 앞선 갱신을 덮어쓸 수 있었다.
+- 결과: Redis List·Sorted Set의 개별 추가 명령으로 전체 JSON 덮어쓰기를 제거하고, `ZADD GT`로 지연된 과거 최근 활동 score의 역전 갱신을 차단했다.
+- overengineering 판단: 이미 사용하는 Redis 자료구조와 Spring Data Redis 기본 명령만 활용했다. Lua, MULTI/EXEC, 분산 락, Kafka, 로그인 MySQL 채팅 변경, 실제 Gemini 호출은 제외했다.
+- 검증: 통제된 동시 요청 20건에서 기존 JSON은 1건 보존·19건 유실, List는 20건 보존·0건 유실을 3회 반복 확인했다. 서로 다른 기사 인덱스도 20/20건을 3회 보존했고 score 200 이후 도착한 score 100을 거부했다. Redis 집중 테스트 9개, 전체 67개 테스트, Backend CI가 통과했으며 AI Reviewer는 Blocking 없음·MERGE_READY로 판정했다.
+- 측정 문서: `docs/backend-improvement/anonymous-chat-redis-concurrency.md`
+
 ### #218 - 백엔드 개선 정량 결과 인덱스 정리
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/218

--- a/docs/backend-improvement/anonymous-chat-redis-concurrency.md
+++ b/docs/backend-improvement/anonymous-chat-redis-concurrency.md
@@ -1,0 +1,50 @@
+# 익명 채팅 Redis 동시 저장 정합성 개선
+
+- Issue: [#221](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/221)
+- PR: [#222](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/222)
+- 상태: `Done`
+
+## 문제
+
+기존 익명 채팅은 `chat:anon:{sessionId}:{articleId}` String에 전체 대화 JSON을 저장했다. 각 요청이 기존 JSON을 읽고 Java에서 새 턴을 추가한 뒤 전체 값을 다시 `SET`하므로, 동일 세션의 SSE 응답이 겹치면 마지막 요청이 앞선 요청의 결과를 덮어쓸 수 있었다.
+
+최근 대화 기사 인덱스도 `chat:anon:index:{sessionId}` JSON Map 전체를 같은 방식으로 갱신해 서로 다른 기사 요청 사이에서 항목이 유실될 수 있었다.
+
+## 변경
+
+| 데이터 | 기존 | 변경 |
+| --- | --- | --- |
+| 세션·기사별 대화 | String에 전체 JSON GET·수정·SET | List에 턴별 JSON `RPUSH`, 최근 N개 `LTRIM` |
+| 세션별 최근 기사 | String에 전체 JSON Map GET·수정·SET | Sorted Set에 articleId와 활동 시각 `ZADD GT` |
+| 만료 | String SET 시 TTL 지정 | List·Sorted Set 갱신 후 `EXPIRE` |
+| key | `chat:anon:*` | 자료형 충돌을 피한 `chat:anon:v2:*` |
+
+각 `RPUSH`와 `ZADD`는 Redis가 명령 단위로 처리하므로 기존처럼 전체 값을 읽고 덮어쓰지 않는다. 최근 활동 score는 `ZADD GT`로 기존 값보다 큰 시각만 반영해 지연된 요청이 최신 시각을 과거로 되돌리지 못하게 한다. Lua, `MULTI/EXEC`, 분산 락은 사용하지 않았다. 여러 명령 전체의 all-or-nothing 보장은 이번 범위가 아니며 실제 부분 실패 근거가 생기면 후속 검토한다.
+
+## 검증 환경
+
+- Java 17, Spring Boot 3.3.10, Spring Data Redis
+- Docker Desktop, Redis `7.2-alpine` Testcontainer
+- 동일 시작 latch를 사용한 동시 요청 20개
+- 동시 대화 저장과 동시 기사 인덱스 시나리오를 각각 3회 반복
+- 실제 Gemini·MySQL·HTTP 요청 없이 Redis 저장 경로만 격리 검증
+
+## 결과
+
+| 시나리오 | 기대 | 기존 JSON | List·Sorted Set | 반복 결과 |
+| --- | ---: | ---: | ---: | --- |
+| 동일 세션·기사에 동시 대화 20건 저장 | 20건 | 1건 보존·19건 유실 | 20건 보존·0건 유실 | 3/3회 동일 |
+| 동일 세션의 서로 다른 기사 20건 인덱스 갱신 | 20건 | 전체 Map 덮어쓰기 위험 | 20건 보존·0건 유실 | 3/3회 동일 |
+| 동일 기사의 score 200 저장 후 지연된 score 100 도착 | score 200 유지 | score 100으로 회귀 가능 | score 200 유지 | 통과 |
+| 5건 순차 저장, `maxTurns=3` | 최근 3건 | 최근 3건 | 최근 3건 | 통과 |
+| 테스트 TTL 60초 | 두 key 모두 TTL 존재 | TTL 존재 | `1~60초` 범위 | 통과 |
+
+집중 테스트는 총 9개가 실행됐으며 failure·error·skip 없이 통과했다. 전체 Gradle 회귀 테스트는 67개 모두 통과했다.
+
+## 해석 제한
+
+- 기존 결과는 모든 worker가 같은 기존 값을 읽은 뒤 저장하도록 통제한 최악의 경쟁 조건이다. 실제 유실률을 의미하지 않는다.
+- 이번 수치는 처리량·응답시간 개선이 아니라 동시 갱신 데이터 보존 결과다.
+- 새 v2 key는 기존 String key와 자료형이 충돌하지 않는다. v1 key fallback은 제공하지 않으므로 전환 전에 생성된 익명 대화는 배포 직후부터 조회되지 않고 저장 공간만 최대 7일 TTL 후 자연 만료된다.
+- 명령 묶음은 원자적으로 처리하지 않는다. `RPUSH` 후 `LTRIM` 실패 시 최대 턴을 초과하고, 대화 append 후 index 갱신 실패 시 최근 기사 목록에서 누락되며, `ZADD` 후 `EXPIRE` 실패 시 TTL이 설정되지 않을 수 있다.
+- 로그인 사용자 MySQL 채팅, 실제 Gemini SSE, 다중 서버 Redis 장애 복구는 검증 범위가 아니다.

--- a/docs/backend-improvement/backend-improvement-quantitative-index.md
+++ b/docs/backend-improvement/backend-improvement-quantitative-index.md
@@ -35,6 +35,7 @@
 | 채팅 팝업이 전체 이력 5,000건을 적재하고 Article N+1 수행 | MySQL `ROW_NUMBER()` latest-per-article projection | SQL `101 → 1`, entity loads `5,100 → 0`, service elapsed 실행별 `83.0~86.8%` 감소 | Testcontainers + Hibernate Statistics + EXPLAIN | [PR #215](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/215), [상세](chat-history-latest-query.md) |
 | 로그인 스크랩의 2단계 N+1과 비로그인 ID별 반복 조회 | DTO projection 일괄 조회와 요청 ID 순서 복원 | 로그인 SQL `201 → 1`·entity `300 → 0`, 비로그인 SQL `200 → 1`·entity `200 → 0` | Testcontainers + Hibernate Statistics + EXPLAIN | [PR #217](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/217), [상세](scrap-list-query-optimization.md) |
 | 수집 로직만으로는 과거·동시 기사 URL 중복을 최종 차단할 수 없음 | SHA-256 generated column UNIQUE와 안전한 Flyway 중복 정리 | 기사 `9,853 → 9,814`, 초과 중복 `39 → 0`; 동일 URL 동시 INSERT 1건 성공·1건 거부 | Testcontainers + Flyway + local MySQL | [PR #211](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/211), [상세](article-url-uniqueness.md) |
+| 익명 채팅 JSON 전체 덮어쓰기로 동일 세션의 동시 대화·최근 기사 유실 가능 | Redis List 턴별 append와 Sorted Set 기사별 갱신 | 통제된 동시 20건에서 대화 보존 `1 → 20`, 유실 `19 → 0`; 서로 다른 기사 인덱스 `20/20` 보존 | Redis Testcontainers | [PR #222](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/222), [상세](anonymous-chat-redis-concurrency.md) |
 
 ## 측정으로 확인한 효과와 기준선
 

--- a/src/main/java/com/example/globalTimes_be/domain/chat/service/AnonymousChatSessionService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/chat/service/AnonymousChatSessionService.java
@@ -5,7 +5,6 @@ import com.example.globalTimes_be.domain.article.repository.ArticleRepository;
 import com.example.globalTimes_be.domain.chat.dto.ChatHistoryListResDTO;
 import com.example.globalTimes_be.domain.chat.dto.ChatMessagePair;
 import com.example.globalTimes_be.global.redis.RedisUtil;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,7 +16,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,9 +27,9 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class AnonymousChatSessionService {
 
-    private static final String KEY_PREFIX = "chat:anon:";
+    private static final String KEY_PREFIX = "chat:anon:v2:";
     /** 세션별 기사 ID → 마지막 활동 시각(epoch ms), TTL은 기사 키와 동일 */
-    private static final String INDEX_PREFIX = "chat:anon:index:";
+    private static final String INDEX_PREFIX = "chat:anon:index:v2:";
 
     private final RedisUtil redisUtil;
     private final ObjectMapper objectMapper;
@@ -86,15 +84,20 @@ public class AnonymousChatSessionService {
             return Collections.emptyList();
         }
         String sid = sessionId.trim();
-        Map<Long, Long> index = loadIndexMap(sid);
+        List<RedisUtil.ScoredValue> index = loadIndex(sid);
         if (index.isEmpty()) {
             return Collections.emptyList();
         }
 
-        List<Long> orderedArticleIds = index.entrySet().stream()
-                .sorted(Map.Entry.<Long, Long>comparingByValue().reversed())
-                .map(Map.Entry::getKey)
-                .toList();
+        Map<Long, Long> lastActivityByArticleId = new LinkedHashMap<>();
+        for (RedisUtil.ScoredValue value : index) {
+            try {
+                lastActivityByArticleId.put(Long.parseLong(value.value()), (long) value.score());
+            } catch (NumberFormatException e) {
+                log.warn("[AnonymousChat] 잘못된 articleId 인덱스 sessionId={}, value={}", sid, value.value());
+            }
+        }
+        List<Long> orderedArticleIds = new ArrayList<>(lastActivityByArticleId.keySet());
 
         List<Article> articles = articleRepository.findAllById(orderedArticleIds);
         Map<Long, Article> byId = articles.stream().collect(Collectors.toMap(Article::getId, a -> a, (a, b) -> a));
@@ -111,7 +114,7 @@ public class AnonymousChatSessionService {
                 continue;
             }
             ChatMessagePair last = history.get(history.size() - 1);
-            Long epochMs = index.get(articleId);
+            Long epochMs = lastActivityByArticleId.get(articleId);
             LocalDateTime lastChatAt = epochMs != null
                     ? LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMs), zone)
                     : LocalDateTime.now(zone);
@@ -127,13 +130,8 @@ public class AnonymousChatSessionService {
         }
         String key = buildKey(sessionId, articleId);
         try {
-            List<ChatMessagePair> list = new ArrayList<>(loadAll(sessionId, articleId));
-            list.add(new ChatMessagePair(question, answer));
-            if (maxTurns > 0 && list.size() > maxTurns) {
-                list = new ArrayList<>(list.subList(list.size() - maxTurns, list.size()));
-            }
-            String json = objectMapper.writeValueAsString(list);
-            redisUtil.setData(key, json, ttlSeconds);
+            String json = objectMapper.writeValueAsString(new ChatMessagePair(question, answer));
+            redisUtil.appendListData(key, json, maxTurns, ttlSeconds);
             touchIndex(sessionId.trim(), articleId);
         } catch (Exception e) {
             log.error("[AnonymousChat] 저장 실패 sessionId={}, articleId={}", sessionId, articleId, e);
@@ -146,12 +144,15 @@ public class AnonymousChatSessionService {
         }
         String key = buildKey(sessionId, articleId);
         try {
-            String json = redisUtil.getData(key);
-            if (json == null || json.isBlank()) {
+            List<String> values = redisUtil.getListData(key);
+            if (values.isEmpty()) {
                 return Collections.emptyList();
             }
-            return objectMapper.readValue(json, new TypeReference<>() {
-            });
+            List<ChatMessagePair> history = new ArrayList<>();
+            for (String value : values) {
+                history.add(objectMapper.readValue(value, ChatMessagePair.class));
+            }
+            return history;
         } catch (Exception e) {
             log.warn("[AnonymousChat] 조회 실패 sessionId={}, articleId={}: {}", sessionId, articleId, e.getMessage());
             return Collections.emptyList();
@@ -166,39 +167,19 @@ public class AnonymousChatSessionService {
         return INDEX_PREFIX + sessionId.trim();
     }
 
-    private Map<Long, Long> loadIndexMap(String sessionId) {
-        String key = buildIndexKey(sessionId);
+    private List<RedisUtil.ScoredValue> loadIndex(String sessionId) {
         try {
-            String json = redisUtil.getData(key);
-            if (json == null || json.isBlank()) {
-                return new HashMap<>();
-            }
-            Map<String, Long> raw = objectMapper.readValue(json, new TypeReference<>() {
-            });
-            Map<Long, Long> out = new HashMap<>();
-            for (Map.Entry<String, Long> e : raw.entrySet()) {
-                out.put(Long.parseLong(e.getKey()), e.getValue());
-            }
-            return out;
+            return redisUtil.getReverseSortedSetData(buildIndexKey(sessionId));
         } catch (Exception e) {
-            log.warn("[AnonymousChat] 인덱스 파싱 실패 sessionId={}: {}", sessionId, e.getMessage());
-            return new HashMap<>();
+            log.warn("[AnonymousChat] 인덱스 조회 실패 sessionId={}: {}", sessionId, e.getMessage());
+            return Collections.emptyList();
         }
-    }
-
-    private void saveIndexMap(String sessionId, Map<Long, Long> map) throws Exception {
-        String key = buildIndexKey(sessionId);
-        Map<String, Long> forJson = new LinkedHashMap<>();
-        map.forEach((k, v) -> forJson.put(String.valueOf(k), v));
-        String json = objectMapper.writeValueAsString(forJson);
-        redisUtil.setData(key, json, ttlSeconds);
     }
 
     private void touchIndex(String sessionId, Long articleId) {
         try {
-            Map<Long, Long> map = loadIndexMap(sessionId);
-            map.put(articleId, System.currentTimeMillis());
-            saveIndexMap(sessionId, map);
+            redisUtil.addSortedSetDataIfGreater(
+                    buildIndexKey(sessionId), String.valueOf(articleId), System.currentTimeMillis(), ttlSeconds);
         } catch (Exception e) {
             log.warn("[AnonymousChat] 인덱스 갱신 실패 sessionId={}, articleId={}", sessionId, articleId, e);
         }
@@ -206,11 +187,8 @@ public class AnonymousChatSessionService {
 
     private void ensureIndexContains(String sessionId, Long articleId) {
         try {
-            Map<Long, Long> map = loadIndexMap(sessionId);
-            if (!map.containsKey(articleId)) {
-                map.put(articleId, System.currentTimeMillis());
-                saveIndexMap(sessionId, map);
-            }
+            redisUtil.addSortedSetDataIfAbsent(
+                    buildIndexKey(sessionId), String.valueOf(articleId), System.currentTimeMillis(), ttlSeconds);
         } catch (Exception e) {
             log.warn("[AnonymousChat] 인덱스 보정 실패 sessionId={}, articleId={}", sessionId, articleId, e);
         }

--- a/src/main/java/com/example/globalTimes_be/global/redis/RedisUtil.java
+++ b/src/main/java/com/example/globalTimes_be/global/redis/RedisUtil.java
@@ -1,11 +1,19 @@
 package com.example.globalTimes_be.global.redis;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.RedisZSetCommands.ZAddArgs;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
 @RequiredArgsConstructor
 @Service
@@ -36,8 +44,52 @@ public class RedisUtil {
         valueOperations.set(key, value, expireDuration);
     }
 
+    public List<String> getListData(String key) {
+        List<String> values = template.opsForList().range(key, 0, -1);
+        return values != null ? values : Collections.emptyList();
+    }
+
+    public void appendListData(String key, String value, long maxSize, long duration) {
+        ListOperations<String, String> operations = template.opsForList();
+        operations.rightPush(key, value);
+        if (maxSize > 0) {
+            operations.trim(key, -maxSize, -1);
+        }
+        template.expire(key, Duration.ofSeconds(duration));
+    }
+
+    public List<ScoredValue> getReverseSortedSetData(String key) {
+        Set<ZSetOperations.TypedTuple<String>> values = template.opsForZSet()
+                .reverseRangeWithScores(key, 0, -1);
+        if (values == null || values.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return values.stream()
+                .filter(value -> value.getValue() != null && value.getScore() != null)
+                .map(value -> new ScoredValue(value.getValue(), value.getScore()))
+                .toList();
+    }
+
+    public void addSortedSetDataIfGreater(String key, String value, double score, long duration) {
+        byte[] rawKey = Objects.requireNonNull(template.getStringSerializer().serialize(key));
+        byte[] rawValue = Objects.requireNonNull(template.getStringSerializer().serialize(value));
+        template.execute((RedisCallback<Boolean>) connection ->
+                connection.zSetCommands().zAdd(rawKey, score, rawValue, ZAddArgs.empty().gt()));
+        template.expire(key, Duration.ofSeconds(duration));
+    }
+
+    public void addSortedSetDataIfAbsent(String key, String value, double score, long duration) {
+        Boolean added = template.opsForZSet().addIfAbsent(key, value, score);
+        if (Boolean.TRUE.equals(added)) {
+            template.expire(key, Duration.ofSeconds(duration));
+        }
+    }
+
     //데이터 삭제
     public void deleteData(String key) {
         template.delete(key);
+    }
+
+    public record ScoredValue(String value, double score) {
     }
 }

--- a/src/test/java/com/example/globalTimes_be/domain/chat/service/AnonymousChatSessionServiceRedisIntegrationTest.java
+++ b/src/test/java/com/example/globalTimes_be/domain/chat/service/AnonymousChatSessionServiceRedisIntegrationTest.java
@@ -1,0 +1,228 @@
+package com.example.globalTimes_be.domain.chat.service;
+
+import com.example.globalTimes_be.domain.article.repository.ArticleRepository;
+import com.example.globalTimes_be.domain.chat.dto.ChatMessagePair;
+import com.example.globalTimes_be.global.redis.RedisUtil;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.function.IntConsumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@Testcontainers
+class AnonymousChatSessionServiceRedisIntegrationTest {
+
+    private static final int REDIS_PORT = 6379;
+    private static final long TEST_TTL_SECONDS = 60;
+
+    @Container
+    static final GenericContainer<?> REDIS = new GenericContainer<>(DockerImageName.parse("redis:7.2-alpine"))
+            .withExposedPorts(REDIS_PORT);
+
+    private static LettuceConnectionFactory connectionFactory;
+    private static StringRedisTemplate redisTemplate;
+    private static RedisUtil redisUtil;
+    private static ObjectMapper objectMapper;
+    private static AnonymousChatSessionService service;
+
+    @BeforeAll
+    static void setUpRedisClient() {
+        connectionFactory = new LettuceConnectionFactory(REDIS.getHost(), REDIS.getMappedPort(REDIS_PORT));
+        connectionFactory.afterPropertiesSet();
+        redisTemplate = new StringRedisTemplate(connectionFactory);
+        redisTemplate.afterPropertiesSet();
+        redisUtil = new RedisUtil(redisTemplate);
+        objectMapper = new ObjectMapper().findAndRegisterModules();
+        service = new AnonymousChatSessionService(redisUtil, objectMapper, mock(ArticleRepository.class));
+        ReflectionTestUtils.setField(service, "ttlSeconds", TEST_TTL_SECONDS);
+    }
+
+    @AfterAll
+    static void closeRedisClient() {
+        if (connectionFactory != null) {
+            connectionFactory.destroy();
+        }
+    }
+
+    @BeforeEach
+    void flushRedis() {
+        try (RedisConnection connection = connectionFactory.getConnection()) {
+            connection.serverCommands().flushAll();
+        }
+    }
+
+    @RepeatedTest(3)
+    void listAppendPreservesConcurrentTurnsThatLegacyJsonOverwriteLoses() throws Exception {
+        int requests = 20;
+        String sessionId = UUID.randomUUID().toString();
+        Long articleId = 1L;
+
+        int legacySavedTurns = runLegacyConcurrentOverwrite(sessionId, articleId, requests);
+        runConcurrently(requests, index ->
+                service.appendTurn(sessionId, articleId, "question-" + index, "answer-" + index, requests));
+
+        List<ChatMessagePair> saved = service.getFullHistory(sessionId, articleId);
+        Set<String> expectedQuestions = IntStream.range(0, requests)
+                .mapToObj(index -> "question-" + index)
+                .collect(Collectors.toSet());
+
+        assertThat(legacySavedTurns).isEqualTo(1);
+        assertThat(saved).hasSize(requests);
+        assertThat(saved).extracting(ChatMessagePair::question)
+                .containsExactlyInAnyOrderElementsOf(expectedQuestions);
+    }
+
+    @RepeatedTest(3)
+    void sortedSetPreservesEveryArticleUpdatedConcurrentlyByOneSession() throws Exception {
+        int articleCount = 20;
+        String sessionId = UUID.randomUUID().toString();
+
+        runConcurrently(articleCount, index ->
+                service.appendTurn(sessionId, (long) index + 1, "question", "answer", 10));
+
+        List<String> indexedArticleIds = redisUtil.getReverseSortedSetData(indexKey(sessionId)).stream()
+                .map(RedisUtil.ScoredValue::value)
+                .toList();
+        Set<String> expectedArticleIds = IntStream.rangeClosed(1, articleCount)
+                .mapToObj(String::valueOf)
+                .collect(Collectors.toSet());
+
+        assertThat(indexedArticleIds).hasSize(articleCount);
+        assertThat(indexedArticleIds).containsExactlyInAnyOrderElementsOf(expectedArticleIds);
+    }
+
+    @Test
+    void appendMaintainsMaxTurnsRecentOrderAndTtl() {
+        String sessionId = UUID.randomUUID().toString();
+        Long articleId = 1L;
+
+        IntStream.range(0, 5).forEach(index ->
+                service.appendTurn(sessionId, articleId, "question-" + index, "answer-" + index, 3));
+
+        List<ChatMessagePair> saved = service.getFullHistory(sessionId, articleId);
+        Long chatTtl = redisTemplate.getExpire(chatKey(sessionId, articleId), TimeUnit.SECONDS);
+        Long indexTtl = redisTemplate.getExpire(indexKey(sessionId), TimeUnit.SECONDS);
+
+        assertThat(saved).extracting(ChatMessagePair::question)
+                .containsExactly("question-2", "question-3", "question-4");
+        assertThat(chatTtl).isBetween(1L, TEST_TTL_SECONDS);
+        assertThat(indexTtl).isBetween(1L, TEST_TTL_SECONDS);
+    }
+
+    @Test
+    void sortedSetReturnsMostRecentlyUpdatedArticleFirst() throws Exception {
+        String sessionId = UUID.randomUUID().toString();
+
+        service.appendTurn(sessionId, 1L, "first", "answer", 3);
+        Thread.sleep(20);
+        service.appendTurn(sessionId, 2L, "second", "answer", 3);
+
+        assertThat(redisUtil.getReverseSortedSetData(indexKey(sessionId)))
+                .extracting(RedisUtil.ScoredValue::value)
+                .containsExactly("2", "1");
+    }
+
+    @Test
+    void sortedSetDoesNotReplaceLatestActivityWithDelayedOlderScore() {
+        String key = indexKey(UUID.randomUUID().toString());
+
+        redisUtil.addSortedSetDataIfGreater(key, "1", 200, TEST_TTL_SECONDS);
+        redisUtil.addSortedSetDataIfGreater(key, "1", 100, TEST_TTL_SECONDS);
+
+        assertThat(redisUtil.getReverseSortedSetData(key))
+                .singleElement()
+                .satisfies(value -> {
+                    assertThat(value.value()).isEqualTo("1");
+                    assertThat(value.score()).isEqualTo(200);
+                });
+    }
+
+    private int runLegacyConcurrentOverwrite(String sessionId, Long articleId, int requests) throws Exception {
+        String key = "chat:anon:" + sessionId + ":" + articleId;
+        CountDownLatch allRead = new CountDownLatch(requests);
+        runConcurrently(requests, index -> {
+            try {
+                String stored = redisUtil.getData(key);
+                List<ChatMessagePair> history = stored == null
+                        ? new ArrayList<>()
+                        : objectMapper.readValue(stored, new TypeReference<>() {
+                        });
+                allRead.countDown();
+                if (!allRead.await(10, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("legacy readers did not synchronize");
+                }
+                history.add(new ChatMessagePair("question-" + index, "answer-" + index));
+                redisUtil.setData(key, objectMapper.writeValueAsString(history), TEST_TTL_SECONDS);
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
+        });
+        String stored = redisUtil.getData(key);
+        List<ChatMessagePair> saved = objectMapper.readValue(stored, new TypeReference<>() {
+        });
+        return saved.size();
+    }
+
+    private void runConcurrently(int tasks, IntConsumer action) throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(tasks);
+        CountDownLatch ready = new CountDownLatch(tasks);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>();
+        try {
+            for (int index = 0; index < tasks; index++) {
+                int taskIndex = index;
+                futures.add(executor.submit(() -> {
+                    ready.countDown();
+                    if (!start.await(10, TimeUnit.SECONDS)) {
+                        throw new IllegalStateException("workers did not start together");
+                    }
+                    action.accept(taskIndex);
+                    return null;
+                }));
+            }
+            if (!ready.await(10, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("workers were not ready");
+            }
+            start.countDown();
+            for (Future<?> future : futures) {
+                future.get(20, TimeUnit.SECONDS);
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private String chatKey(String sessionId, Long articleId) {
+        return "chat:anon:v2:" + sessionId + ":" + articleId;
+    }
+
+    private String indexKey(String sessionId) {
+        return "chat:anon:index:v2:" + sessionId;
+    }
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #221

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [x] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- 익명 채팅의 전체 JSON GET·수정·SET 저장을 Redis List의 턴별 `RPUSH`와 `LTRIM`으로 교체했습니다.
- 세션별 최근 기사 JSON Map을 Sorted Set의 articleId별 `ZADD GT`로 교체해 지연된 과거 시각이 최신 score를 덮어쓰지 못하게 했습니다.
- 기존 String key와 자료형이 충돌하지 않도록 `chat:anon:v2:*` key를 사용하고 기존 key는 TTL 만료에 맡겼습니다.
- 실제 Redis Testcontainers 동시성 회귀 테스트와 측정 문서를 추가하고 진척 문서를 함께 갱신했습니다.

## 🔍 기술적 배경
- 세션 ID는 익명 사용자를 구분하지만 같은 세션의 동시 SSE 완료를 직렬화하지 않습니다.
- 기존 read-modify-write는 여러 요청이 같은 JSON을 읽은 뒤 전체 값을 덮어써 대화와 기사 인덱스를 유실할 수 있었습니다.
- List·Sorted Set의 개별 추가 명령은 전체 값을 읽고 다시 쓰지 않으며, `ZADD GT`는 기존 score보다 큰 최근 활동 시각만 반영합니다.
- Lua, `MULTI/EXEC`, 분산 락은 사용하지 않았으며 여러 명령의 all-or-nothing 보장은 실제 부분 실패 근거가 생길 때 후속 검토합니다.

## 🧪 테스트/검증 (필수)
- [x] Redis `7.2-alpine` Testcontainer에서 동일 세션·기사 동시 20건: 기존 JSON 1건 보존·19건 유실, List 20건 보존·0건 유실을 3회 확인
- [x] 동일 세션의 서로 다른 기사 20건 인덱스 갱신: Sorted Set 20/20건 보존을 3회 확인
- [x] score 200 이후 지연된 score 100 갱신을 시도해 최종 score 200 유지 확인
- [x] 최근 3턴 제한, 저장 순서, 최근 기사순, List·Sorted Set TTL 회귀 검증
- [x] Redis 집중 테스트 9개 통과
- [x] `./gradlew test`: 전체 67개, failure·error·skip 0
- [x] `git diff --check` 통과

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop` 대상)
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 로그인 사용자 MySQL 채팅과 익명 채팅 API 응답 계약을 변경하지 않았는가?

## 📸 스크린샷 (선택)
- 해당 없음

## 💬 리뷰 요구사항(선택)
- List·Sorted Set 전환이 동일 세션의 대화와 최근 기사 인덱스 lost update를 제거하는지 확인해 주세요.
- `ZADD GT`가 지연된 과거 score의 역전 갱신을 차단하는지 확인해 주세요.
- `maxTurns`, TTL, 최근 활동순과 v2 key 전환이 기존 익명 채팅 동작을 유지하는지 확인해 주세요.
- Lua·transaction을 제외한 부분 실패와 hard cutover 한계가 명확하게 기록됐는지 확인해 주세요.

## ➕ 추후 계획(선택)
- 명령 사이 부분 실패가 실제로 관측되면 명령 묶음의 all-or-nothing 보장을 별도 Issue로 검토합니다.
