### PR TITLE
🐛 [FIX/#229] 스크랩 토글 동시 요청 정합성 보강

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -11,6 +11,15 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## Recently Completed
 
+### P1. 스크랩 토글 동시 요청 직렬화 및 정합성 보강
+
+- 상태: `Done` ([#229](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/229), [PR #230](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/230))
+- AS-IS: 동일 user/article의 동시 POST toggle 20건에서 unique INSERT 경쟁으로 성공 2건·실패 18건이 발생했다.
+- TO-BE: user 행 pessimistic lock으로 기존 toggle 의미를 직렬화해 성공 20건·실패 0건, `true/false` 각 10건, 최종 scrap 0건을 확인했다.
+- 범위: `ScrapService`, `UserRepository`, MySQL Testcontainers와 문서로 제한했다. 멱등 PUT/DELETE API, 프론트 변경, Redis 분산 락·Kafka·queue는 제외했다.
+- 검증: 스크랩 집중 테스트 7개, 전체 80개 테스트, Backend CI 통과, AI Reviewer Blocking 없음·MERGE_READY.
+- 근거: `docs/backend-improvement/scrap-toggle-concurrency.md`
+
 ### P1. Perspectives 실제 DB 정답 표본 Precision@5 기준선
 
 - 상태: `Done` ([#227](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/227), [PR #228](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/228))

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -9,6 +9,12 @@
 
 ## Recently Completed
 
+- #229 / PR #230: `Done`
+- 결과: 동일 user/article 동시 POST toggle 20건의 성공 2·실패 18을 user 행 `PESSIMISTIC_WRITE`로 성공 20·실패 0, `true/false` 각 10건, 최종 scrap 0건으로 개선했다.
+- 잠금·API 경계: 서로 다른 사용자의 같은 기사 요청은 각각 저장되며 POST toggle의 비멱등 의미는 유지했다. PUT/DELETE·프론트 변경·Redis 분산 락·Kafka·queue는 제외했다.
+- 검증: 스크랩 집중 테스트 7개, 전체 80개 테스트, Backend CI 통과, AI Reviewer Blocking 없음·MERGE_READY.
+- 범위: `ScrapService`, `UserRepository`, MySQL Testcontainers와 문서만 변경했으며 Issue #110은 제외했다.
+
 - #227 / PR #228: `Done`
 - 결과: 선행 작업에서 이어받은 실제 DB 고정 표본 6건에서 strict Precision@5 `0.267`, Useful Precision@5 `0.467`, Hit@5 `0.500`, 평균 반환 국가 수 `1.67`을 기록했다.
 - 해석 경계: 전체 9,814건의 정확도가 아니며 8148·8468의 candidate 0건은 coverage 또는 retrieval 원인 미확정으로 유지했다.

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -9,6 +9,19 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Recently Completed
 
+### #229 - 스크랩 토글 동시 요청 직렬화 및 정합성 보강
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/229
+- 작업 브랜치: `fix/#229-scrap-toggle-concurrency`
+- 상태: `Done` ([PR #230](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/230))
+- 기준선: 동일 user/article 동시 POST toggle 20건에서 unique INSERT 경쟁으로 성공 2건·실패 18건이 발생했다.
+- 결과: user 행 `PESSIMISTIC_WRITE`로 동일 사용자의 toggle을 직렬화해 같은 조건에서 성공 20건·실패 0건, `true` 10건·`false` 10건, 최종 scrap 0건을 확인했다.
+- 잠금 경계: 서로 다른 사용자 두 명은 같은 기사를 동시에 추가해 각각 한 행을 유지한다. article 전역 경합은 만들지 않는다.
+- API 경계: POST toggle의 비멱등 `추가 → 취소` 의미를 유지했다. 멱등 `PUT 추가 / DELETE 취소`와 프론트 계약 변경은 제외했다.
+- overengineering 판단: 기존 MySQL row lock과 Testcontainers만 사용했으며 Redis 분산 락·Kafka·queue는 도입하지 않았다.
+- 검증: 스크랩 집중 테스트 7개, 전체 80개 테스트, Backend CI가 통과했고 AI Reviewer는 Blocking 없음·MERGE_READY로 판정했다.
+- 작업 문서: `docs/backend-improvement/scrap-toggle-concurrency.md`
+
 ### #227 - Perspectives 실제 DB 정답 표본 Precision@5 기준선
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/227

--- a/docs/backend-improvement/scrap-toggle-concurrency.md
+++ b/docs/backend-improvement/scrap-toggle-concurrency.md
@@ -1,0 +1,109 @@
+# 스크랩 토글 동시 요청 정합성 개선
+
+## 문제
+
+로그인 사용자의 스크랩 API는 `POST /api/articles/{id}/scrap` 한 번으로 현재 상태를 반전한다.
+
+기존 `ScrapService.toggle()`은 하나의 transaction에서 다음 순서로 동작했다.
+
+```text
+user 조회
+article 조회
+scrap(user_id, article_id) 조회
+있으면 DELETE, 없으면 INSERT
+commit
+```
+
+`scrap(user_id, article_id)`에는 unique 제약이 있어 중복 행은 저장되지 않는다. 그러나 scrap 행이 아직 없을 때 동일 사용자·동일 기사 요청이 겹치면 여러 transaction이 모두 “없음”을 읽은 뒤 INSERT를 시도할 수 있다. unique 제약은 데이터 중복을 막지만 충돌한 API 요청의 성공까지 보장하지 않는다.
+
+## 측정 환경
+
+| 항목 | 값 |
+| --- | --- |
+| DB | MySQL 8 Testcontainers |
+| 대상 | 동일 user ID, 동일 article ID |
+| 초기 상태 | scrap 0건 |
+| 동시 요청 | 20 |
+| 시작 제어 | `CountDownLatch` |
+| transaction | 실제 `ScrapService.toggle()` 호출 |
+
+## 개선 전
+
+동시 요청 20건을 같은 시점에 시작한 결과는 다음과 같았다.
+
+| 지표 | 결과 |
+| --- | ---: |
+| 성공 | 2 |
+| 실패 | 18 |
+| `scrapped=true` | 1 |
+| `scrapped=false` | 1 |
+| 최종 scrap 행 | 0 |
+
+실패 요청은 같은 unique key에 대한 INSERT 경쟁에서 발생했다. 공통 예외 처리에는 해당 충돌을 별도 처리하는 경로가 없어 HTTP 요청에서는 500으로 변환될 수 있다.
+
+최종 행이 0건이라는 사실만으로 정상이라고 볼 수 없다. 순차 toggle 두 번과 같은 최종 상태가 우연히 만들어졌지만 18개 요청은 정상 응답을 받지 못했다.
+
+## 대안 판단
+
+### Scrap 행 잠금
+
+초기 상태에는 잠글 scrap 행이 없으므로 동시 INSERT 경쟁을 막을 수 없다.
+
+### Article 행 잠금
+
+같은 기사를 스크랩하는 모든 사용자가 하나의 article 행에서 대기한다. 인기 기사일수록 사용자 간 불필요한 경합 범위가 커진다.
+
+### User 행 잠금
+
+사용자 행은 스크랩 여부와 관계없이 존재한다. 동일 사용자의 짧은 toggle transaction만 직렬화하고, 서로 다른 사용자는 같은 기사를 동시에 스크랩할 수 있다. DB row lock이므로 단일·다중 애플리케이션 인스턴스에서 같은 MySQL을 사용할 때 동일하게 적용된다.
+
+현재 규모와 API 계약에서는 `PESSIMISTIC_WRITE` user 행 잠금이 가장 작은 변경이다. Redis 분산 락, Kafka, 별도 queue는 필요하지 않다.
+
+## 변경
+
+`UserRepository.findByIdForUpdate()`에 `PESSIMISTIC_WRITE`를 적용하고 `ScrapService.toggle()`이 transaction 시작 후 사용자 행을 먼저 잠그도록 변경했다.
+
+```text
+user SELECT FOR UPDATE
+article 조회
+scrap 조회
+INSERT 또는 DELETE
+commit 후 다음 동일 user 요청 진행
+```
+
+article 행을 잠그지 않으므로 서로 다른 사용자의 같은 기사 요청은 독립적으로 처리된다.
+
+## 개선 후
+
+개선 전과 같은 20건 조건을 실행한 결과다.
+
+| 지표 | 개선 전 | 개선 후 |
+| --- | ---: | ---: |
+| 성공 | 2 | 20 |
+| 실패 | 18 | 0 |
+| `scrapped=true` | 1 | 10 |
+| `scrapped=false` | 1 | 10 |
+| 최종 scrap 행 | 0 | 0 |
+
+20개 요청이 DB에서 순서대로 실행되어 기존 toggle 의미인 `추가 → 취소`를 10회 반복했다. 요청 수가 짝수이므로 최종 행은 0건이며 모든 호출이 정상 완료됐다.
+
+추가 회귀 테스트로 다음을 확인했다.
+
+- 순차 호출은 기존처럼 첫 호출 `true`, 두 번째 호출 `false`를 반환한다.
+- 서로 다른 사용자 두 명은 같은 기사를 동시에 스크랩하고 각각 한 행을 유지한다.
+- 존재하지 않는 사용자와 기사는 기존과 동일한 not-found 예외를 반환한다.
+- 기존 스크랩 목록 projection과 nullable source 동작을 포함한 `ScrapQueryIntegrationTest` 7개가 통과한다.
+- MySQL·Redis Testcontainers를 포함한 전체 80개 테스트가 통과한다.
+
+## API 경계
+
+POST toggle은 호출할 때마다 상태를 반전하므로 본질적으로 멱등하지 않다. 이번 변경은 동시 요청을 순차 실행해 기존 계약대로 처리하며, 중복 요청을 하나의 요청으로 취급하지 않는다.
+
+같은 “스크랩 추가” 요청의 반복에도 최종 상태가 항상 추가되도록 만들려면 `PUT 추가 / DELETE 취소`처럼 의도를 분리한 API와 프론트 계약 변경이 필요하다. 이는 이번 동시성 정합성 수정에 포함하지 않는다.
+
+## 해석 경계
+
+- 이 결과는 MySQL 8 Testcontainers의 동일 사용자·동일 기사 20건 통제 조건이다.
+- 운영 TPS나 사용자 클릭 빈도를 측정한 부하 테스트가 아니다.
+- user 행 잠금은 동일 사용자의 toggle을 직렬화하므로 한 사용자가 비정상적으로 많은 스크랩 요청을 병렬 전송하면 대기 시간이 늘 수 있다.
+- 일반 사용자의 짧은 transaction을 대상으로 하며 lock wait·timeout이 실제 운영 지표에서 나타날 때 별도 조정을 검토한다.

--- a/src/main/java/com/example/globalTimes_be/domain/scrap/service/ScrapService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/scrap/service/ScrapService.java
@@ -54,7 +54,7 @@ public class ScrapService {
     // 스크랩 토글 (추가/취소)
     @Transactional
     public boolean toggle(Long userId, Long articleId) {
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdForUpdate(userId)
                 .orElseThrow(() -> new BaseException(ScrapErrorStatus._SCRAP_USER_NOT_FOUND.getResponse()));
         Article article = articleRepository.findById(articleId)
                 .orElseThrow(() -> new BaseException(ScrapErrorStatus._SCRAP_ARTICLE_NOT_FOUND.getResponse()));

--- a/src/main/java/com/example/globalTimes_be/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/globalTimes_be/domain/user/repository/UserRepository.java
@@ -1,7 +1,11 @@
 package com.example.globalTimes_be.domain.user.repository;
 
 import com.example.globalTimes_be.domain.user.entity.User;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -12,4 +16,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByProviderAndProviderId(String provider, String providerId);
 
     Optional<User> findByEmail(String email);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT user FROM User user WHERE user.id = :userId")
+    Optional<User> findByIdForUpdate(@Param("userId") Long userId);
 }

--- a/src/test/java/com/example/globalTimes_be/domain/scrap/service/ScrapQueryIntegrationTest.java
+++ b/src/test/java/com/example/globalTimes_be/domain/scrap/service/ScrapQueryIntegrationTest.java
@@ -4,6 +4,7 @@ import com.example.globalTimes_be.domain.article.entity.Article;
 import com.example.globalTimes_be.domain.scrap.dto.response.ScrapListResDTO;
 import com.example.globalTimes_be.domain.scrap.dto.response.ScrapResDTO;
 import com.example.globalTimes_be.domain.scrap.entity.Scrap;
+import com.example.globalTimes_be.global.exception.BaseException;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import org.hibernate.SessionFactory;
@@ -31,8 +32,15 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -168,6 +176,130 @@ class ScrapQueryIntegrationTest {
         assertThat(statistics.getPrepareStatementCount()).isEqualTo(1L);
         assertThat(statistics.getEntityLoadCount()).isZero();
         System.out.println("SCRAP_LIST_OPTIMIZED_PLAN type=legacy " + legacyPlan());
+    }
+
+    @Test
+    void concurrentToggleSerializesRequestsForSameUserAndArticle() throws Exception {
+        long articleId = articleIds.get(0);
+        int requestCount = 20;
+        jdbcTemplate.update(
+                "DELETE FROM scrap WHERE user_id = ? AND article_id = ?",
+                userId,
+                articleId
+        );
+
+        ExecutorService executor = Executors.newFixedThreadPool(requestCount);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<Boolean>> toggles = new ArrayList<>();
+
+        try {
+            for (int i = 0; i < requestCount; i++) {
+                toggles.add(executor.submit(() -> {
+                    start.await();
+                    return scrapService.toggle(userId, articleId);
+                }));
+            }
+            start.countDown();
+
+            int successes = 0;
+            int failures = 0;
+            int added = 0;
+            int canceled = 0;
+            for (Future<Boolean> toggle : toggles) {
+                try {
+                    if (toggle.get(30, TimeUnit.SECONDS)) {
+                        added++;
+                    } else {
+                        canceled++;
+                    }
+                    successes++;
+                } catch (ExecutionException e) {
+                    failures++;
+                }
+            }
+
+            Integer finalRows = jdbcTemplate.queryForObject(
+                    "SELECT COUNT(*) FROM scrap WHERE user_id = ? AND article_id = ?",
+                    Integer.class,
+                    userId,
+                    articleId
+            );
+            System.out.printf(
+                    "SCRAP_TOGGLE_IMPROVED requests=%d, successes=%d, failures=%d, " +
+                            "added=%d, canceled=%d, finalRows=%d%n",
+                    requestCount,
+                    successes,
+                    failures,
+                    added,
+                    canceled,
+                    finalRows
+            );
+
+            assertThat(successes).isEqualTo(requestCount);
+            assertThat(failures).isZero();
+            assertThat(added).isEqualTo(requestCount / 2);
+            assertThat(canceled).isEqualTo(requestCount / 2);
+            assertThat(finalRows).isZero();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void sequentialTogglePreservesAddThenCancelBehavior() {
+        long articleId = articleIds.get(0);
+        jdbcTemplate.update(
+                "DELETE FROM scrap WHERE user_id = ? AND article_id = ?",
+                userId,
+                articleId
+        );
+
+        assertThat(scrapService.toggle(userId, articleId)).isTrue();
+        assertThat(scrapCount(userId, articleId)).isEqualTo(1);
+
+        assertThat(scrapService.toggle(userId, articleId)).isFalse();
+        assertThat(scrapCount(userId, articleId)).isZero();
+    }
+
+    @Test
+    void differentUsersCanScrapSameArticleConcurrently() throws Exception {
+        long articleId = articleIds.get(0);
+        long anotherUserId = insertAdditionalUser();
+        jdbcTemplate.update("DELETE FROM scrap WHERE article_id = ?", articleId);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch start = new CountDownLatch(1);
+
+        try {
+            Future<Boolean> first = executor.submit(() -> {
+                start.await();
+                return scrapService.toggle(userId, articleId);
+            });
+            Future<Boolean> second = executor.submit(() -> {
+                start.await();
+                return scrapService.toggle(anotherUserId, articleId);
+            });
+
+            start.countDown();
+
+            assertThat(first.get(30, TimeUnit.SECONDS)).isTrue();
+            assertThat(second.get(30, TimeUnit.SECONDS)).isTrue();
+            assertThat(scrapCount(userId, articleId)).isEqualTo(1);
+            assertThat(scrapCount(anotherUserId, articleId)).isEqualTo(1);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void togglePreservesMissingUserAndArticleErrors() {
+        assertThatThrownBy(() -> scrapService.toggle(Long.MAX_VALUE, articleIds.get(0)))
+                .isInstanceOf(BaseException.class)
+                .hasMessage("존재하지 않는 사용자입니다.");
+
+        assertThatThrownBy(() -> scrapService.toggle(userId, Long.MAX_VALUE))
+                .isInstanceOf(BaseException.class)
+                .hasMessage("존재하지 않는 기사입니다.");
     }
 
     @Test
@@ -311,6 +443,30 @@ class ScrapQueryIntegrationTest {
                 "SELECT user_id FROM users WHERE email = ?",
                 Long.class,
                 "scrap-query@example.com"
+        );
+    }
+
+    private long insertAdditionalUser() {
+        jdbcTemplate.update(
+                "INSERT INTO users(created_at, email, nickname, provider, provider_id) VALUES (NOW(6), ?, ?, ?, ?)",
+                "scrap-query-2@example.com",
+                "scrap-query-user-2",
+                "test",
+                "scrap-query-provider-id-2"
+        );
+        return jdbcTemplate.queryForObject(
+                "SELECT user_id FROM users WHERE email = ?",
+                Long.class,
+                "scrap-query-2@example.com"
+        );
+    }
+
+    private int scrapCount(long targetUserId, long targetArticleId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM scrap WHERE user_id = ? AND article_id = ?",
+                Integer.class,
+                targetUserId,
+                targetArticleId
         );
     }
 


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #229

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [x] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- 동일 사용자 행을 `PESSIMISTIC_WRITE`로 조회한 뒤 스크랩 toggle을 처리하도록 변경했습니다.
- 동일 user/article 동시 20건, 순차 추가·취소, 서로 다른 사용자의 동일 기사 동시 추가, 누락 사용자·기사 회귀 테스트를 추가했습니다.
- 개선 전후 측정과 잠금 선택 근거, POST toggle의 비멱등 API 경계를 문서화했습니다.

## 🔍 기술적 배경
- 기존 `조회 → INSERT/DELETE`는 scrap 행이 없는 상태에서 여러 transaction이 동시에 없음을 읽고 같은 unique key로 INSERT할 수 있었습니다.
- unique 제약은 중복 행은 막지만 충돌 요청을 정상 응답으로 만들지 않아, 통제된 동시 20건 중 18건이 실패했습니다.
- scrap 행은 초기 상태에 존재하지 않고 article 행 잠금은 모든 사용자를 직렬화하므로, 항상 존재하는 user 행만 짧은 transaction 동안 잠급니다.

## 🧪 테스트/검증 (필수)
- [x] 개선 전 MySQL 8: 동시 20건 중 성공 2·실패 18, true 1·false 1, 최종 0건
- [x] 개선 후 MySQL 8: 동시 20건 중 성공 20·실패 0, true 10·false 10, 최종 0건
- [x] 서로 다른 사용자 2명의 동일 기사 동시 추가가 각각 1건을 유지
- [x] 순차 toggle의 true → false 응답 및 누락 사용자·기사 not-found 유지
- [x] 스크랩 집중 테스트 7개 통과
- [x] MySQL·Redis Testcontainers 포함 전체 80개 테스트, 실패 0
- [x] `git diff --check`

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop`)
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 기존 POST toggle의 추가·취소 의미가 유지되는가?

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
- user row pessimistic lock이 동일 사용자의 toggle만 직렬화하는지 확인 부탁드립니다.
- article 단위 전역 경합이나 transaction 밖 lock 사용이 없는지 확인 부탁드립니다.
- 동시 요청 수치와 POST toggle 비멱등 경계가 과장 없이 기록됐는지 확인 부탁드립니다.

## ➕ 추후 계획(선택)
- 반복 요청에도 최종 추가·취소 의도를 보장하는 멱등 `PUT / DELETE` API는 프론트 계약과 함께 별도 이슈로 판단합니다.
- 실제 운영에서 lock wait·timeout이 관찰되기 전에는 Redis 분산 락이나 queue를 도입하지 않습니다.
