### PR TITLE
🔎 [OBS/#223] RSS·News API freshness·coverage 수집 통계 보강

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -7,9 +7,18 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## Current Active Work
 
-현재 진행 중인 작업 없음.
+- 없음
 
 ## Recently Completed
+
+### P1. RSS·News API source별 freshness·coverage 기준선 및 수집 통계 보강
+
+- 상태: `Done` ([#223](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/223), [PR #224](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/224))
+- AS-IS: 백엔드 scheduler 주기는 알 수 있지만 source별 실제 갱신 시점·신규 기사 수·언어 및 국가 coverage가 측정되지 않아 매칭 결과 부족의 원인을 분리하기 어려웠다.
+- TO-BE: 기존 DB snapshot SQL과 수집 batch 로그에 source·country·language·category 분포, 최초·최신 발행 시각, freshness를 기록했다.
+- 범위: 기존 컬럼·로그·mock fixture·문서로 제한했다. 실제 외부 호출, 신규 schema·관측 stack, 기사 번역, ranking, retry·Kafka는 제외했다.
+- 검증: mock batch 통계 fixture와 전체 71개 테스트 및 Backend CI가 통과했고 AI Reviewer는 Blocking 없음·MERGE_READY로 판정했다. 실행 중인 compose DB가 없어 실데이터 snapshot 수치는 주장하지 않았다.
+- 근거: `docs/backend-improvement/collection-freshness-coverage-baseline.md`, `docs/backend-improvement/sql/collection-coverage-snapshot.sql`
 
 ### P1. 익명 채팅 Redis 동시 요청 데이터 유실 방지 및 회귀 검증
 

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -5,9 +5,14 @@
 
 ## Current Active Work
 
-- None.
+- None
 
 ## Recently Completed
+
+- #223 / PR #224: `Done`
+- Result: News API/RSS batch logs now expose source dimensions, received/invalid/duplicate/saved counts, publication range, and freshness; a read-only SQL snapshot separates local coverage gaps from matching failures
+- Validation: fixtures report 4 received, 1 invalid, 2 duplicate, 1 saved, and the 09:00-11:00 UTC range; all 71 tests and Backend CI passed, and the AI Reviewer reported no Blocking and MERGE_READY
+- Boundary: no real external call, populated compose DB claim, schema, translation, ranking, retry, Kafka, APM, or Issue #110 work
 
 - #221 / PR #222: `Done`
 - Result: Redis List append preserved 20/20 concurrent anonymous chat turns instead of 1/20, Sorted Set preserved 20/20 article entries, and `ZADD GT` prevented delayed older activity scores from replacing newer scores; all 67 tests and Backend CI passed

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -5,9 +5,21 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Current Active Work
 
-현재 진행 중인 작업 없음.
+- 없음
 
 ## Recently Completed
+
+### #223 - RSS·News API source별 freshness·coverage 기준선 및 수집 통계 보강
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/223
+- 작업 브랜치: `obs/#223-collection-freshness-coverage`
+- 상태: `Done` ([PR #224](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/224))
+- 기준선: 백엔드 poll 주기는 News API headline 4시간·Everything 1일·RSS 6시간으로 정해져 있지만 외부 source의 실제 갱신 시점과 신규 기사 수는 보장할 수 없다. 기존 로그는 응답·invalid·중복·저장 수만 제공해 Perspectives 결과 부족이 데이터 부재인지 매칭 실패인지 구분하기 어려웠다.
+- 결과: News API·RSS batch 로그에 source·country·language·category, 응답·invalid·중복·저장 수, 최초·최신 발행 시각과 freshness를 추가하고 기존 DB 분포를 확인하는 read-only SQL을 남겼다.
+- overengineering 판단: 기존 컬럼·로그·fixture를 활용하고 신규 schema·수집 이력 테이블·Prometheus/APM은 추가하지 않았다. 실제 News API/RSS·번역 API 호출, 영어 번역 저장, ranking·retry·Kafka 변경도 제외했다.
+- 검증: fixture별 응답 4·invalid 1·중복 2·저장 1과 발행 시각 09:00~11:00 UTC를 확인했고 MySQL·Redis Testcontainers 포함 전체 71개 테스트와 Backend CI가 통과했다. 실행 중인 compose DB가 없어 실데이터 분포 수치는 주장하지 않았으며 AI Reviewer는 Blocking 없음·MERGE_READY로 판정했다.
+- 작업 문서: `docs/backend-improvement/collection-freshness-coverage-baseline.md`
+- 재현 SQL: `docs/backend-improvement/sql/collection-coverage-snapshot.sql`
 
 ### #221 - 익명 채팅 Redis 동시 요청 데이터 유실 방지 및 회귀 검증
 

--- a/docs/backend-improvement/collection-freshness-coverage-baseline.md
+++ b/docs/backend-improvement/collection-freshness-coverage-baseline.md
@@ -1,0 +1,75 @@
+# Collection Freshness And Coverage Baseline
+
+## Purpose
+
+This baseline separates two causes of weak Perspectives results:
+
+- the related article was not collected from the configured upstream sources
+- the article exists locally, but query translation, tokenization, or matching did not find it
+
+It adds measurement to the existing collection path. It does not translate or backfill articles and does not change collection frequency.
+
+## Known Boundary
+
+The backend polls News API headlines every four hours, News API Everything once a day, and RSS every six hours when `news-fetch.enabled=true`. These schedules control when this application asks for data; they do not guarantee when an upstream source publishes, refreshes, or exposes an article.
+
+Real upstream calls remain disabled by default. Unit tests use News API DTO and RSS XML fixtures, so CI does not consume API quota or depend on external source availability.
+
+## Batch Statistics
+
+Each processed News API or RSS batch emits one structured collection log containing:
+
+| Field | Meaning |
+| --- | --- |
+| `provider` | `news-api` or `rss` |
+| `source` / `sourceCount` | RSS source name or distinct News API source count |
+| `country`, `language`, `category` | configured collection dimensions |
+| `response` | articles or RSS items received |
+| `invalid` | items rejected before duplicate checks |
+| `duplicate` | duplicate URL in the response or already present in the DB |
+| `saved` | new articles passed to persistence |
+| `oldestPublishedAt`, `latestPublishedAt` | valid publication-time range in the response |
+| `freshnessSeconds` | observation time minus the latest valid publication time |
+
+`freshnessSeconds` is a source-response observation, not API latency. A negative value is retained because it exposes a future timestamp or clock/timezone anomaly instead of hiding it.
+
+## Database Snapshot
+
+Run [`sql/collection-coverage-snapshot.sql`](sql/collection-coverage-snapshot.sql) against the existing MySQL database. It reports:
+
+- total article count and publication-time range
+- source-level counts and latest article age
+- country, language, and category distribution
+- country/language counts collected during the last 24 hours, 7 days, and 30 days
+
+The database stores `published_at` as a timezone-less `DATETIME`. The snapshot consistently compares it with `UTC_TIMESTAMP()` according to the application's existing UTC convention. Per-batch logs use the upstream offset as an `Instant` and are the more reliable freshness observation.
+
+## Interpretation
+
+| Observation | Primary follow-up |
+| --- | --- |
+| Relevant article is absent from the DB | inspect source coverage, feed selection, and collection timing |
+| Relevant article exists but matching returns zero | inspect query language, translation, tokenization, and matching |
+| One country/language has little or stale data | treat cross-country result quality as coverage-limited |
+| Batch response is fresh but `saved=0` with high duplicates | current poll may be healthy without new upstream content |
+| Batch response itself is stale | inspect upstream refresh behavior before changing ranking |
+
+Counts alone do not prove that a specific world event is covered. A future matching-quality snapshot should pair this distribution with representative article IDs and returned titles.
+
+## Fixture Verification
+
+News API and RSS fixtures each process four inputs: one new item, one same-response duplicate, one DB-existing item, and one invalid item. The expected result is:
+
+- response: 4
+- invalid: 1
+- duplicate: 2
+- saved: 1
+- valid publication range: `2026-07-15T09:00:00Z` through `2026-07-15T11:00:00Z`
+
+`CollectionBatchStats` also verifies that freshness is calculated from the latest valid publication time and remains absent when a batch has no valid publication time.
+
+All 71 Gradle tests passed with MySQL and Redis Testcontainers. No compose database was running during this measurement, so this issue does not claim a current production-like article distribution. The SQL is retained as the repeatable read-only snapshot for a populated local database.
+
+## Deferred Decisions
+
+Ingestion-time English normalization is not introduced by this issue. Translating every article would add external-call cost, ingestion latency, backfill work, failure handling, and schema decisions before the actual coverage gap is measured. If snapshots later show that collected non-English articles exist but are repeatedly missed, selective asynchronous title/keyword normalization can be evaluated with that evidence.

--- a/docs/backend-improvement/sql/collection-coverage-snapshot.sql
+++ b/docs/backend-improvement/sql/collection-coverage-snapshot.sql
@@ -1,0 +1,45 @@
+-- Read-only snapshot for Issue #223.
+-- published_at is stored as a timezone-less DATETIME. The application treats it
+-- as UTC, so UTC_TIMESTAMP() is used consistently for this diagnostic snapshot.
+
+SELECT
+    COUNT(*) AS article_count,
+    MIN(published_at) AS oldest_published_at,
+    MAX(published_at) AS latest_published_at,
+    TIMESTAMPDIFF(SECOND, MAX(published_at), UTC_TIMESTAMP()) AS latest_age_seconds
+FROM article;
+
+SELECT
+    COALESCE(s.source_name, '(no source)') AS source_name,
+    COUNT(*) AS article_count,
+    MIN(a.published_at) AS oldest_published_at,
+    MAX(a.published_at) AS latest_published_at,
+    TIMESTAMPDIFF(SECOND, MAX(a.published_at), UTC_TIMESTAMP()) AS latest_age_seconds
+FROM article a
+LEFT JOIN source s ON s.source_id = a.source_id
+GROUP BY s.source_id, s.source_name
+ORDER BY article_count DESC, source_name;
+
+SELECT
+    country,
+    language,
+    category,
+    COUNT(*) AS article_count,
+    MIN(published_at) AS oldest_published_at,
+    MAX(published_at) AS latest_published_at,
+    TIMESTAMPDIFF(SECOND, MAX(published_at), UTC_TIMESTAMP()) AS latest_age_seconds
+FROM article
+GROUP BY country, language, category
+ORDER BY article_count DESC, country, language, category;
+
+SELECT
+    country,
+    language,
+    COUNT(*) AS article_count,
+    SUM(published_at >= UTC_TIMESTAMP() - INTERVAL 24 HOUR) AS articles_last_24h,
+    SUM(published_at >= UTC_TIMESTAMP() - INTERVAL 7 DAY) AS articles_last_7d,
+    SUM(published_at >= UTC_TIMESTAMP() - INTERVAL 30 DAY) AS articles_last_30d,
+    MAX(published_at) AS latest_published_at
+FROM article
+GROUP BY country, language
+ORDER BY article_count DESC, country, language;

--- a/src/main/java/com/example/globalTimes_be/externalApi/service/CollectionBatchStats.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/service/CollectionBatchStats.java
@@ -1,0 +1,33 @@
+package com.example.globalTimes_be.externalApi.service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Comparator;
+
+public record CollectionBatchStats(
+        int receivedCount,
+        int invalidCount,
+        int duplicateCount,
+        int savedCount,
+        Instant oldestPublishedAt,
+        Instant latestPublishedAt
+) {
+
+    public static CollectionBatchStats from(
+            int receivedCount,
+            int invalidCount,
+            int duplicateCount,
+            int savedCount,
+            Collection<Instant> publishedAtValues
+    ) {
+        Instant oldest = publishedAtValues.stream().min(Comparator.naturalOrder()).orElse(null);
+        Instant latest = publishedAtValues.stream().max(Comparator.naturalOrder()).orElse(null);
+        return new CollectionBatchStats(
+                receivedCount, invalidCount, duplicateCount, savedCount, oldest, latest);
+    }
+
+    public Long freshnessSeconds(Instant observedAt) {
+        return latestPublishedAt == null ? null : Duration.between(latestPublishedAt, observedAt).getSeconds();
+    }
+}

--- a/src/main/java/com/example/globalTimes_be/externalApi/service/NewsApiService.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/service/NewsApiService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -201,8 +202,14 @@ public class NewsApiService {
     }
 
     int processArticles(List<NewsApiArticleDto> articles, String country, String category) {
+        return processArticlesWithStats(articles, country, category).savedCount();
+    }
+
+    CollectionBatchStats processArticlesWithStats(
+            List<NewsApiArticleDto> articles, String country, String category) {
         Set<String> seenUrls = new HashSet<>();
         List<NewsApiArticleDto> uniqueValidArticles = new ArrayList<>();
+        List<Instant> validPublishedAtValues = new ArrayList<>();
         int invalidCount = 0;
         int duplicateCount = 0;
 
@@ -211,6 +218,7 @@ public class NewsApiService {
                 invalidCount++;
                 continue;
             }
+            validPublishedAtValues.add(OffsetDateTime.parse(article.getPublishedAt()).toInstant());
             if (!seenUrls.add(article.getUrl())) {
                 duplicateCount++;
                 continue;
@@ -247,9 +255,18 @@ public class NewsApiService {
             totalNewArticles += articleList.size();
         }
 
-        log.info("[수집 통계] {}/{} | 응답:{}, invalid:{}, 중복:{}, 저장:{}",
-                country, category, articles.size(), invalidCount, duplicateCount, articleList.size());
-        return articleList.size();
+        CollectionBatchStats stats = CollectionBatchStats.from(
+                articles.size(), invalidCount, duplicateCount, articleList.size(), validPublishedAtValues);
+        long sourceCount = uniqueValidArticles.stream()
+                .map(NewsApiArticleDto::getSource)
+                .map(NewsApiSourceDto::getName)
+                .distinct()
+                .count();
+        log.info("[수집 통계] provider=news-api sourceCount={} country={} language=en category={} response={} invalid={} duplicate={} saved={} oldestPublishedAt={} latestPublishedAt={} freshnessSeconds={}",
+                sourceCount, country, category, stats.receivedCount(), stats.invalidCount(),
+                stats.duplicateCount(), stats.savedCount(), stats.oldestPublishedAt(), stats.latestPublishedAt(),
+                stats.freshnessSeconds(Instant.now()));
+        return stats;
     }
 
     private boolean isInvalid(NewsApiArticleDto dto) {

--- a/src/main/java/com/example/globalTimes_be/externalApi/service/RssNewsService.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/service/RssNewsService.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -106,6 +107,10 @@ public class RssNewsService {
     }
 
     int processItems(RssFeedConfig.FeedSource feed, Elements items) {
+        return processItemsWithStats(feed, items).savedCount();
+    }
+
+    CollectionBatchStats processItemsWithStats(RssFeedConfig.FeedSource feed, Elements items) {
         try {
             List<String> urls = items.stream()
                     .map(item -> item.select("link").text().trim())
@@ -118,9 +123,12 @@ public class RssNewsService {
 
             // feed.sourceName()은 하드코딩된 RSS 피드 설정값이므로 null/empty 가능성 없음
             Source source = sourceService.getOrCreateSource(feed.sourceName(), null);
-            if (source == null) return 0;
+            if (source == null) {
+                return CollectionBatchStats.from(items.size(), items.size(), 0, 0, List.of());
+            }
 
             List<Article> toSave = new ArrayList<>();
+            List<Instant> validPublishedAtValues = new ArrayList<>();
             Set<String> seenUrls = new HashSet<>();
             int invalidCount = 0;
             int duplicateCount = 0;
@@ -141,11 +149,12 @@ public class RssNewsService {
                 }
 
                 // 날짜 파싱
-                LocalDateTime publishedAt = parseRssDate(pubDateStr);
+                ParsedRssDate publishedAt = parseRssDate(pubDateStr);
                 if (publishedAt == null) {
                     invalidCount++;
                     continue;
                 }
+                validPublishedAtValues.add(publishedAt.instant());
 
                 // 중복 체크
                 if (!seenUrls.add(url) || existingUrls.contains(url)) {
@@ -159,7 +168,7 @@ public class RssNewsService {
 
                 Article article = Article.createRssArticle(
                         source, author, title, description, null,
-                        url, urlToImage, publishedAt,
+                        url, urlToImage, publishedAt.localDateTime(),
                         feed.country(), feed.category(), feed.language()
                 );
                 toSave.add(article);
@@ -169,26 +178,34 @@ public class RssNewsService {
                 articleRepository.saveAll(toSave);
             }
 
-            log.info("[수집 통계] {} | 응답:{}, invalid:{}, 중복:{}, 저장:{}",
-                    feed.sourceName(), items.size(), invalidCount, duplicateCount, toSave.size());
+            CollectionBatchStats stats = CollectionBatchStats.from(
+                    items.size(), invalidCount, duplicateCount, toSave.size(), validPublishedAtValues);
+            log.info("[수집 통계] provider=rss source={} country={} language={} category={} response={} invalid={} duplicate={} saved={} oldestPublishedAt={} latestPublishedAt={} freshnessSeconds={}",
+                    feed.sourceName(), feed.country(), feed.language(), feed.category(), stats.receivedCount(),
+                    stats.invalidCount(), stats.duplicateCount(), stats.savedCount(), stats.oldestPublishedAt(),
+                    stats.latestPublishedAt(), stats.freshnessSeconds(Instant.now()));
 
-            return toSave.size();
+            return stats;
 
         } catch (Exception e) {
             log.error("[RSS 수집 처리 오류] {} 처리 중 오류 발생", feed.sourceName(), e);
-            return 0;
+            return CollectionBatchStats.from(items.size(), items.size(), 0, 0, List.of());
         }
     }
 
-    private LocalDateTime parseRssDate(String pubDateStr) {
+    private ParsedRssDate parseRssDate(String pubDateStr) {
         for (DateTimeFormatter formatter : DATE_FORMATTERS) {
             try {
-                return ZonedDateTime.parse(pubDateStr, formatter).toLocalDateTime();
+                ZonedDateTime parsed = ZonedDateTime.parse(pubDateStr, formatter);
+                return new ParsedRssDate(parsed.toLocalDateTime(), parsed.toInstant());
             } catch (DateTimeParseException ignored) {
             }
         }
         log.warn("[RSS 날짜 파싱 실패] pubDate: {}", pubDateStr);
         return null;
+    }
+
+    private record ParsedRssDate(LocalDateTime localDateTime, Instant instant) {
     }
 
     private String extractAuthor(Element item) {

--- a/src/test/java/com/example/globalTimes_be/externalApi/service/CollectionBatchStatsTest.java
+++ b/src/test/java/com/example/globalTimes_be/externalApi/service/CollectionBatchStatsTest.java
@@ -1,0 +1,29 @@
+package com.example.globalTimes_be.externalApi.service;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CollectionBatchStatsTest {
+
+    @Test
+    void freshnessSeconds_usesLatestPublicationTime() {
+        CollectionBatchStats stats = CollectionBatchStats.from(
+                2, 0, 0, 2,
+                List.of(Instant.parse("2026-07-15T09:00:00Z"), Instant.parse("2026-07-15T11:00:00Z")));
+
+        assertThat(stats.freshnessSeconds(Instant.parse("2026-07-15T11:05:00Z"))).isEqualTo(300L);
+    }
+
+    @Test
+    void freshnessSeconds_isNullWhenBatchHasNoValidPublicationTime() {
+        CollectionBatchStats stats = CollectionBatchStats.from(1, 1, 0, 0, List.of());
+
+        assertThat(stats.oldestPublishedAt()).isNull();
+        assertThat(stats.latestPublishedAt()).isNull();
+        assertThat(stats.freshnessSeconds(Instant.parse("2026-07-15T11:05:00Z"))).isNull();
+    }
+}

--- a/src/test/java/com/example/globalTimes_be/externalApi/service/NewsApiServiceTest.java
+++ b/src/test/java/com/example/globalTimes_be/externalApi/service/NewsApiServiceTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -76,6 +77,32 @@ class NewsApiServiceTest {
     }
 
     @Test
+    void processArticlesWithStats_reportsCountsAndPublicationRange() {
+        Source source = Source.createSource("Test Source", null);
+        NewsApiArticleDto newArticle = article(
+                "https://news.example/new", "new", "2026-07-15T10:00:00Z");
+        NewsApiArticleDto repeated = article(
+                "https://news.example/new", "repeated", "2026-07-15T11:00:00Z");
+        NewsApiArticleDto existing = article(
+                "https://news.example/existing", "existing", "2026-07-15T09:00:00Z");
+        NewsApiArticleDto invalid = article("", "invalid", "2026-07-15T12:00:00Z");
+        when(articleRepository.findExistingUrls(anyList()))
+                .thenReturn(Set.of("https://news.example/existing"));
+        when(sourceService.preloadSources(List.of("Test Source")))
+                .thenReturn(Map.of("Test Source", source));
+
+        CollectionBatchStats stats = service.processArticlesWithStats(
+                List.of(newArticle, repeated, existing, invalid), "us", "general");
+
+        assertThat(stats.receivedCount()).isEqualTo(4);
+        assertThat(stats.invalidCount()).isEqualTo(1);
+        assertThat(stats.duplicateCount()).isEqualTo(2);
+        assertThat(stats.savedCount()).isEqualTo(1);
+        assertThat(stats.oldestPublishedAt()).isEqualTo(Instant.parse("2026-07-15T09:00:00Z"));
+        assertThat(stats.latestPublishedAt()).isEqualTo(Instant.parse("2026-07-15T11:00:00Z"));
+    }
+
+    @Test
     void collectionEntryPoints_doNothingWhenNewsFetchIsDisabled() {
         ReflectionTestUtils.setField(service, "fetchEnabled", false);
 
@@ -88,6 +115,10 @@ class NewsApiServiceTest {
     }
 
     private NewsApiArticleDto article(String url, String title) {
+        return article(url, title, "2026-07-15T10:00:00Z");
+    }
+
+    private NewsApiArticleDto article(String url, String title, String publishedAt) {
         NewsApiSourceDto source = new NewsApiSourceDto();
         source.setName("Test Source");
 
@@ -98,7 +129,7 @@ class NewsApiServiceTest {
         article.setContent("content");
         article.setUrl(url);
         article.setUrlToImage("https://news.example/image.jpg");
-        article.setPublishedAt("2026-07-15T10:00:00Z");
+        article.setPublishedAt(publishedAt);
         article.setSource(source);
         return article;
     }

--- a/src/test/java/com/example/globalTimes_be/externalApi/service/RssNewsServiceTest.java
+++ b/src/test/java/com/example/globalTimes_be/externalApi/service/RssNewsServiceTest.java
@@ -11,6 +11,7 @@ import org.jsoup.select.Elements;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.StreamSupport;
@@ -70,6 +71,29 @@ class RssNewsServiceTest {
     }
 
     @Test
+    void processItemsWithStats_reportsCountsAndPublicationRange() {
+        Source source = Source.createSource("Test RSS", null);
+        Elements items = items(
+                item("https://news.example/new", "new", "Wed, 15 Jul 2026 10:00:00 GMT"),
+                item("https://news.example/new", "repeated", "Wed, 15 Jul 2026 11:00:00 GMT"),
+                item("https://news.example/existing", "existing", "Wed, 15 Jul 2026 09:00:00 GMT"),
+                item("https://news.example/invalid", "invalid", "not-a-date")
+        );
+        when(articleRepository.findExistingUrls(anyList()))
+                .thenReturn(Set.of("https://news.example/existing"));
+        when(sourceService.getOrCreateSource("Test RSS", null)).thenReturn(source);
+
+        CollectionBatchStats stats = service.processItemsWithStats(feed, items);
+
+        assertThat(stats.receivedCount()).isEqualTo(4);
+        assertThat(stats.invalidCount()).isEqualTo(1);
+        assertThat(stats.duplicateCount()).isEqualTo(2);
+        assertThat(stats.savedCount()).isEqualTo(1);
+        assertThat(stats.oldestPublishedAt()).isEqualTo(Instant.parse("2026-07-15T09:00:00Z"));
+        assertThat(stats.latestPublishedAt()).isEqualTo(Instant.parse("2026-07-15T11:00:00Z"));
+    }
+
+    @Test
     void collectionEntryPoints_doNothingWhenNewsFetchIsDisabled() {
         ReflectionTestUtils.setField(service, "fetchEnabled", false);
 
@@ -85,8 +109,12 @@ class RssNewsServiceTest {
     }
 
     private String item(String url, String title) {
+        return item(url, title, "Wed, 15 Jul 2026 10:00:00 GMT");
+    }
+
+    private String item(String url, String title, String publishedAt) {
         return "<item><link>" + url + "</link><title>" + title + "</title>"
-                + "<pubDate>Wed, 15 Jul 2026 10:00:00 GMT</pubDate>"
+                + "<pubDate>" + publishedAt + "</pubDate>"
                 + "<description>description</description></item>";
     }
 


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #223

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- News API와 RSS 수집 batch에 응답·invalid·중복·저장 수, 발행 시각 범위, freshness 구조화 로그를 추가했습니다.
- source·country·language·category별 DB coverage와 최근 수집 분포를 조회하는 read-only SQL을 추가했습니다.
- 실제 외부 API 호출 없이 DTO/XML fixture로 통계 경계를 고정하고 측정·해석 기준을 문서화했습니다.

## 🔍 기술적 배경
- Perspectives 결과가 부족할 때 관련 기사가 DB에 없는 coverage 문제와, 존재하지만 검색되지 않는 matching 문제를 구분할 근거가 필요했습니다.
- 백엔드 scheduler 주기는 외부 source의 실제 갱신 시점과 기사 제공 범위를 보장하지 않으므로 batch freshness와 DB 분포를 별도로 관측합니다.
- 기사별 영어 번역 저장은 호출 비용·지연·실패 처리·schema 변경 근거가 부족해 이번 범위에서 제외했습니다.

## 🧪 테스트/검증 (필수)
- [x] News API fixture 4건에서 response 4, invalid 1, duplicate 2, saved 1과 09:00~11:00 UTC 범위를 확인했습니다.
- [x] RSS XML fixture에서 동일한 통계와 offset 기반 `Instant` 발행 시각 범위를 확인했습니다.
- [x] 최신 발행 시각 기준 freshness 계산 및 유효 시각이 없는 batch의 null 처리를 확인했습니다.
- [x] MySQL·Redis Testcontainers 포함 `./gradlew test` 전체 71개 테스트가 통과했습니다.
- [x] 실행 중인 compose DB가 없어 실데이터 분포 수치는 주장하지 않고 재현 SQL만 남겼습니다.

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop` 대상)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 기존 수집 저장 결과와 `processArticles`/`processItems` 반환값을 유지했는가?

## 📸 스크린샷 (선택)
- 해당 없음

## 💬 리뷰 요구사항(선택)
- batch 통계에서 invalid·duplicate 집계 경계와 RSS timezone 처리 보존 여부를 확인해주세요.
- 관측 변경이 기존 저장 동작에 영향을 주지 않는지 확인해주세요.

## ➕ 추후 계획(선택)
- populated local DB가 준비되면 read-only snapshot을 실행해 실제 source·country·language 분포를 기록합니다.
- 수집된 비영어 기사가 존재하지만 반복적으로 매칭되지 않는 근거가 쌓일 때 선택적 비동기 영어 title/keyword 정규화를 검토합니다.
