### PR TITLE
📊 [PERF/#233] RSS/News API 수집 배치 처리량 기준선

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -9,7 +9,39 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 현재 진행 중인 backend improvement Issue는 없다.
 
+## Phase 1 Exit Roadmap
+
+### P1. Trend Gemini prompt·timeout·오류 정책 보강
+
+- 상태: `Backlog`
+- 근거: 사용자 요청 경로의 `TrendAiService` system prompt가 `?` 문자로 손상돼 있고, Gemini `.block()` 호출에 timeout과 upstream·timeout·내부 오류 분리가 없다.
+- 범위: prompt 복구, configurable timeout, mock WebClient 회귀 테스트와 오류 정책으로 제한한다. 실제 Gemini, async 전환, queue·Kafka는 제외한다.
+
+### P1. Trend Redis 갱신 시 기존 데이터 보존
+
+- 상태: `Backlog`
+- 근거: scheduler가 국가별 기존 trend key를 DELETE한 뒤 새 값을 SET하므로 직렬화·저장 실패 사이에 기존 데이터가 사라질 수 있다.
+- 범위: 선행 DELETE 제거, 성공 시 단일 SET 교체, 실패 시 기존 값 보존 회귀 테스트로 제한한다. Redis 자료구조 변경과 분산 락은 제외한다.
+
+### P1. Phase 1 백엔드 구조·정량 근거 맵 및 README 최신화
+
+- 상태: `Backlog`
+- 근거: 상세 PR·측정 문서는 남아 있지만 정량 인덱스에 #223 이후 작업이 빠져 있고 README의 legacy CI/CD 설명과 학습 진입 링크가 현재 상태를 반영하지 못한다.
+- 범위: 도메인별 `진입점 → Service → DB/Redis/외부 API → 문제 → 해결 → 수치 → 테스트/PR` 맵, 정량 인덱스, README 링크 최신화로 제한한다.
+
 ## Recently Completed
+
+### P1. RSS/News API 수집 배치 처리량 및 지연 전파 기준선
+
+- 상태: `Done` ([#233](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/233), [PR #234](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/234))
+- AS-IS: 수집 중복 방지·재실행 안전성·부분 실패 격리는 검증했지만 100·500·1,000건의 실제 MySQL 처리량과 순차 source 지연 전파는 수치가 없었다.
+- TO-BE: fixture와 mock upstream, MySQL Testcontainers로 신규 저장·중복 재실행·혼합 데이터·지연/5xx 조건을 측정하고 후속 기술 검토 근거를 남겼다.
+- 범위: 테스트와 측정 문서로 제한했다. 실제 API, `news-fetch.enabled=true`, 운영 DB, schema/index, scheduler, Kafka·별도 queue·retry는 변경하지 않았다.
+- 측정: 신규 1,000건은 News API 4,244.38ms·1,022 statements, RSS 2,860.14ms·1,003 statements였다. 재실행은 53.83ms·1 statement, 56.15ms·2 statements와 저장 0건이었다.
+- 지연 전파: all-fast 506.69ms 대비 300ms 지연 source 포함 790.89ms로 284.20ms 증가했고, 중간 5xx 이후에도 총 75건 저장을 유지했다.
+- 판단: 현재 4/6시간 scheduler 대비 배치 처리 여유가 있어 Kafka는 보류했다. 지속 backlog·replay·독립 consumer·scale-out 요구가 생길 때 Phase 2에서 검토한다.
+- 검증: 집중 4개·전체 91개 테스트와 Backend CI가 통과했고 AI Reviewer는 Blocking 수정 재검토 후 MERGE_READY로 판정했다.
+- 근거: `docs/backend-improvement/collection-batch-throughput-baseline.md`
 
 ### P1. SSE 완료 후 채팅 이력 저장 실패 격리 및 트랜잭션 예외 가시성
 

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -9,6 +9,14 @@
 
 ## Recently Completed
 
+- #233 / PR #234: `Done`
+- 결과: RSS/News API의 100·500·1,000건 신규 저장·중복 재실행과 mock upstream 순차 지연 전파를 MySQL Testcontainers에서 측정했다.
+- 측정: 신규 1,000건은 News API 4,244.38ms·1,022 statements, RSS 2,860.14ms·1,003 statements였다. 재실행은 각각 53.83ms·1 statement, 56.15ms·2 statements와 저장 0건이었다.
+- 지연 전파: 동일 4요청·75저장·5xx 1건에서 all-fast 506.69ms, 300ms 지연 source 포함 790.89ms, 차이 284.20ms였다. 5xx 이후 source는 계속 처리됐다.
+- 판단: 4/6시간 scheduler와 겹칠 근거가 없어 Kafka·durable queue는 보류했다. 집중 4개·전체 91개 테스트와 Backend CI가 통과했고 AI Reviewer는 Blocking 수정 재검토 후 MERGE_READY로 판정했다.
+- Phase 1 잔여 순서: Trend Gemini prompt·timeout·오류 정책 → Trend Redis 갱신 데이터 보존 → Phase 1 구조·정량 근거 맵과 README 최신화.
+- 범위: 테스트·fixture·측정 문서만 변경했으며 실제 API, flag, 운영 DB, production code, schema/index, scheduler, Kafka·queue·retry·Issue #110은 제외했다.
+
 - #231 / PR #232: `Done`
 - 결과: transactional save 내부 catch와 commit 전 성공 로그를 제거하고, `AiSseService`가 transaction proxy 호출 반환 뒤 성공 또는 실패를 기록해 로그인 이력 저장 실패와 이미 전달된 SSE 답변 완료를 분리했다.
 - 정책: 로그인 이력 저장은 답변 생성 후 best-effort 부가 기능이며 실패한 turn은 다음 context에서 빠지지만 현재 답변 성공은 유지한다. 익명 Redis 경로는 변경하지 않았다.

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -9,6 +9,20 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Recently Completed
 
+### #233 - RSS/News API 수집 배치 처리량 및 지연 전파 기준선 측정
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/233
+- 작업 브랜치: `measure/#233-collection-batch-baseline`
+- 상태: `Done` ([PR #234](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/234))
+- 기준선: RSS/News API 수집은 URL 일괄 중복 조회와 `saveAll`, source별 실패 격리와 통계를 갖췄지만 배치 규모별 실제 MySQL 처리량과 순차 source 지연 전파 수치가 없었다.
+- overengineering 판단: 실제 외부 API와 운영 DB를 사용하지 않고 fixture, random-port mock HTTP server, MySQL Testcontainers로 측정했다. Kafka·별도 queue·schema/index·scheduler 변경은 제외했다.
+- 측정: 신규 1,000건은 News API fixture 4,244.38ms·1,022 statements, RSS fixture 2,860.14ms·1,003 statements였다. 동일 배치 재실행은 각각 53.83ms·1 statement, 56.15ms·2 statements이며 추가 저장은 0건이었다.
+- 지연 전파: 동일 4요청·75저장·5xx 1건 조건에서 all-fast 506.69ms, 300ms 지연 source 포함 790.89ms로 284.20ms 증가했다. 5xx 이후 source 저장은 계속됐다.
+- 판단: 통제된 1,000건 배치가 4/6시간 scheduler와 겹칠 근거가 없어 Kafka 도입은 보류했다. 지속 backlog, replay, 독립 consumer scale-out, 수만 건 DB 병목이 확인될 때 Phase 2에서 재검토한다.
+- 검증: 집중 테스트 4개와 전체 91개 테스트, Backend CI가 통과했다. AI Reviewer의 측정 경계 문서 Blocking을 수정했고 최신 HEAD 재검토에서 Blocking 없음·MERGE_READY로 판정됐다.
+- Phase 1 종료선: Trend Gemini prompt·timeout·오류 정책, Trend Redis 갱신 데이터 보존, Phase 1 구조·정량 근거 맵과 README 최신화를 순서대로 완료한다. 그 전에는 신규 기술을 운영 경로에 도입하지 않는다.
+- 측정 문서: `docs/backend-improvement/collection-batch-throughput-baseline.md`
+
 ### #231 - SSE 완료 후 채팅 이력 저장 실패 격리 및 트랜잭션 예외 가시성
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/231

--- a/docs/backend-improvement/collection-batch-throughput-baseline.md
+++ b/docs/backend-improvement/collection-batch-throughput-baseline.md
@@ -1,0 +1,127 @@
+# RSS/News API 수집 배치 처리량 및 지연 전파 기준선
+
+## 1. 목적
+
+RSS/News API 수집은 단일 인스턴스에서 source를 순차 처리하고, 응답 단위 URL 일괄 중복 조회와 `saveAll`을 사용한다.
+기존 #196, #212, #223은 중복 방지, 부분 실패 격리, 수집 통계를 검증했지만 배치 규모 증가에 따른 실제 MySQL 처리량과 순차 source 지연 전파는 측정하지 않았다.
+
+이 문서는 통제된 fixture와 mock upstream으로 현재 구조의 처리 여유를 확인하고, 단순 DB 개선이나 별도 worker·durable message queue가 필요한지 판단하는 기준선을 남긴다.
+
+## 2. 측정 경계
+
+- Windows 로컬 노트북, 메모리 8GB
+- Java 17, Docker Desktop `25.0.2`, MySQL `8.0` Testcontainers
+- `news-fetch.enabled=false` 유지
+- 실제 News API, RSS, 번역, Gemini 호출 0회
+- 100·500·1,000건 News API 규모 측정은 DTO fixture 생성을 먼저 완료하고, timer 시작 후 `processArticlesWithStats()`와 MySQL 저장만 측정
+- RSS 규모 측정은 XML fixture 생성과 Jsoup parsing을 먼저 완료해 `Elements`를 만들고, timer 시작 후 `processItemsWithStats()`와 MySQL 저장만 측정
+- fixture 생성, News DTO 생성, RSS XML 생성·Jsoup parsing 시간은 규모별 elapsed와 rows/s에서 제외
+- source 지연 전파 측정만 timer 안에서 local random-port HTTP 요청, JSON 역직렬화, `fetchTopHeadlines()` 처리와 JPA/MySQL 저장까지 전체 News API 경로를 실행
+- 각 규모는 warm-up 후 3회 실행하고 elapsed 중앙값을 사용
+- Hibernate SQL 콘솔 출력은 측정 테스트에서만 끄고 statistics statement 수는 유지
+- 시간은 로컬 환경 영향을 받으므로 테스트 assertion으로 사용하지 않고 저장·중복·실패 격리만 회귀 조건으로 고정
+
+운영 DB, schema/index, API, scheduler 설정, retry/circuit breaker, Kafka, 별도 queue, 분산 락은 변경하지 않았다.
+
+## 3. Fixture와 실행 흐름
+
+### 3.1 데이터 생성
+
+`CollectionBatchPerformanceIntegrationTest`의 fixture 메서드가 입력을 만든다.
+
+- `validNewsArticles(count, prefix)`: 서로 다른 URL과 10개 source를 순환하는 정상 News API 기사
+- `rssItems(count, prefix)`: 서로 다른 URL의 RSS `<item>` XML을 생성하고 Jsoup parsing을 마친 `Elements` 반환
+- `mixedNewsArticles()`: 정상 신규 700건, DB 기존 100건, 응답 내부 중복 100건, invalid 100건
+- `handleMockUpstream(...)`: 정상, 300ms 지연, HTTP 500 source 응답
+
+### 3.2 서비스 호출
+
+- `measureNewsBatch(...)`는 미리 생성된 `List<NewsApiArticleDto>`를 받은 뒤 statistics와 timer를 초기화하고 `NewsApiService.processArticlesWithStats()`를 호출한다.
+- `measureRssBatch(...)`는 XML 생성·Jsoup parsing이 끝난 `Elements`를 받은 뒤 statistics와 timer를 초기화하고 `RssNewsService.processItemsWithStats()`를 호출한다.
+- `measureMockUpstreamScenario(...)`는 `fetchTopHeadlines()` 호출 직전에 timer를 시작하므로 실제 local HTTP 요청, JSON 역직렬화, service 처리와 JPA/MySQL 저장을 모두 포함한다.
+- 첫 실행 후 같은 fixture를 다시 전달해 기존 URL 일괄 조회와 저장 0건을 확인한다.
+- 모든 저장은 임시 MySQL 8 Testcontainers에서 실행되고 테스트 종료 후 폐기된다.
+
+## 4. 배치 규모별 결과
+
+### 4.1 News API fixture
+
+| 응답 건수 | 신규 저장 | 신규 SQL statement | 신규 elapsed 중앙값 | 신규 처리량 | 재실행 저장 | 재실행 중복 | 재실행 SQL | 재실행 elapsed |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 100 | 100 | 122 | 605.06ms | 165.27 rows/s | 0 | 100 | 1 | 22.05ms |
+| 500 | 500 | 522 | 1,942.33ms | 257.42 rows/s | 0 | 500 | 1 | 29.63ms |
+| 1,000 | 1,000 | 1,022 | 4,244.38ms | 235.61 rows/s | 0 | 1,000 | 1 | 53.83ms |
+
+10개 source를 처음 생성하는 조회·INSERT와 기사별 INSERT 때문에 신규 statement는 기사 수에 비례했다.
+재실행은 URL 목록을 한 번에 조회한 뒤 저장하지 않아 규모별 SQL statement가 1개로 유지됐다.
+
+### 4.2 RSS fixture
+
+| 응답 건수 | 신규 저장 | 신규 SQL statement | 신규 elapsed 중앙값 | 신규 처리량 | 재실행 저장 | 재실행 중복 | 재실행 SQL | 재실행 elapsed |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 100 | 100 | 103 | 523.04ms | 191.19 rows/s | 0 | 100 | 2 | 22.95ms |
+| 500 | 500 | 503 | 1,929.99ms | 259.07 rows/s | 0 | 500 | 2 | 25.22ms |
+| 1,000 | 1,000 | 1,003 | 2,860.14ms | 349.63 rows/s | 0 | 1,000 | 2 | 56.15ms |
+
+RSS 신규 statement는 기사별 INSERT와 source 조회·생성, 기존 URL 조회로 구성됐다.
+처리량이 단조 증가하지 않는 것은 짧은 로컬 실행의 JIT, Docker, 파일·콘솔 및 host 부하 영향이 섞이기 때문이며 운영 capacity로 일반화하지 않는다.
+
+### 4.3 혼합 News API fixture
+
+| received | invalid | duplicate | saved | SQL statement | elapsed | 처리량 |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1,000 | 100 | 200 | 700 | 702 | 3,973.96ms | 251.64 rows/s |
+
+기존 100건과 신규 700건을 합쳐 DB에는 800건이 남았고 URL 중복 group은 0건이었다.
+
+## 5. 순차 source 지연 전파
+
+두 시나리오는 source 4개, HTTP 500 source 1개, 정상 저장 75건으로 조건을 맞췄다.
+차이는 두 번째 source가 즉시 응답하는지 300ms 후 응답하는지뿐이다.
+
+| 시나리오 | 요청 | 저장 | 실패 source | elapsed 중앙값 |
+| --- | ---: | ---: | ---: | ---: |
+| all-fast control | 4 | 75 | 1 | 506.69ms |
+| 300ms delayed | 4 | 75 | 1 | 790.89ms |
+| 차이 | - | - | - | 284.20ms |
+
+300ms source 지연이 전체 순차 실행에 약 284ms 추가됐다.
+중간 HTTP 500은 로그로 격리됐고 이후 source 요청과 정상 기사 저장은 계속됐다.
+
+## 6. 판단
+
+### 현재 구조
+
+- 신규 1,000건은 로컬 MySQL에서 약 2.86~4.24초에 저장됐다.
+- News API 4시간, RSS 6시간 주기와 비교하면 통제된 1,000건 배치가 다음 실행과 겹칠 근거는 없다.
+- 동일 배치 재실행은 1,000건에서도 약 54~56ms, SQL 1~2개, 추가 저장 0건이었다.
+- source 지연은 순차 실행 전체 시간에 그대로 더해지지만 source 1건의 5xx가 이후 수집을 막지는 않았다.
+
+따라서 현재 데이터 규모와 단일 인스턴스에서는 Kafka나 durable message queue를 도입할 근거가 부족하다.
+Issue #233으로 Phase 1의 수집 안정성·처리량 기준선은 마무리한다. 프로젝트 전체 Phase 1은 아래 잔여 안정성·문서 이슈를 완료한 뒤 종료하고, 신규 기술 도입은 Phase 2의 별도 문제와 지표를 기준으로 판단한다.
+
+### 후속 검토 조건
+
+- 수집 한 번이 다음 4/6시간 scheduler 실행과 겹치거나 지속적인 backlog가 발생한다.
+- 작업 유실 방지, 재처리·replay, source별 독립 retry가 필요하다.
+- 수집·번역·임베딩을 독립 consumer로 분리하고 각 단계를 별도 scale-out해야 한다.
+- 수만 건 배치에서 기사별 INSERT가 확인 가능한 DB 병목이 된다.
+
+마지막 조건만 발생한다면 Kafka보다 JDBC/JPA insert batching 또는 저장 단위 조정이 먼저다.
+현재 수치만으로 구현을 변경하면 복잡도 대비 효과가 작으므로 이번 범위에서는 측정과 보류 판단으로 끝낸다.
+
+## 7. Phase 1 종료 로드맵
+
+1. Trend Gemini의 손상된 system prompt를 복구하고 configurable timeout과 upstream·timeout·내부 오류 경계를 mock 테스트로 고정한다.
+2. Trend Redis 갱신의 선행 DELETE를 제거해 새 값 생성·저장 실패 시 기존 값을 보존한다.
+3. 루트 README의 오래된 CI/CD 설명을 현재 상태로 고치고, #223 이후 결과를 정량 인덱스에 연결한 Phase 1 구조·근거 맵을 완성한다.
+
+`NewsApiService`의 singleton 실행 카운터는 현재 기본 단일 scheduler에서 동시 실행 근거가 없으므로 Phase 1 필수 작업으로 확장하지 않는다. scheduler 병렬화나 수동 동시 실행 요구가 생길 때 실행별 지역 상태 전환을 검토한다.
+
+## 8. 재현
+
+```powershell
+.\gradlew.bat test --tests "com.example.globalTimes_be.externalApi.service.CollectionBatchPerformanceIntegrationTest" --rerun-tasks
+```
+
+로그의 `COLLECTION_BATCH_MEDIAN`, `COLLECTION_BATCH`, `COLLECTION_UPSTREAM_COMPARISON` 행에서 측정값을 확인한다.

--- a/src/test/java/com/example/globalTimes_be/externalApi/service/CollectionBatchPerformanceIntegrationTest.java
+++ b/src/test/java/com/example/globalTimes_be/externalApi/service/CollectionBatchPerformanceIntegrationTest.java
@@ -1,0 +1,557 @@
+package com.example.globalTimes_be.externalApi.service;
+
+import com.example.globalTimes_be.domain.article.repository.ArticleRepository;
+import com.example.globalTimes_be.domain.article.service.ArticleService;
+import com.example.globalTimes_be.domain.source.repository.SourceRepository;
+import com.example.globalTimes_be.domain.source.service.SourceService;
+import com.example.globalTimes_be.externalApi.config.NewsFetchConfig;
+import com.example.globalTimes_be.externalApi.config.RssFeedConfig;
+import com.example.globalTimes_be.externalApi.dto.NewsApiArticleDto;
+import com.example.globalTimes_be.externalApi.dto.NewsApiResponseDto;
+import com.example.globalTimes_be.externalApi.dto.NewsApiSourceDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.jsoup.Jsoup;
+import org.jsoup.parser.Parser;
+import org.jsoup.select.Elements;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToLongFunction;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DataJpaTest(showSql = false)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@Import(SourceService.class)
+@TestPropertySource(properties = {
+        "spring.jpa.properties.hibernate.generate_statistics=true",
+        "logging.level.org.hibernate.SQL=OFF",
+        "logging.level.org.hibernate.orm.jdbc.bind=OFF",
+        "logging.level.org.hibernate.engine.internal.StatisticalLoggingSessionEventListener=OFF"
+})
+class CollectionBatchPerformanceIntegrationTest {
+
+    private static final int[] BATCH_SIZES = {100, 500, 1_000};
+    private static final int MEASUREMENT_RUNS = 3;
+    private static final RssFeedConfig.FeedSource RSS_FEED = new RssFeedConfig.FeedSource(
+            "https://fixture.example/rss", "gb", "en", "Fixture RSS", "general"
+    );
+
+    @Container
+    @ServiceConnection
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
+            .withUsername("root")
+            .withPassword("test");
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private SourceRepository sourceRepository;
+
+    @Autowired
+    private SourceService sourceService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    private Statistics statistics;
+
+    @BeforeEach
+    void setUp() {
+        statistics = entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+        clearTables();
+    }
+
+    @Test
+    void newsApiBatchMeasuresNewSaveAndDuplicateRerunAtIncreasingSizes() {
+        warmUpNewsApi();
+
+        for (int size : BATCH_SIZES) {
+            List<BatchMeasurement> measurements = new ArrayList<>();
+            for (int run = 1; run <= MEASUREMENT_RUNS; run++) {
+                measurements.add(measureNewsBatch(size, run));
+            }
+            printMedian("news-api", size, measurements);
+        }
+    }
+
+    @Test
+    void rssBatchMeasuresNewSaveAndDuplicateRerunAtIncreasingSizes() {
+        warmUpRss();
+
+        for (int size : BATCH_SIZES) {
+            List<BatchMeasurement> measurements = new ArrayList<>();
+            for (int run = 1; run <= MEASUREMENT_RUNS; run++) {
+                measurements.add(measureRssBatch(size, run));
+            }
+            printMedian("rss", size, measurements);
+        }
+    }
+
+    @Test
+    void mixedNewsApiBatchClassifiesInvalidAndDuplicateArticles() {
+        clearTables();
+        NewsApiService service = newsApiService(mock(NewsFetchConfig.class));
+        service.processArticlesWithStats(validNewsArticles(100, "existing"), "us", "general");
+
+        List<NewsApiArticleDto> mixed = mixedNewsArticles();
+        statistics.clear();
+        long startedAt = System.nanoTime();
+
+        CollectionBatchStats stats = service.processArticlesWithStats(mixed, "us", "general");
+        double elapsedMs = elapsedMs(startedAt);
+        long statements = statistics.getPrepareStatementCount();
+
+        assertThat(stats.receivedCount()).isEqualTo(1_000);
+        assertThat(stats.invalidCount()).isEqualTo(100);
+        assertThat(stats.duplicateCount()).isEqualTo(200);
+        assertThat(stats.savedCount()).isEqualTo(700);
+        assertThat(articleCount()).isEqualTo(800);
+        assertThat(duplicateUrlGroupCount()).isZero();
+
+        System.out.printf(
+                "COLLECTION_BATCH provider=news-api mode=mixed received=%d invalid=%d duplicate=%d saved=%d statements=%d elapsedMs=%.2f rowsPerSecond=%.2f%n",
+                stats.receivedCount(),
+                stats.invalidCount(),
+                stats.duplicateCount(),
+                stats.savedCount(),
+                statements,
+                elapsedMs,
+                rowsPerSecond(stats.receivedCount(), elapsedMs)
+        );
+    }
+
+    @Test
+    void sequentialMockUpstreamMeasuresSlowAndFailedSourcePropagation() throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        ExecutorService executor = Executors.newCachedThreadPool();
+        ObjectMapper objectMapper = new ObjectMapper();
+        List<String> requestOrder = Collections.synchronizedList(new ArrayList<>());
+        server.createContext("/v2/top-headlines",
+                exchange -> handleMockUpstream(exchange, objectMapper, requestOrder));
+        server.setExecutor(executor);
+        server.start();
+
+        try {
+            String mockBaseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+            List<Double> controlRuns = measureMockUpstreamScenario(
+                    mockBaseUrl,
+                    requestOrder,
+                    List.of("fast-a", "fast-c", "failure", "fast-b"),
+                    "control"
+            );
+            List<Double> delayedRuns = measureMockUpstreamScenario(
+                    mockBaseUrl,
+                    requestOrder,
+                    List.of("fast-a", "slow", "failure", "fast-b"),
+                    "delayed"
+            );
+            double controlMedianMs = median(controlRuns);
+            double delayedMedianMs = median(delayedRuns);
+            System.out.printf(
+                    "COLLECTION_UPSTREAM_COMPARISON requests=4 saved=75 failures=1 controlElapsedMs=%.2f delayedElapsedMs=%.2f slowDelayMs=300 deltaMs=%.2f%n",
+                    controlMedianMs,
+                    delayedMedianMs,
+                    delayedMedianMs - controlMedianMs
+            );
+        } finally {
+            server.stop(0);
+            executor.shutdownNow();
+        }
+    }
+
+    private BatchMeasurement measureNewsBatch(int size, int run) {
+        clearTables();
+        NewsApiService service = newsApiService(mock(NewsFetchConfig.class));
+        List<NewsApiArticleDto> articles = validNewsArticles(size, "news-" + size + "-" + run);
+
+        statistics.clear();
+        long newStartedAt = System.nanoTime();
+        CollectionBatchStats newStats = service.processArticlesWithStats(articles, "us", "general");
+        double newElapsedMs = elapsedMs(newStartedAt);
+        long newStatements = statistics.getPrepareStatementCount();
+
+        assertThat(newStats.savedCount()).isEqualTo(size);
+        assertThat(newStats.invalidCount()).isZero();
+        assertThat(newStats.duplicateCount()).isZero();
+        assertThat(articleCount()).isEqualTo(size);
+
+        statistics.clear();
+        long rerunStartedAt = System.nanoTime();
+        CollectionBatchStats rerunStats = service.processArticlesWithStats(articles, "us", "general");
+        double rerunElapsedMs = elapsedMs(rerunStartedAt);
+        long rerunStatements = statistics.getPrepareStatementCount();
+
+        assertThat(rerunStats.savedCount()).isZero();
+        assertThat(rerunStats.duplicateCount()).isEqualTo(size);
+        assertThat(articleCount()).isEqualTo(size);
+        assertThat(duplicateUrlGroupCount()).isZero();
+
+        return new BatchMeasurement(
+                newElapsedMs, newStatements, rerunElapsedMs, rerunStatements
+        );
+    }
+
+    private BatchMeasurement measureRssBatch(int size, int run) {
+        clearTables();
+        RssNewsService service = rssNewsService();
+        Elements items = rssItems(size, "rss-" + size + "-" + run);
+
+        statistics.clear();
+        long newStartedAt = System.nanoTime();
+        CollectionBatchStats newStats = service.processItemsWithStats(RSS_FEED, items);
+        double newElapsedMs = elapsedMs(newStartedAt);
+        long newStatements = statistics.getPrepareStatementCount();
+
+        assertThat(newStats.savedCount()).isEqualTo(size);
+        assertThat(newStats.invalidCount()).isZero();
+        assertThat(newStats.duplicateCount()).isZero();
+        assertThat(articleCount()).isEqualTo(size);
+
+        statistics.clear();
+        long rerunStartedAt = System.nanoTime();
+        CollectionBatchStats rerunStats = service.processItemsWithStats(RSS_FEED, items);
+        double rerunElapsedMs = elapsedMs(rerunStartedAt);
+        long rerunStatements = statistics.getPrepareStatementCount();
+
+        assertThat(rerunStats.savedCount()).isZero();
+        assertThat(rerunStats.duplicateCount()).isEqualTo(size);
+        assertThat(articleCount()).isEqualTo(size);
+        assertThat(duplicateUrlGroupCount()).isZero();
+
+        return new BatchMeasurement(
+                newElapsedMs, newStatements, rerunElapsedMs, rerunStatements
+        );
+    }
+
+    private void warmUpNewsApi() {
+        NewsApiService service = newsApiService(mock(NewsFetchConfig.class));
+        service.processArticlesWithStats(validNewsArticles(20, "warmup-news"), "us", "general");
+        clearTables();
+    }
+
+    private void warmUpRss() {
+        rssNewsService().processItemsWithStats(RSS_FEED, rssItems(20, "warmup-rss"));
+        clearTables();
+    }
+
+    private List<NewsApiArticleDto> validNewsArticles(int count, String prefix) {
+        List<NewsApiArticleDto> articles = new ArrayList<>(count);
+        for (int index = 0; index < count; index++) {
+            articles.add(newsArticle(
+                    "https://fixture.example/" + prefix + "/" + index,
+                    prefix + " article " + index,
+                    "Fixture Source " + (index % 10),
+                    true
+            ));
+        }
+        return articles;
+    }
+
+    private List<NewsApiArticleDto> mixedNewsArticles() {
+        List<NewsApiArticleDto> articles = new ArrayList<>(1_000);
+        articles.addAll(validNewsArticles(700, "mixed-new"));
+        articles.addAll(validNewsArticles(100, "existing"));
+        for (int index = 0; index < 100; index++) {
+            articles.add(newsArticle(
+                    "https://fixture.example/mixed-new/" + index,
+                    "duplicate article " + index,
+                    "Fixture Source " + (index % 10),
+                    true
+            ));
+        }
+        for (int index = 0; index < 100; index++) {
+            articles.add(newsArticle(
+                    "",
+                    "invalid article " + index,
+                    "Fixture Source " + (index % 10),
+                    false
+            ));
+        }
+        return articles;
+    }
+
+    private NewsApiArticleDto newsArticle(
+            String url,
+            String title,
+            String sourceName,
+            boolean valid
+    ) {
+        NewsApiSourceDto source = new NewsApiSourceDto();
+        source.setName(sourceName);
+
+        NewsApiArticleDto article = new NewsApiArticleDto();
+        article.setAuthor("fixture-author");
+        article.setTitle(title);
+        article.setDescription("fixture-description");
+        article.setContent("fixture-content");
+        article.setUrl(url);
+        article.setUrlToImage("https://fixture.example/image.jpg");
+        article.setPublishedAt(valid ? "2026-07-25T10:00:00Z" : null);
+        article.setSource(source);
+        return article;
+    }
+
+    private Elements rssItems(int count, String prefix) {
+        StringBuilder xml = new StringBuilder("<rss><channel>");
+        for (int index = 0; index < count; index++) {
+            xml.append("<item>")
+                    .append("<link>https://fixture.example/").append(prefix).append("/").append(index).append("</link>")
+                    .append("<title>").append(prefix).append(" article ").append(index).append("</title>")
+                    .append("<pubDate>Sat, 25 Jul 2026 10:00:00 GMT</pubDate>")
+                    .append("<description>fixture-description</description>")
+                    .append("</item>");
+        }
+        xml.append("</channel></rss>");
+        return Jsoup.parse(xml.toString(), "", Parser.xmlParser()).select("item");
+    }
+
+    private NewsApiService newsApiService(NewsFetchConfig config) {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(1_000);
+        requestFactory.setReadTimeout(1_000);
+        NewsApiService service = new NewsApiService(
+                new RestTemplate(requestFactory),
+                articleRepository,
+                sourceRepository,
+                mock(ArticleService.class),
+                sourceService,
+                config
+        );
+        ReflectionTestUtils.setField(service, "apiKey", "fixture-api-key");
+        return service;
+    }
+
+    private RssNewsService rssNewsService() {
+        return new RssNewsService(
+                articleRepository,
+                sourceService,
+                mock(RssFeedConfig.class)
+        );
+    }
+
+    private List<Double> measureMockUpstreamScenario(
+            String mockBaseUrl,
+            List<String> requestOrder,
+            List<String> categories,
+            String scenario
+    ) {
+        List<Double> elapsedRuns = new ArrayList<>();
+        for (int run = 1; run <= MEASUREMENT_RUNS; run++) {
+            clearTables();
+            requestOrder.clear();
+            NewsApiService service = newsApiService(mockUpstreamConfig(categories));
+            ReflectionTestUtils.setField(service, "newsApiBaseUrl", mockBaseUrl);
+            statistics.clear();
+            long startedAt = System.nanoTime();
+
+            service.fetchTopHeadlines(false);
+
+            double elapsedMs = elapsedMs(startedAt);
+            long statements = statistics.getPrepareStatementCount();
+            elapsedRuns.add(elapsedMs);
+            assertThat(requestOrder).containsExactlyElementsOf(categories);
+            assertThat(articleCount()).isEqualTo(75);
+            assertThat(duplicateUrlGroupCount()).isZero();
+            System.out.printf(
+                    "COLLECTION_UPSTREAM scenario=%s run=%d requests=%d saved=75 failures=1 statements=%d elapsedMs=%.2f%n",
+                    scenario,
+                    run,
+                    requestOrder.size(),
+                    statements,
+                    elapsedMs
+            );
+        }
+        return elapsedRuns;
+    }
+
+    private NewsFetchConfig mockUpstreamConfig(List<String> categories) {
+        NewsFetchConfig config = mock(NewsFetchConfig.class);
+        when(config.getCountries()).thenReturn(List.of("us"));
+        when(config.getCategories()).thenReturn(categories);
+        when(config.getPageSize()).thenReturn(25);
+        when(config.getMaxRequestsPerRun()).thenReturn(10);
+        when(config.getRequestDelayMs()).thenReturn(0L);
+        return config;
+    }
+
+    private void handleMockUpstream(
+            HttpExchange exchange,
+            ObjectMapper objectMapper,
+            List<String> requestOrder
+    ) throws IOException {
+        String category = queryParameters(exchange).get("category");
+        requestOrder.add(category);
+        if ("slow".equals(category)) {
+            sleep(300);
+        }
+        if ("failure".equals(category)) {
+            exchange.sendResponseHeaders(500, -1);
+            exchange.close();
+            return;
+        }
+
+        NewsApiResponseDto response = new NewsApiResponseDto();
+        response.setStatus("ok");
+        response.setTotalResults(25);
+        response.setArticles(validNewsArticles(25, "upstream-" + category));
+        byte[] body = objectMapper.writeValueAsBytes(response);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, body.length);
+        try {
+            exchange.getResponseBody().write(body);
+        } finally {
+            exchange.close();
+        }
+    }
+
+    private Map<String, String> queryParameters(HttpExchange exchange) {
+        return java.util.Arrays.stream(exchange.getRequestURI().getRawQuery().split("&"))
+                .map(parameter -> parameter.split("=", 2))
+                .collect(java.util.stream.Collectors.toMap(
+                        pair -> URLDecoder.decode(pair[0], StandardCharsets.UTF_8),
+                        pair -> pair.length == 2
+                                ? URLDecoder.decode(pair[1], StandardCharsets.UTF_8)
+                                : ""
+                ));
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void printMedian(String provider, int size, List<BatchMeasurement> measurements) {
+        double newElapsedMedian = medianDouble(measurements, BatchMeasurement::newElapsedMs);
+        long newStatementsMedian = medianLong(measurements, BatchMeasurement::newStatements);
+        double rerunElapsedMedian = medianDouble(measurements, BatchMeasurement::rerunElapsedMs);
+        long rerunStatementsMedian = medianLong(measurements, BatchMeasurement::rerunStatements);
+        System.out.printf(
+                "COLLECTION_BATCH_MEDIAN provider=%s size=%d newSaved=%d newStatements=%d newElapsedMs=%.2f newRowsPerSecond=%.2f rerunSaved=0 rerunDuplicates=%d rerunStatements=%d rerunElapsedMs=%.2f rerunRowsPerSecond=%.2f%n",
+                provider,
+                size,
+                size,
+                newStatementsMedian,
+                newElapsedMedian,
+                rowsPerSecond(size, newElapsedMedian),
+                size,
+                rerunStatementsMedian,
+                rerunElapsedMedian,
+                rowsPerSecond(size, rerunElapsedMedian)
+        );
+    }
+
+    private double medianDouble(
+            List<BatchMeasurement> measurements,
+            ToDoubleFunction<BatchMeasurement> extractor
+    ) {
+        return measurements.stream()
+                .mapToDouble(extractor)
+                .sorted()
+                .skip(measurements.size() / 2)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private long medianLong(
+            List<BatchMeasurement> measurements,
+            ToLongFunction<BatchMeasurement> extractor
+    ) {
+        return measurements.stream()
+                .mapToLong(extractor)
+                .sorted()
+                .skip(measurements.size() / 2)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private double median(List<Double> values) {
+        return values.stream()
+                .mapToDouble(Double::doubleValue)
+                .sorted()
+                .skip(values.size() / 2)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private double elapsedMs(long startedAt) {
+        return (System.nanoTime() - startedAt) / 1_000_000.0;
+    }
+
+    private double rowsPerSecond(int rows, double elapsedMs) {
+        return rows * 1_000.0 / elapsedMs;
+    }
+
+    private int articleCount() {
+        Integer count = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM article", Integer.class);
+        return count == null ? 0 : count;
+    }
+
+    private int duplicateUrlGroupCount() {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM (" +
+                        "SELECT url_hash FROM article GROUP BY url_hash HAVING COUNT(*) > 1" +
+                        ") duplicate_urls",
+                Integer.class
+        );
+        return count == null ? 0 : count;
+    }
+
+    private void clearTables() {
+        jdbcTemplate.update("DELETE FROM article");
+        jdbcTemplate.update("DELETE FROM source");
+        if (statistics != null) {
+            statistics.clear();
+        }
+    }
+
+    private record BatchMeasurement(
+            double newElapsedMs,
+            long newStatements,
+            double rerunElapsedMs,
+            long rerunStatements
+    ) {
+    }
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #233

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- MySQL 8 Testcontainers에서 미리 생성된 News DTO와 미리 파싱된 RSS `Elements` 100·500·1,000건의 신규 저장과 동일 배치 재실행을 3회 측정하고 중앙값을 기록했습니다.
- 정상 신규, DB 기존 URL, 응답 내부 중복, invalid를 합친 1,000건 fixture가 `700 saved / 200 duplicate / 100 invalid`로 분류되는지 검증했습니다.
- random-port mock News API에서 동일한 4요청·75저장·5xx 1건 조건의 all-fast 대조군과 300ms 지연군을 비교했습니다.
- 측정 결과, Kafka 보류 근거, Phase 1 잔여 안정성·문서 로드맵을 backend improvement 문서와 진척 문서에 반영했습니다.

## 🔍 기술적 배경
- 기존 수집 경로는 URL 일괄 중복 조회, `saveAll`, source별 실패 격리와 수집 통계를 갖췄지만 배치 규모별 MySQL 처리량과 순차 source 지연 전파 수치가 없었습니다.
- News 규모별 elapsed는 DTO fixture 생성을 완료한 뒤 `processArticlesWithStats()` 호출 직전에 시작하며, RSS elapsed는 XML 생성·Jsoup parsing을 완료한 `Elements`를 만든 뒤 `processItemsWithStats()` 호출 직전에 시작합니다. fixture 생성·파싱 시간은 두 수치에서 제외됩니다.
- mock upstream 비교만 `fetchTopHeadlines()` 호출 직전에 timer를 시작해 local HTTP 요청, JSON 역직렬화, service 처리와 JPA/MySQL 저장까지 전체 News API 경로를 포함합니다.
- SQL 콘솔 출력 시간을 DB 처리 시간으로 오인하지 않도록 측정 테스트에서만 `@DataJpaTest(showSql = false)`를 사용하고 Hibernate statistics는 유지했습니다.
- 최종 집중 측정에서 신규 1,000건은 News API fixture `4,244.38ms / 1,022 statements`, RSS fixture `2,860.14ms / 1,003 statements`였습니다.
- 동일 배치 재실행은 각각 `53.83ms / 1 statement`, `56.15ms / 2 statements`, 추가 저장 0건이었습니다.
- all-fast `506.69ms` 대비 300ms 지연 source 포함 `790.89ms`로 `284.20ms` 증가했고, 중간 5xx 이후 source 저장은 계속됐습니다.
- 통제된 1,000건 처리가 4/6시간 scheduler와 겹칠 근거가 없어 Kafka·durable queue는 보류했습니다.

## 🧪 테스트/검증 (필수)
- [x] `CollectionBatchPerformanceIntegrationTest` 4개 집중 테스트 통과
- [x] 전체 Gradle 테스트 91개 통과 (`failures=0`, `errors=0`)
- [x] MySQL Testcontainers에서 신규 저장, 중복 재실행 저장 0건, URL 중복 group 0건 검증
- [x] 실제 News API/RSS/번역/Gemini 호출 0회 및 `news-fetch.enabled=false` 유지

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop`)
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 운영 코드·DB schema/index·API·scheduler 동작이 변경되지 않았는가?

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
- fixture 생성 메서드와 실제 서비스 호출 경계가 배치 처리량을 재현하기에 적절한지 확인해 주세요.
- 시간 기반 assertion 없이 저장·중복·실패 격리를 회귀 조건으로 고정했는지 확인해 주세요.
- DTO·Elements 이후 서비스/DB 측정과 mock HTTP 전체 경로를 구분하고, 로컬 합성 수치를 운영 capacity나 Kafka 도입 근거로 과장하지 않았는지 확인해 주세요.

## ➕ 추후 계획(선택)
- #233은 Phase 1 수집 안정성·처리량 기준선을 마무리합니다.
- 프로젝트 전체 Phase 1은 `Trend Gemini prompt·timeout·오류 정책 → Trend Redis 갱신 데이터 보존 → Phase 1 구조·정량 근거 맵과 README 최신화` 순서로 완료합니다.
- 지속 backlog, scheduler 실행 중첩, replay, 독립 consumer scale-out 요구가 확인될 때 Phase 2에서 durable message queue를 검토합니다.
- 수만 건에서 기사별 INSERT가 DB 병목으로 확인되면 Kafka보다 insert batching 또는 저장 단위 조정을 먼저 비교합니다.
