### PR TITLE
🧪 [TEST/#225] Perspectives 다국어 FULLTEXT 경로 회귀 검증

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -11,6 +11,15 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## Recently Completed
 
+### P1. Perspectives 다국어 번역·FULLTEXT 경로 원인 분리 회귀 검증
+
+- 상태: `Done` ([#225](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/225), [PR #226](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/226))
+- AS-IS: 번역 실패 fallback은 mock 단위 테스트만 있고 비영어 기사에서 번역·원문 키워드가 실제 MySQL FULLTEXT를 거쳐 병합되는 경로는 자동 검증되지 않았다.
+- TO-BE: 통제된 fixture에서 관련 데이터 존재 여부와 mock 번역 결과를 분리해 coverage 부재·matching 실패·fallback·중복 제거 조건을 실제 MySQL로 검증했다.
+- 범위: 테스트와 검증 문서로 제한했고 운영 코드·schema·API·ranking·번역 저장, 실제 외부 API·compose DB, 신규 검색 기술은 제외했다.
+- 검증: MySQL FULLTEXT 기반 5개 통제 시나리오와 전체 76개 테스트 및 Backend CI가 통과했고 AI Reviewer는 Blocking 없음·MERGE_READY로 판정했다. 실제 번역 품질·source coverage·semantic similarity 개선은 주장하지 않는다.
+- 근거: `docs/backend-improvement/perspectives-multilingual-fulltext-integration.md`
+
 ### P1. RSS·News API source별 freshness·coverage 기준선 및 수집 통계 보강
 
 - 상태: `Done` ([#223](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/223), [PR #224](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/224))

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -9,6 +9,11 @@
 
 ## Recently Completed
 
+- #225 / PR #226: `Done`
+- Result: controlled MySQL fixtures now verify translated search, absent-data and wrong-translation zero-result conditions, original-keyword fallback, and translated/original result deduplication
+- Validation: five focused scenarios, all 76 tests, and Backend CI passed; the AI Reviewer reported no Blocking and MERGE_READY
+- Boundary: backend orchestration only; no claim about real translation quality, source coverage, semantic similarity, production code, schema, API, ranking, translation persistence, real external API, compose DB, new search technology, or Issue #110
+
 - #223 / PR #224: `Done`
 - Result: News API/RSS batch logs now expose source dimensions, received/invalid/duplicate/saved counts, publication range, and freshness; a read-only SQL snapshot separates local coverage gaps from matching failures
 - Validation: fixtures report 4 received, 1 invalid, 2 duplicate, 1 saved, and the 09:00-11:00 UTC range; all 71 tests and Backend CI passed, and the AI Reviewer reported no Blocking and MERGE_READY

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -9,6 +9,17 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Recently Completed
 
+### #225 - Perspectives 다국어 번역·FULLTEXT 경로 원인 분리 회귀 검증
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/225
+- 작업 브랜치: `test/#225-perspectives-multilingual-fulltext`
+- 상태: `Done` ([PR #226](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/226))
+- 기준선: 기존 `PerspectivesServiceTest`는 번역 실패 fallback을 mock repository로만 확인하며, 비영어 기준 기사에서 mock 번역·실제 MySQL FULLTEXT·원문 검색·결과 병합까지 이어지는 성공 경로는 자동 검증하지 않았다.
+- 결과: 통제된 Testcontainers fixture에서 관련 기사 존재 여부와 mock 번역 결과만 바꿔 coverage 부재와 번역·matching 실패 조건을 분리하고, fallback·결과 병합·중복 제거·국가별 응답 회귀를 고정했다.
+- overengineering 판단: 기존 MySQL Testcontainers·Flyway·Mockito를 재사용하고 운영 코드·schema·API·ranking·번역 저장은 변경하지 않았다. 실제 Google Translation API, News API/RSS, compose DB, Elasticsearch·Vector DB·Kafka도 사용하지 않았다.
+- 검증: 5개 통제 시나리오에서 번역 성공 1건 반환, coverage 부재 0건, 오역 0건, 번역 실패 원문 fallback 1건, 번역·원문 중복 최종 1건을 확인했다. 전체 76개 테스트와 Backend CI가 통과했고 AI Reviewer는 Blocking 없음·MERGE_READY로 판정했다. 실제 유사도 정확성이나 외부 번역 품질 개선은 주장하지 않는다.
+- 검증 문서: `docs/backend-improvement/perspectives-multilingual-fulltext-integration.md`
+
 ### #223 - RSS·News API source별 freshness·coverage 기준선 및 수집 통계 보강
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/223

--- a/docs/backend-improvement/perspectives-multilingual-fulltext-integration.md
+++ b/docs/backend-improvement/perspectives-multilingual-fulltext-integration.md
@@ -1,0 +1,70 @@
+# Perspectives Multilingual FULLTEXT Integration
+
+## Purpose
+
+This verification fixes the backend behavior of the controlled non-English Perspectives search path:
+
+```text
+non-English base article
+-> keyword extraction
+-> mocked English translation
+-> real MySQL FULLTEXT search
+-> optional original-keyword search
+-> deduplication and country grouping
+```
+
+It does not measure semantic similarity or improve matching quality. Its purpose is to distinguish deterministic backend-path failures from conditions where a related article is absent or the supplied translation keyword is wrong.
+
+## Test Boundary
+
+| Component | Test behavior |
+| --- | --- |
+| `PerspectivesService` | Real service implementation |
+| `KeywordExtractor` | Real keyword extraction |
+| `ArticleRepository.findPerspectives` | Real native query |
+| Database | MySQL 8 Testcontainers with Flyway FULLTEXT schema |
+| Translation | Mockito-controlled result or exception |
+| Redis | Cache TTL set to zero; no read or write |
+| Article data | Test-only Source and Article fixtures |
+
+The test does not call Google Translation, News API, RSS, the compose database, or any deployed service.
+
+## Controlled Scenarios
+
+| Scenario | Related row in MySQL | Translation condition | Expected result |
+| --- | --- | --- | --- |
+| translated success | present | `Lunaris Summit Joint Statement` | English related article returned |
+| source coverage absence | absent | same correct translation | zero articles |
+| wrong translation | present | `Football Transfer Market Opens` | zero articles |
+| translation failure | French related row present | translation exception | original French FULLTEXT result returned |
+| translated/original overlap | one row matches both keyword sets | valid translated keyword | one final article, not two |
+
+The absence and wrong-translation scenarios intentionally produce the same zero-result response under different controlled inputs. This shows why a real zero-result response cannot be assigned to FULLTEXT, translation, or source coverage without additional evidence.
+
+## Fixture Interpretation
+
+The fixture text is written to make each expected FULLTEXT boundary deterministic. It is not a sample of real editorial content and is not evidence that the same query will find semantically related articles in the collected dataset.
+
+The French fallback fixture uses whitespace-separated Latin tokens so the test focuses on fallback orchestration rather than introducing Korean tokenizer behavior into the same assertion.
+
+Fixtures are committed before the service query runs. The service call runs in a transaction so the native query and lazy `Source` access use the real persistence path.
+
+## Claims And Non-Claims
+
+This verification supports the following claims:
+
+- non-English inputs request translation
+- a supplied translated keyword reaches MySQL BOOLEAN MODE FULLTEXT
+- translation failure retains the original-keyword fallback
+- translated and original query results are merged without duplicate article IDs
+- country grouping and total counts reflect the merged result
+
+It does not support these claims:
+
+- Google Translation produces an accurate keyword
+- configured RSS or News API sources contain the related event
+- returned articles describe the same real-world event
+- multilingual recall, precision, or semantic similarity improved
+- Elasticsearch, embeddings, Vector DB, or translation persistence is required
+
+Real matching quality requires a separately labeled sample containing expected related article IDs. Source freshness and local coverage must also be recorded before interpreting missing results.

--- a/src/test/java/com/example/globalTimes_be/domain/detail/service/PerspectivesMultilingualIntegrationTest.java
+++ b/src/test/java/com/example/globalTimes_be/domain/detail/service/PerspectivesMultilingualIntegrationTest.java
@@ -1,0 +1,227 @@
+package com.example.globalTimes_be.domain.detail.service;
+
+import com.example.globalTimes_be.domain.article.entity.Article;
+import com.example.globalTimes_be.domain.article.repository.ArticleRepository;
+import com.example.globalTimes_be.domain.detail.dto.response.PerspectiveArticleDTO;
+import com.example.globalTimes_be.domain.detail.dto.response.PerspectivesResDTO;
+import com.example.globalTimes_be.domain.search.service.TranslationService;
+import com.example.globalTimes_be.domain.source.entity.Source;
+import com.example.globalTimes_be.domain.source.repository.SourceRepository;
+import com.example.globalTimes_be.global.redis.RedisUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class PerspectivesMultilingualIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
+            .withUsername("root")
+            .withPassword("test");
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private SourceRepository sourceRepository;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    private TranslationService translationService;
+    private RedisUtil redisUtil;
+    private PerspectivesService perspectivesService;
+    private TransactionTemplate transactionTemplate;
+
+    @BeforeEach
+    void setUp() {
+        translationService = mock(TranslationService.class);
+        redisUtil = mock(RedisUtil.class);
+        perspectivesService = new PerspectivesService(
+                articleRepository,
+                translationService,
+                redisUtil,
+                new ObjectMapper().findAndRegisterModules()
+        );
+        ReflectionTestUtils.setField(perspectivesService, "cacheTtlSeconds", 0L);
+        transactionTemplate = new TransactionTemplate(transactionManager);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        transactionTemplate.executeWithoutResult(status -> {
+            articleRepository.deleteAll();
+            sourceRepository.deleteAll();
+        });
+    }
+
+    @Test
+    void translatedKeywordFindsStoredEnglishArticle() {
+        Fixture fixture = persistFixture(
+                article("kr", "ko", "루나리스 정상회담 공동성명 발표"),
+                article("us", "en", "Lunaris Summit leaders release joint statement"),
+                article("gb", "en", "European football transfer market opens")
+        );
+        when(translationService.translateToEnglish("루나리스 정상회담 공동성명"))
+                .thenReturn("Lunaris Summit Joint Statement");
+
+        PerspectivesResDTO response = getPerspectives(fixture.baseArticleId());
+
+        assertThat(articleIds(response)).containsExactly(fixture.relatedArticleId());
+        assertThat(response.getPerspectives()).containsOnlyKeys("us");
+        assertThat(response.getCountriesFound()).isEqualTo(1);
+        assertThat(response.getTotalArticles()).isEqualTo(1);
+        verify(translationService).translateToEnglish("루나리스 정상회담 공동성명");
+        verifyNoInteractions(redisUtil);
+    }
+
+    @Test
+    void exactTranslationReturnsNoResultWhenRelatedArticleIsAbsent() {
+        Fixture fixture = persistFixture(
+                article("kr", "ko", "루나리스 정상회담 공동성명 발표"),
+                null,
+                article("gb", "en", "European football transfer market opens")
+        );
+        when(translationService.translateToEnglish("루나리스 정상회담 공동성명"))
+                .thenReturn("Lunaris Summit Joint Statement");
+
+        PerspectivesResDTO response = getPerspectives(fixture.baseArticleId());
+
+        assertThat(articleIds(response)).isEmpty();
+        assertThat(response.getCountriesFound()).isZero();
+        assertThat(response.getTotalArticles()).isZero();
+    }
+
+    @Test
+    void wrongTranslationReturnsNoResultEvenWhenRelatedArticleExists() {
+        Fixture fixture = persistFixture(
+                article("kr", "ko", "루나리스 정상회담 공동성명 발표"),
+                article("us", "en", "Lunaris Summit leaders release joint statement"),
+                null
+        );
+        when(translationService.translateToEnglish("루나리스 정상회담 공동성명"))
+                .thenReturn("Football Transfer Market Opens");
+
+        PerspectivesResDTO response = getPerspectives(fixture.baseArticleId());
+
+        assertThat(articleIds(response)).isEmpty();
+        assertThat(response.getCountriesFound()).isZero();
+        assertThat(response.getTotalArticles()).isZero();
+    }
+
+    @Test
+    void translationFailureFallsBackToOriginalFullTextKeyword() {
+        Fixture fixture = persistFixture(
+                article("fr", "fr", "Sommet Lunaris declaration commune"),
+                article("fr", "fr", "Le Sommet Lunaris publie une declaration commune"),
+                null
+        );
+        doThrow(new RuntimeException("translation timeout"))
+                .when(translationService)
+                .translateToEnglish("Sommet Lunaris declaration commune");
+
+        PerspectivesResDTO response = getPerspectives(fixture.baseArticleId());
+
+        assertThat(articleIds(response)).containsExactly(fixture.relatedArticleId());
+        assertThat(response.getPerspectives()).containsOnlyKeys("fr");
+        assertThat(response.getCountriesFound()).isEqualTo(1);
+        assertThat(response.getTotalArticles()).isEqualTo(1);
+    }
+
+    @Test
+    void translatedAndOriginalSearchesDoNotDuplicateSameArticle() {
+        Fixture fixture = persistFixture(
+                article("fr", "fr", "Sommet Lunaris declaration commune"),
+                article("ca", "fr", "Lunaris Summit covers Sommet Lunaris declaration"),
+                null
+        );
+        when(translationService.translateToEnglish("Sommet Lunaris declaration commune"))
+                .thenReturn("Lunaris Summit Joint Statement");
+
+        PerspectivesResDTO response = getPerspectives(fixture.baseArticleId());
+
+        assertThat(articleIds(response)).containsExactly(fixture.relatedArticleId());
+        assertThat(response.getPerspectives()).containsOnlyKeys("ca");
+        assertThat(response.getTotalArticles()).isEqualTo(1);
+    }
+
+    private PerspectivesResDTO getPerspectives(Long articleId) {
+        return transactionTemplate.execute(status -> perspectivesService.getPerspectives(articleId));
+    }
+
+    private Fixture persistFixture(Article base, Article related, Article unrelated) {
+        return transactionTemplate.execute(status -> {
+            Article savedBase = saveWithSource(base);
+            Article savedRelated = related == null ? null : saveWithSource(related);
+            if (unrelated != null) {
+                saveWithSource(unrelated);
+            }
+            articleRepository.flush();
+            return new Fixture(
+                    savedBase.getId(),
+                    savedRelated == null ? null : savedRelated.getId()
+            );
+        });
+    }
+
+    private Article saveWithSource(Article article) {
+        Source source = sourceRepository.save(article.getSource());
+        ReflectionTestUtils.setField(article, "source", source);
+        return articleRepository.save(article);
+    }
+
+    private Article article(String country, String language, String title) {
+        Source source = Source.createSource("Source " + country + " " + title, null);
+        return Article.createRssArticle(
+                source,
+                "Reporter",
+                title,
+                "Description " + title,
+                "Content " + title,
+                "https://news.example/" + country + "/" + Integer.toUnsignedString(title.hashCode()),
+                "https://image.example/" + country + ".jpg",
+                LocalDateTime.of(2026, 7, 24, 12, 0),
+                country,
+                "general",
+                language
+        );
+    }
+
+    private List<Long> articleIds(PerspectivesResDTO response) {
+        return response.getPerspectives().values().stream()
+                .flatMap(List::stream)
+                .map(PerspectiveArticleDTO::getId)
+                .toList();
+    }
+
+    private record Fixture(Long baseArticleId, Long relatedArticleId) {
+    }
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #225

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- 비영어 Perspectives cache-miss 경로를 실제 MySQL FULLTEXT까지 연결하는 Testcontainers 통합 테스트를 추가했습니다.
- mock 번역 결과와 관련 기사 존재 여부만 바꿔 정상 번역·coverage 부재·오역·번역 실패 fallback·결과 중복 제거를 검증했습니다.
- 실제 유사도·번역 품질·source coverage를 보장하지 않는 테스트 경계를 문서화했습니다.

## 🔍 기술적 배경
- 기존 단위 테스트는 번역 실패 fallback을 mock repository로 확인하지만, 번역 및 원문 키워드가 실제 `ArticleRepository.findPerspectives`를 거쳐 병합되는 성공 경로는 검증하지 않았습니다.
- 현실 데이터의 0건은 source coverage와 번역·matching 실패가 섞일 수 있으므로, 통제된 fixture에서 조건 하나씩 바꿔 백엔드 흐름을 분리했습니다.

## 🧪 테스트/검증 (필수)
- [x] 정확한 mock 번역과 영어 관련 기사 조건에서 관련 기사 1건 반환
- [x] 정확한 번역이지만 관련 기사가 없는 coverage 조건에서 0건
- [x] 관련 기사는 있지만 의도적으로 잘못된 번역 조건에서 0건
- [x] 번역 예외 시 프랑스어 원문 FULLTEXT fallback으로 관련 기사 1건 반환
- [x] 번역·원문 검색에 모두 매칭되는 동일 기사가 최종 응답에 1회만 포함
- [x] MySQL·Redis Testcontainers 포함 `./gradlew test` 전체 76개 테스트 통과

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop` 대상)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 운영 코드·DB schema·API 응답을 변경하지 않았는가?

## 📸 스크린샷 (선택)
- 해당 없음

## 💬 리뷰 요구사항(선택)
- fixture가 coverage 부재와 잘못된 번역 조건을 실제로 분리하는지 확인해주세요.
- mock 번역 외에는 실제 MySQL FULLTEXT 경로를 사용하며 중복 제거 assertion이 유효한지 확인해주세요.
- 실제 유사도 품질을 개선하거나 보장한다고 과장한 표현이 없는지 확인해주세요.

## ➕ 추후 계획(선택)
- 실제 품질 평가는 기대 관련 기사 ID가 표시된 별도 정답 표본과 source freshness·coverage 근거가 준비된 뒤 수행합니다.
- 표본 실패가 반복되기 전에는 번역 저장, Elasticsearch, Vector DB 같은 확장을 도입하지 않습니다.
