### PR TITLE
🐛 [FIX/#231] SSE 채팅 이력 저장 실패 격리

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -7,9 +7,18 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## Current Active Work
 
-- 없음
+현재 진행 중인 backend improvement Issue는 없다.
 
 ## Recently Completed
+
+### P1. SSE 완료 후 채팅 이력 저장 실패 격리 및 트랜잭션 예외 가시성
+
+- 상태: `Done` ([#231](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/231), [PR #232](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/232))
+- AS-IS: transactional 채팅 저장 메서드 내부의 광범위 catch가 사용자·기사 누락은 숨기면서도 메서드 반환 뒤 commit 실패는 안정적으로 격리하지 못했다.
+- TO-BE: 저장 실패를 transaction proxy 바깥 SSE 완료 callback에서 best-effort로 처리하고 실패와 관계없이 이미 생성된 로그인 답변 stream을 완료한다.
+- 범위: `AiSseService`, `ChatHistoryService`, mock SSE 및 MySQL Testcontainers와 문서로 제한했다. 실제 Gemini·retry·outbox·Kafka·queue·익명 Redis 변경은 제외했다.
+- 검증: mock SSE 4개, MySQL 저장 3개, 전체 87개 테스트와 Backend CI 통과. 정상 1건 저장, 누락 리소스·70,000자 DB 실패 전달 및 rollback, 실패 후 emitter complete를 확인했다. AI Reviewer는 Blocking 없음·MERGE_READY로 판정했다.
+- 근거: `docs/backend-improvement/chat-history-sse-persistence-boundary.md`
 
 ### P1. 스크랩 토글 동시 요청 직렬화 및 정합성 보강
 

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -5,9 +5,15 @@
 
 ## Current Active Work
 
-- 없음
+현재 진행 중인 backend improvement Issue는 없다.
 
 ## Recently Completed
+
+- #231 / PR #232: `Done`
+- 결과: transactional save 내부 catch와 commit 전 성공 로그를 제거하고, `AiSseService`가 transaction proxy 호출 반환 뒤 성공 또는 실패를 기록해 로그인 이력 저장 실패와 이미 전달된 SSE 답변 완료를 분리했다.
+- 정책: 로그인 이력 저장은 답변 생성 후 best-effort 부가 기능이며 실패한 turn은 다음 context에서 빠지지만 현재 답변 성공은 유지한다. 익명 Redis 경로는 변경하지 않았다.
+- 검증: mock SSE 4개, MySQL 저장 3개, 전체 87개 테스트와 Backend CI 통과. 실제 외부 API 호출 0회이며 AI Reviewer는 Blocking 없음·MERGE_READY로 판정했다.
+- 범위: `AiSseService`, `ChatHistoryService`, mock SSE, MySQL Testcontainers와 문서만 변경했다. 실제 Gemini·retry·outbox·Kafka·queue·익명 Redis·Issue #110은 제외했다.
 
 - #229 / PR #230: `Done`
 - 결과: 동일 user/article 동시 POST toggle 20건의 성공 2·실패 18을 user 행 `PESSIMISTIC_WRITE`로 성공 20·실패 0, `true/false` 각 10건, 최종 scrap 0건으로 개선했다.

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -5,9 +5,21 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Current Active Work
 
-- 없음
+현재 진행 중인 backend improvement Issue는 없다.
 
 ## Recently Completed
+
+### #231 - SSE 완료 후 채팅 이력 저장 실패 격리 및 트랜잭션 예외 가시성
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/231
+- 작업 브랜치: `fix/#231-chat-history-transaction-boundary`
+- 상태: `Done` ([PR #232](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/232))
+- 기준선: `ChatHistoryService.save()`는 `@Transactional` 메서드 내부에서 모든 예외를 삼키지만, JPA flush·commit은 대상 메서드 반환 후 transaction proxy에서 실패할 수 있어 이 catch가 저장 실패 전체를 보장하지 않는다.
+- 결과: transactional 저장 메서드는 실패를 호출자까지 전달하고, proxy 바깥의 `AiSseService` 완료 callback이 로그인 이력 저장 실패를 best-effort로 격리해 이미 전달된 Gemini SSE 답변을 정상 완료한다.
+- overengineering 판단: mock `SseEmitter`와 경량 MySQL Testcontainers로 검증했으며 실제 Gemini 호출, retry, outbox, Kafka, 별도 저장 queue는 도입하지 않았다.
+- 정책 경계: 로그인 이력 저장은 답변 생성 후 부가 기능으로 취급한다. 실패한 turn은 다음 context에 포함되지 않지만 현재 답변 스트림은 성공으로 유지한다. 익명 Redis 저장 경로는 변경하지 않았다.
+- 검증: mock SSE 완료 callback 4개, MySQL 저장 통합 테스트 3개, 전체 87개 테스트와 Backend CI가 통과했다. 실제 Gemini·Translation 호출은 0회이며 AI Reviewer는 Blocking 없음·MERGE_READY로 판정했다.
+- 작업 문서: `docs/backend-improvement/chat-history-sse-persistence-boundary.md`
 
 ### #229 - 스크랩 토글 동시 요청 직렬화 및 정합성 보강
 

--- a/docs/backend-improvement/chat-history-sse-persistence-boundary.md
+++ b/docs/backend-improvement/chat-history-sse-persistence-boundary.md
@@ -1,0 +1,99 @@
+# SSE 완료 후 채팅 이력 저장 실패 경계
+
+## 문제
+
+로그인 사용자의 Gemini 질의는 답변 stream이 완료된 뒤 질문과 답변을 MySQL `chat_history`에 저장한다.
+
+기존 `ChatHistoryService.save()`는 `@Transactional` 메서드 내부에서 모든 예외를 잡고 로그만 남겼다.
+
+```text
+transaction proxy 시작
+→ ChatHistoryService.save() 본문
+   → 내부 try-catch
+→ JPA flush 및 transaction commit
+```
+
+사용자·기사 누락처럼 메서드 본문에서 발생한 예외는 내부 catch가 숨긴다. 반면 JPA flush 또는 commit이 대상 메서드 반환 후 실패하면 내부 catch 범위 밖이므로 호출자까지 예외가 전달될 수 있다.
+
+이 저장은 Gemini stream의 `doOnComplete` callback에서 실행된다. 사용자가 답변을 이미 전달받은 뒤 이력 저장 실패가 callback 오류가 되면 답변 성공과 부가 저장 실패의 경계가 불명확해진다.
+
+## 정책
+
+| 작업 | 정책 |
+| --- | --- |
+| Gemini 답변 생성·SSE 전달 | 주 기능 |
+| 로그인 채팅 이력 저장 | 답변 완료 후 best-effort 부가 기능 |
+| 이력 저장 실패 | 현재 답변 stream은 정상 완료하고 구조화 로그 기록 |
+| 다음 대화 context | 저장에 실패한 turn은 포함되지 않음 |
+| 익명 Redis 이력 저장 | 기존 경로 유지 |
+
+이 정책은 저장 실패를 성공으로 위장한다는 의미가 아니다. 사용자에게 이미 전달한 답변의 성공 상태와, 이후 MySQL에 남기는 부가 이력의 성공 상태를 분리한다.
+
+## Transaction 경계 변경
+
+### 기존
+
+```text
+AiSseService
+→ transactional save()
+   → try
+      → repository.save()
+   → catch
+→ commit
+```
+
+메서드 내부 catch는 commit 전체를 감싸지 못하고 누락 리소스 예외를 호출자에게 전달하지 않았다. 또한 transactional 메서드 내부의 저장 성공 로그는 실제 commit 성공 전에 기록될 수 있었다.
+
+### 변경
+
+```text
+AiSseService try
+→ transactional proxy
+   → ChatHistoryService.save()
+   → flush
+   → commit
+→ 정상 반환 후 성공 로그
+catch
+→ userId, articleId, 예외 유형과 stack trace 기록
+→ SseEmitter.complete()
+```
+
+`ChatHistoryService.save()`는 저장 책임만 수행하고 예외를 숨기지 않는다. `AiSseService`는 proxy 호출 전체를 감싸므로 사용자·기사 조회, INSERT, flush, commit에서 전달된 실패를 같은 경계에서 처리한다.
+
+## 검증
+
+### Mock SSE 완료 callback
+
+외부 Gemini API를 호출하지 않고 mock `WebClient`와 mock `SseEmitter`를 사용했다.
+
+| 시나리오 | 결과 |
+| --- | --- |
+| 로그인 이력 저장 성공 | save 호출 후 emitter complete |
+| 이력 저장 예외 | 예외를 stream error로 전파하지 않고 emitter complete |
+| 저장 실패 로그 | user ID, article ID, `DataIntegrityViolationException` 기록 |
+| 익명 요청 | 기존 Redis `appendTurn` 호출 유지 |
+| mock Gemini SSE `data:` 완료 | 누적 답변을 로그인 이력 save에 전달 |
+
+### MySQL 8 Testcontainers
+
+| 시나리오 | 결과 |
+| --- | --- |
+| 정상 사용자·기사 | chat_history 1건 저장 |
+| 존재하지 않는 사용자 | `IllegalArgumentException`이 호출자까지 전달 |
+| 존재하지 않는 기사 | `IllegalArgumentException`이 호출자까지 전달 |
+| TEXT 한도를 넘는 70,000자 답변 | DB 쓰기 예외가 호출자까지 전달되고 0건 rollback |
+
+mock SSE 테스트 4개와 MySQL 저장 테스트 3개가 통과했다. MySQL·Redis Testcontainers를 포함한 전체 87개 테스트도 실패 없이 통과했다.
+
+## 비용과 범위
+
+- 실제 Gemini 호출은 0회다.
+- 실제 Cloud Translation 호출도 없다.
+- schema, API 응답 형식, SSE event 형식, 익명 Redis 저장은 변경하지 않는다.
+- retry, outbox, Kafka, 별도 저장 executor·queue는 추가하지 않는다.
+
+## 해석 경계
+
+- 이력 저장 실패 시 해당 turn은 다음 Gemini context에 포함되지 않는다.
+- 현재 정책은 답변 가용성을 우선하는 best-effort 결정이며, 이력 보존을 결제·감사 데이터처럼 반드시 보장하는 정책이 아니다.
+- 저장 실패가 실제 운영에서 반복 관찰될 때 retry 또는 outbox를 별도 근거와 함께 검토한다.

--- a/src/main/java/com/example/globalTimes_be/domain/ai/service/AiSseService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/ai/service/AiSseService.java
@@ -162,25 +162,46 @@ public class AiSseService {
                         log.warn("[Gemini SSE] JSON 파싱 오류: {}", e.getMessage());
                     }
                 })
-                .doOnComplete(() -> {
-                    // 스트리밍 완료 후 히스토리 저장
-                    if (userId != null && articleId != null && question != null) {
-                        chatHistoryService.save(userId, articleId, question, resultBuilder.toString());
-                    } else if (anonymousSessionId != null && articleId != null && question != null) {
-                        anonymousChatSessionService.appendTurn(
-                                anonymousSessionId, articleId, question, resultBuilder.toString(), contextWindowSize);
-                    }
-                    try {
-                        emitter.complete();
-                    } catch (Exception e) {
-                        log.warn("[Gemini SSE] emitter complete 오류: {}", e.getMessage());
-                    }
-                })
+                .doOnComplete(() -> completeStreaming(
+                        emitter,
+                        question,
+                        userId,
+                        articleId,
+                        anonymousSessionId,
+                        resultBuilder.toString()
+                ))
                 .doOnError(error -> {
                     log.error("[Gemini SSE] 처리 중 오류 발생", error);
                     emitter.completeWithError(error);
                 })
                 .subscribe();
+    }
+
+    void completeStreaming(SseEmitter emitter, String question, Long userId, Long articleId,
+                           String anonymousSessionId, String answer) {
+        if (userId != null && articleId != null && question != null) {
+            try {
+                chatHistoryService.save(userId, articleId, question, answer);
+                log.info("[Gemini SSE] 채팅 이력 저장 완료 - userId={}, articleId={}", userId, articleId);
+            } catch (Exception e) {
+                log.error(
+                        "[Gemini SSE] 채팅 이력 저장 실패 - userId={}, articleId={}, exception={}",
+                        userId,
+                        articleId,
+                        e.getClass().getSimpleName(),
+                        e
+                );
+            }
+        } else if (anonymousSessionId != null && articleId != null && question != null) {
+            anonymousChatSessionService.appendTurn(
+                    anonymousSessionId, articleId, question, answer, contextWindowSize);
+        }
+
+        try {
+            emitter.complete();
+        } catch (Exception e) {
+            log.warn("[Gemini SSE] emitter complete 오류: {}", e.getMessage());
+        }
     }
 
 

--- a/src/main/java/com/example/globalTimes_be/domain/chat/service/ChatHistoryService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/chat/service/ChatHistoryService.java
@@ -10,7 +10,6 @@ import com.example.globalTimes_be.domain.chat.repository.ChatHistoryRepository;
 import com.example.globalTimes_be.domain.user.entity.User;
 import com.example.globalTimes_be.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,7 +21,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatHistoryService {
@@ -34,17 +32,12 @@ public class ChatHistoryService {
     // GPT 질의 완료 시 저장 (AiSseService에서 호출)
     @Transactional
     public void save(Long userId, Long articleId, String question, String answer) {
-        try {
-            User user = userRepository.findById(userId)
-                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자: " + userId));
-            Article article = articleRepository.findById(articleId)
-                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 기사: " + articleId));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자: " + userId));
+        Article article = articleRepository.findById(articleId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 기사: " + articleId));
 
-            chatHistoryRepository.save(ChatHistory.create(user, article, question, answer));
-            log.info("[ChatHistory] 저장 완료 - userId: {}, articleId: {}", userId, articleId);
-        } catch (Exception e) {
-            log.error("[ChatHistory] 저장 실패 - userId: {}, articleId: {}, error: {}", userId, articleId, e.getMessage());
-        }
+        chatHistoryRepository.save(ChatHistory.create(user, article, question, answer));
     }
 
     // 팝업 목록용: 사용자의 기사별 마지막 대화 미리보기

--- a/src/test/java/com/example/globalTimes_be/domain/ai/service/AiSseServiceCompletionTest.java
+++ b/src/test/java/com/example/globalTimes_be/domain/ai/service/AiSseServiceCompletionTest.java
@@ -1,0 +1,125 @@
+package com.example.globalTimes_be.domain.ai.service;
+
+import com.example.globalTimes_be.domain.chat.service.AnonymousChatSessionService;
+import com.example.globalTimes_be.domain.chat.service.ChatHistoryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(OutputCaptureExtension.class)
+class AiSseServiceCompletionTest {
+
+    private ChatHistoryService chatHistoryService;
+    private AnonymousChatSessionService anonymousChatSessionService;
+    private AiSseService aiSseService;
+    private SseEmitter emitter;
+
+    @BeforeEach
+    void setUp() {
+        chatHistoryService = mock(ChatHistoryService.class);
+        anonymousChatSessionService = mock(AnonymousChatSessionService.class);
+        aiSseService = new AiSseService(
+                mock(WebClient.class),
+                chatHistoryService,
+                anonymousChatSessionService
+        );
+        ReflectionTestUtils.setField(aiSseService, "contextWindowSize", 10);
+        emitter = mock(SseEmitter.class);
+    }
+
+    @Test
+    void completesLoginStreamAfterHistorySave() {
+        aiSseService.completeStreaming(emitter, "question", 1L, 2L, null, "answer");
+
+        verify(chatHistoryService).save(1L, 2L, "question", "answer");
+        verify(emitter).complete();
+        verify(emitter, never()).completeWithError(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void historySaveFailureIsLoggedAndDoesNotFailCompletedAnswer(CapturedOutput output) {
+        doThrow(new DataIntegrityViolationException("commit failed"))
+                .when(chatHistoryService)
+                .save(1L, 2L, "question", "answer");
+
+        assertThatCode(() ->
+                aiSseService.completeStreaming(emitter, "question", 1L, 2L, null, "answer")
+        ).doesNotThrowAnyException();
+
+        verify(emitter).complete();
+        verify(emitter, never()).completeWithError(org.mockito.ArgumentMatchers.any());
+        assertThat(output)
+                .contains("채팅 이력 저장 실패")
+                .contains("userId=1")
+                .contains("articleId=2")
+                .contains("DataIntegrityViolationException");
+    }
+
+    @Test
+    void anonymousCompletionKeepsExistingRedisAppendPath() {
+        aiSseService.completeStreaming(
+                emitter,
+                "question",
+                null,
+                2L,
+                "anonymous-session",
+                "answer"
+        );
+
+        verify(anonymousChatSessionService)
+                .appendTurn("anonymous-session", 2L, "question", "answer", 10);
+        verify(chatHistoryService, never())
+                .save(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
+                        org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+        verify(emitter).complete();
+    }
+
+    @Test
+    void mockGeminiCompletionDelegatesLoginHistorySave() {
+        WebClient mockGemini = WebClient.builder()
+                .exchangeFunction(request -> Mono.just(
+                        ClientResponse.create(HttpStatus.OK)
+                                .header("Content-Type", MediaType.TEXT_EVENT_STREAM_VALUE)
+                                .body("""
+                                        data: {"candidates":[{"content":{"parts":[{"text":"mock answer"}]}}]}
+
+                                        """)
+                                .build()
+                ))
+                .build();
+        AiSseService streamingService = new AiSseService(
+                mockGemini,
+                chatHistoryService,
+                anonymousChatSessionService
+        );
+        ReflectionTestUtils.setField(streamingService, "geminiApiKey", "test-api-key");
+        ReflectionTestUtils.setField(streamingService, "contextWindowSize", 10);
+        when(chatHistoryService.getRecentContext(1L, 2L, 10)).thenReturn(List.of());
+
+        assertThatCode(() ->
+                streamingService.askGPT("article content", "question", 1L, 2L, null)
+        ).doesNotThrowAnyException();
+
+        verify(chatHistoryService).save(1L, 2L, "question", "mock answer");
+    }
+}

--- a/src/test/java/com/example/globalTimes_be/domain/chat/service/ChatHistorySaveIntegrationTest.java
+++ b/src/test/java/com/example/globalTimes_be/domain/chat/service/ChatHistorySaveIntegrationTest.java
@@ -1,0 +1,142 @@
+package com.example.globalTimes_be.domain.chat.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@Import(ChatHistoryService.class)
+class ChatHistorySaveIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
+            .withUsername("root")
+            .withPassword("test");
+
+    @Autowired
+    private ChatHistoryService chatHistoryService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private long userId;
+    private long articleId;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.update(
+                "INSERT INTO source(source_api_id, source_name) VALUES (?, ?)",
+                "chat-save-source-id",
+                "Chat Save Source"
+        );
+        long sourceId = jdbcTemplate.queryForObject(
+                "SELECT source_id FROM source WHERE source_name = ?",
+                Long.class,
+                "Chat Save Source"
+        );
+
+        jdbcTemplate.update(
+                "INSERT INTO users(created_at, email, nickname, provider, provider_id) " +
+                        "VALUES (NOW(6), ?, ?, ?, ?)",
+                "chat-save@example.com",
+                "chat-save-user",
+                "test",
+                "chat-save-provider-id"
+        );
+        userId = jdbcTemplate.queryForObject(
+                "SELECT user_id FROM users WHERE email = ?",
+                Long.class,
+                "chat-save@example.com"
+        );
+
+        jdbcTemplate.update(
+                "INSERT INTO article(author, category, content, country, description, published_at, " +
+                        "title, url, url_to_image, view_count, source_id, language) " +
+                        "VALUES (?, ?, ?, ?, ?, NOW(6), ?, ?, ?, ?, ?, ?)",
+                "author",
+                "general",
+                "content",
+                "us",
+                "description",
+                "Chat save article",
+                "https://news.example/chat-save",
+                "https://news.example/chat-save.jpg",
+                0L,
+                sourceId,
+                "en"
+        );
+        articleId = jdbcTemplate.queryForObject(
+                "SELECT article_id FROM article WHERE url = ?",
+                Long.class,
+                "https://news.example/chat-save"
+        );
+    }
+
+    @AfterEach
+    void cleanUp() {
+        jdbcTemplate.update("DELETE FROM chat_history");
+        jdbcTemplate.update("DELETE FROM article");
+        jdbcTemplate.update("DELETE FROM users");
+        jdbcTemplate.update("DELETE FROM source");
+    }
+
+    @Test
+    void savesCompletedLoginTurn() {
+        chatHistoryService.save(userId, articleId, "question", "answer");
+
+        assertThat(chatCount()).isEqualTo(1);
+    }
+
+    @Test
+    void missingUserAndArticleFailuresReachCaller() {
+        assertThatThrownBy(() ->
+                chatHistoryService.save(Long.MAX_VALUE, articleId, "question", "answer")
+        )
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 사용자: " + Long.MAX_VALUE);
+
+        assertThatThrownBy(() ->
+                chatHistoryService.save(userId, Long.MAX_VALUE, "question", "answer")
+        )
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 기사: " + Long.MAX_VALUE);
+    }
+
+    @Test
+    void databaseWriteFailureReachesCallerAndRollsBack() {
+        String oversizedAnswer = "x".repeat(70_000);
+
+        assertThatThrownBy(() ->
+                chatHistoryService.save(userId, articleId, "question", oversizedAnswer)
+        ).isInstanceOf(RuntimeException.class);
+
+        assertThat(chatCount()).isZero();
+    }
+
+    private int chatCount() {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM chat_history WHERE user_id = ? AND article_id = ?",
+                Integer.class,
+                userId,
+                articleId
+        );
+    }
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #231

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [x] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- `ChatHistoryService.save()` 내부의 광범위한 예외 처리와 commit 전 성공 로그를 제거했습니다.
- `AiSseService`가 transactional proxy 호출 전체의 성공·실패를 처리하도록 SSE 완료 callback을 분리했습니다.
- 로그인 이력 저장 실패 시 user/article/예외 유형을 기록하고 이미 생성된 SSE 답변은 정상 완료합니다.
- mock SSE 완료 테스트와 경량 MySQL 저장 통합 테스트, 정책 문서를 추가했습니다.

## 🔍 기술적 배경
- JPA flush·transaction commit은 대상 `@Transactional` 메서드 반환 후 proxy에서 실패할 수 있어 메서드 내부 catch가 전체 저장 실패를 감싸지 못합니다.
- 사용자에게 Gemini 답변이 이미 전달된 뒤 발생하는 이력 저장은 best-effort 부가 기능으로 분리하는 것이 현재 서비스 의미에 맞습니다.
- 성공 로그도 proxy 호출이 정상 반환된 뒤 기록해야 실제 commit 성공과 일치합니다.

## 🧪 테스트/검증 (필수)
- [x] mock Gemini SSE `data:` 완료가 누적 답변을 로그인 이력 저장에 전달
- [x] 저장 성공 시 emitter complete
- [x] 저장 예외 시 user/article/예외 유형 로그 후 emitter complete, stream error 미전파
- [x] 익명 요청의 기존 Redis append 경로 유지
- [x] MySQL 정상 chat_history 1건 저장
- [x] 누락 사용자·기사 예외가 호출자까지 전달
- [x] 70,000자 TEXT 저장 실패가 호출자까지 전달되고 0건 rollback
- [x] 집중 테스트 7개와 MySQL·Redis Testcontainers 포함 전체 87개 테스트 통과
- [x] 실제 Gemini·Translation 호출 0회
- [x] `git diff --check`

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop`)
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?
- [x] SSE 응답 형식과 익명 Redis 저장 동작이 유지되는가?

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
- transaction proxy 바깥 catch가 flush·commit 실패까지 관측하는 경계인지 확인 부탁드립니다.
- 로그인 이력 저장 실패 후 emitter 완료 정책이 기존 Reactor 오류 흐름과 충돌하지 않는지 확인 부탁드립니다.
- 익명 Redis 경로와 원래 Gemini stream 오류의 `completeWithError` 처리가 유지되는지 확인 부탁드립니다.
- retry/outbox/queue를 제외한 범위가 현재 단계에 적절한지 확인 부탁드립니다.

## ➕ 추후 계획(선택)
- 저장 실패가 운영에서 반복 관찰될 때만 retry 또는 outbox를 별도 근거로 검토합니다.
- 이력 저장 실패 turn은 다음 Gemini context에 포함되지 않는다는 현재 best-effort 한계를 유지합니다.
