### PR TITLE
🐛 [FIX/#235] Trend Gemini timeout 및 오류 정책 보강

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -13,9 +13,10 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ### P1. Trend Gemini prompt·timeout·오류 정책 보강
 
-- 상태: `Backlog`
+- 상태: `Done` ([#235](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/235), [PR #236](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/236))
 - 근거: 사용자 요청 경로의 `TrendAiService` system prompt가 `?` 문자로 손상돼 있고, Gemini `.block()` 호출에 timeout과 upstream·timeout·내부 오류 분리가 없다.
 - 범위: prompt 복구, configurable timeout, mock WebClient 회귀 테스트와 오류 정책으로 제한한다. 실제 Gemini, async 전환, queue·Kafka는 제외한다.
+- 결과: 기존 `gemini.timeout-ms`를 재사용하고 Gemini non-2xx 502, timeout 504, 응답 처리 실패 500으로 구분했다. cache hit와 Redis 장애 fallback을 포함한 집중 테스트 7개 및 Backend CI 전체 테스트가 통과했다.
 
 ### P1. Trend Redis 갱신 시 기존 데이터 보존
 

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -9,12 +9,19 @@
 
 ## Recently Completed
 
+- #235 / PR #236: `Done`
+- 결과: 손상된 Trend Gemini prompt를 복구하고 기존 `gemini.timeout-ms`를 적용해 non-2xx 502, timeout 504, 내부 응답 처리 오류 500 계약을 고정했다.
+- 캐시: cache hit는 Gemini를 생략하며 Redis read 실패 fallback과 write 실패 시 정상 summary 반환을 유지했다.
+- 검증: mock HTTP·Redis 집중 테스트 7개, Docker 비의존 58개 테스트와 Backend CI 전체 테스트가 통과했고 AI Reviewer는 Blocking 없음·MERGE_READY로 판정했다.
+- 범위: 실제 Gemini·async·retry·circuit breaker·queue·Kafka·캐시 정책·Issue #110은 제외했다.
+- Phase 1 잔여 순서: Trend Redis 갱신 데이터 보존 → Phase 1 구조·정량 근거 맵과 README 최신화.
+
 - #233 / PR #234: `Done`
 - 결과: RSS/News API의 100·500·1,000건 신규 저장·중복 재실행과 mock upstream 순차 지연 전파를 MySQL Testcontainers에서 측정했다.
 - 측정: 신규 1,000건은 News API 4,244.38ms·1,022 statements, RSS 2,860.14ms·1,003 statements였다. 재실행은 각각 53.83ms·1 statement, 56.15ms·2 statements와 저장 0건이었다.
 - 지연 전파: 동일 4요청·75저장·5xx 1건에서 all-fast 506.69ms, 300ms 지연 source 포함 790.89ms, 차이 284.20ms였다. 5xx 이후 source는 계속 처리됐다.
 - 판단: 4/6시간 scheduler와 겹칠 근거가 없어 Kafka·durable queue는 보류했다. 집중 4개·전체 91개 테스트와 Backend CI가 통과했고 AI Reviewer는 Blocking 수정 재검토 후 MERGE_READY로 판정했다.
-- Phase 1 잔여 순서: Trend Gemini prompt·timeout·오류 정책 → Trend Redis 갱신 데이터 보존 → Phase 1 구조·정량 근거 맵과 README 최신화.
+- Phase 1 종료선은 위 #235 완료 결과와 잔여 순서를 기준으로 판단한다.
 - 범위: 테스트·fixture·측정 문서만 변경했으며 실제 API, flag, 운영 DB, production code, schema/index, scheduler, Kafka·queue·retry·Issue #110은 제외했다.
 
 - #231 / PR #232: `Done`

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -9,6 +9,18 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Recently Completed
 
+### #235 - Trend Gemini 프롬프트 인코딩 및 timeout·오류 정책 보강
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/235
+- 작업 브랜치: `fix/#235-trend-gemini-error-policy`
+- 상태: `Done` ([PR #236](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/236))
+- 기준선: Trend 기사 요약의 system prompt가 손상돼 있고 외부 Gemini 호출에 timeout과 오류 원인별 HTTP 계약이 없었다.
+- 결과: 요청 언어와 2문장 조건을 포함한 prompt를 복구하고 기존 `gemini.timeout-ms`를 재사용해 Gemini non-2xx 502, timeout 504, 응답 처리 실패 500으로 구분했다.
+- 캐시 경계: cache hit는 외부 호출을 생략하고 Redis read 실패는 Gemini로 fallback하며, write 실패는 생성된 summary 응답을 유지한다.
+- 검증: mock HTTP·Redis 집중 테스트 7개와 Docker 비의존 58개 테스트, GitHub Backend CI 전체 테스트가 통과했다. AI Reviewer는 Blocking 없음·MERGE_READY로 판정했다.
+- overengineering 판단: 실제 Gemini, 비동기 전환, retry·circuit breaker, queue·Kafka, 캐시 키·TTL 변경과 Issue #110은 제외했다.
+- 작업 문서: `docs/backend-improvement/trend-gemini-error-policy.md`
+
 ### #233 - RSS/News API 수집 배치 처리량 및 지연 전파 기준선 측정
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/233

--- a/docs/backend-improvement/trend-gemini-error-policy.md
+++ b/docs/backend-improvement/trend-gemini-error-policy.md
@@ -1,0 +1,45 @@
+# Trend Gemini 요청 오류 정책
+
+## 문제
+
+Trend 기사 요약 경로의 system prompt가 손상된 문자열로 전송되고 있었다. 또한 Gemini 호출에 제한 시간이 없고 외부 서비스의 비정상 응답, timeout, 내부 응답 처리 실패가 모두 500으로 보일 수 있었다.
+
+## 적용 범위
+
+- 요청 언어와 2문장 요약 조건을 포함한 system prompt 복구
+- 기사 요약 경로와 동일한 `gemini.timeout-ms` 설정 사용
+- Gemini 4xx/5xx를 502 Bad Gateway로 변환
+- timeout을 504 Gateway Timeout으로 변환
+- 응답 파싱과 내부 처리 실패는 500 Internal Server Error 유지
+- Redis cache hit, cache read fallback, cache write 실패 시 응답 유지 정책 보존
+
+## 검증 방법
+
+실제 Gemini API와 운영 Redis는 호출하지 않는다. random port에서 실행한 JDK `HttpServer`가 Gemini 성공, 500, 지연, 비정상 JSON 응답을 재현하고 Mockito Redis fixture가 cache hit와 장애 조건을 재현한다.
+
+요청 본문을 mock server에서 캡처해 기사 본문, 선택 언어, `2 sentences` 조건이 포함되고 손상된 `??` 문자열이 없는지도 검증한다.
+
+## 오류 계약
+
+| 조건 | HTTP 상태 | 의미 |
+| --- | ---: | --- |
+| 정상 Gemini 응답 | 200 | 요약 반환 및 가능한 경우 Redis 저장 |
+| 기사 크롤링 불가 | 400 | 기존 crawler 정책 유지 |
+| Gemini 4xx/5xx | 502 | 외부 AI 서비스 응답 실패 |
+| Gemini 제한 시간 초과 | 504 | 외부 AI 서비스 응답 지연 |
+| 응답 구조 오류·내부 실패 | 500 | 서버 내부 처리 실패 |
+
+## 제외 범위
+
+Trend controller의 동기 처리 방식은 유지한다. 비동기 executor, retry, circuit breaker, queue, Kafka, cache key·TTL 변경은 별도 측정 근거 없이 추가하지 않는다.
+
+## 검증 결과
+
+- mock HTTP·Redis 집중 테스트 7개 통과
+- Docker 비의존 14개 클래스 58개 테스트 통과, 실패·오류·skip 0건
+- GitHub Backend CI 전체 Gradle test 통과
+- AI Reviewer: Blocking 없음, MERGE_READY
+
+로컬 전체 suite는 Docker daemon의 CLI 무응답으로 Testcontainers 실행 전에 중단됐고, 동일 commit의 전체 suite를 GitHub CI에서 검증했다.
+
+연결 거부나 DNS 실패처럼 HTTP 응답 이전에 발생하는 transport 예외는 현재 내부 오류 500으로 처리된다. 이번 이슈는 non-2xx 응답과 timeout 계약을 대상으로 하므로 transport 오류 재분류는 후속 검토 대상으로 남긴다.

--- a/src/main/java/com/example/globalTimes_be/domain/trend/controller/TrendAiControllerDocs.java
+++ b/src/main/java/com/example/globalTimes_be/domain/trend/controller/TrendAiControllerDocs.java
@@ -10,71 +10,85 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@Tag(name = "실시간 검색어 페이지", description = "실시간 검색어 관련 API입니다.")
+@Tag(name = "실시간 검색어 페이지", description = "실시간 검색어 관련 API")
 public interface TrendAiControllerDocs {
 
-    @Operation(summary = "기사 요약",
-            description = "해당 기사에 대한 요약을 한번에 반환합니다.")
+    @Operation(
+            summary = "Trend 기사 요약",
+            description = "기사 본문을 요청한 언어로 두 문장 이내로 요약합니다."
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "응답 성공",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = com.example.globalTimes_be.global.apiPayload.code.ApiResponse.class),
-                            examples = @ExampleObject(value = """
-                                {
-                                    "timestamp": "2025-04-01T15:41:45.2180857",
-                                    "isSuccess": true,
-                                    "message": "응답에 성공했습니다.",
-                                    "data": "국가정보원이 최근 5년간 공공기관의 인공지능(AI) 정보화사업 실태를 조사하기 시작했으며, 이는 AI 기술의 안전한 운용과 보안 강화 방안을 모색하기 위한 차원이다. 이번 조사는 공공기관의 AI 활용 확대에 따른 보안 체계 정비를 목적으로 하고 있다."
-                                }
-                            """)
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "요약 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(
+                                    implementation = com.example.globalTimes_be.global.apiPayload.code.ApiResponse.class
+                            )
                     )
             ),
-            @ApiResponse(responseCode = "400", description = "크롤링 불가",
-                    content = @Content(mediaType = "application/json",
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "기사 크롤링 불가",
+                    content = @Content(
+                            mediaType = "application/json",
                             examples = @ExampleObject(value = """
-                                {
-                                     "timestamp": "2025-04-01T13:37:56.6982049",
-                                     "isSuccess": false,
-                                     "message": "해당 언론사는 요약 정보 제공이 불가능합니다. (크롤링 불가)"
-                                 }
-                                """)
-                    )
-            ),
-            @ApiResponse(responseCode = "500", description = "서버 에러가 발생하였습니다.",
-                    content = @Content(mediaType = "application/json",
-                            examples = {
-                                @ExampleObject(name="서버 에러", value = """
                                     {
-                                      "timestamp": "2024-10-30T15:38:12.43483271",
                                       "isSuccess": false,
-                                      "message": "서버 에러가 발생하였습니다.",
-                                      "data": null
-                                    }
-                                    """),
-                                @ExampleObject(name = "gpt 에러", value = """
-                                    {
-                                      "timestamp": "2024-10-30T15:40:00.12345678",
-                                      "isSuccess": false,
-                                      "message": "GPT 요약 중 에러가 발생하였습니다.",
-                                      "data": null
+                                      "message": "해당 언론사는 요약 정보 제공이 불가능합니다. (크롤링 불가)"
                                     }
                                     """)
-                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "502",
+                    description = "외부 AI 요약 서비스 응답 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "message": "외부 AI 요약 서비스 응답에 실패했습니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "504",
+                    description = "외부 AI 요약 서비스 응답 시간 초과",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "message": "외부 AI 요약 서비스 응답 시간이 초과되었습니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "AI 요약 내부 처리 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "message": "AI 요약 처리 중 내부 오류가 발생했습니다."
+                                    }
+                                    """)
                     )
             )
     })
-    public ResponseEntity<?> getSummarizeTrendArticle(
-            @Parameter(description = "뉴스기사 url", example = "https://www.etnews.com/20...")
-            @NotNull(message = "뉴스기사 url은 비어있을 수 없습니다.")
-            @PathVariable String url,
+    ResponseEntity<?> getSummarizeTrendArticle(
+            @Parameter(description = "뉴스 기사 URL", example = "https://www.example.com/news/1")
+            @NotNull(message = "뉴스 기사 URL은 필수입니다.")
+            @RequestParam String url,
 
-            @Parameter(description = "언어 설정 (기본값: 영어)", examples = {
-                    @ExampleObject(name = "영어", value = "영어"),
-                    @ExampleObject(name = "한국어", value = "한국어"),
-                    @ExampleObject(name = "중국어", value = "중국어")})
-            @RequestParam String language);
-
+            @Parameter(description = "요약 언어", example = "Korean")
+            @RequestParam String language
+    );
 }

--- a/src/main/java/com/example/globalTimes_be/domain/trend/exception/TrendErrorStatus.java
+++ b/src/main/java/com/example/globalTimes_be/domain/trend/exception/TrendErrorStatus.java
@@ -9,14 +9,13 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum TrendErrorStatus implements BaseResponse {
     _CUSTOM_ERROR(HttpStatus.BAD_REQUEST, "에러테스트 요청입니다."),
-
     _INVALID_COUNTRY_CODE(HttpStatus.BAD_REQUEST, "잘못된 국가 코드입니다."),
     _FAIL_SERIALIZATION(HttpStatus.INTERNAL_SERVER_ERROR, "직렬화에 실패하였습니다."),
     _FAIL_DESERIALIZATION(HttpStatus.INTERNAL_SERVER_ERROR, "역직렬화에 실패하였습니다."),
-
     _CRAWLER_ERROR(HttpStatus.BAD_REQUEST, "해당 언론사는 요약 정보 제공이 불가능합니다. (크롤링 불가)"),
-
-    _GPT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GPT 요약 중 에러가 발생하였습니다."),
+    _GEMINI_UPSTREAM_ERROR(HttpStatus.BAD_GATEWAY, "외부 AI 요약 서비스 응답에 실패했습니다."),
+    _GEMINI_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "외부 AI 요약 서비스 응답 시간이 초과되었습니다."),
+    _GPT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI 요약 처리 중 내부 오류가 발생했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/globalTimes_be/domain/trend/service/TrendAiService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/trend/service/TrendAiService.java
@@ -9,12 +9,15 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.time.Duration;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -31,6 +34,9 @@ public class TrendAiService {
     @Value("${gemini.api-key}")
     private String geminiApiKey;
 
+    @Value("${gemini.timeout-ms:10000}")
+    private long geminiTimeoutMs;
+
     private final RedisUtil redisUtil;
 
     @Value("${trend.summary-cache-ttl-seconds:21600}")
@@ -42,11 +48,12 @@ public class TrendAiService {
             try {
                 String cached = redisUtil.getData(cacheKey);
                 if (cached != null) {
-                    log.debug("[??? ??] ?? ?? url={}", url);
+                    log.debug("[Trend summary] cacheHit=true url={}", url);
                     return cached;
                 }
             } catch (Exception e) {
-                log.warn("[??? ??] ?? ?? ??, Gemini ??: {}", e.getMessage());
+                log.warn("[Trend summary] cacheReadFailed=true fallback=gemini type={}",
+                        e.getClass().getSimpleName());
             }
 
             String summary = callGemini(content, language);
@@ -54,7 +61,8 @@ public class TrendAiService {
             try {
                 redisUtil.setData(cacheKey, summary, cacheTtlSeconds);
             } catch (Exception e) {
-                log.warn("[??? ??] ?? ?? ?? (??): {}", e.getMessage());
+                log.warn("[Trend summary] cacheWriteFailed=true responsePreserved=true type={}",
+                        e.getClass().getSimpleName());
             }
             return summary;
         }
@@ -63,22 +71,55 @@ public class TrendAiService {
     }
 
     private String callGemini(String content, String language) {
-        Map<String, Object> requestBody = Map.of(
+        return geminiWebClient.post()
+                .uri("/v1beta/models/" + GEMINI_MODEL + ":generateContent?key=" + geminiApiKey)
+                .bodyValue(createGeminiRequestBody(content, language))
+                .retrieve()
+                .onStatus(
+                        status -> !status.is2xxSuccessful(),
+                        response -> {
+                            log.warn("[Trend Gemini] upstreamError=true status={}",
+                                    response.statusCode().value());
+                            return response.releaseBody()
+                                    .then(Mono.error(new BaseException(
+                                            TrendErrorStatus._GEMINI_UPSTREAM_ERROR.getResponse()
+                                    )));
+                        }
+                )
+                .bodyToMono(Map.class)
+                .timeout(Duration.ofMillis(geminiTimeoutMs))
+                .onErrorMap(
+                        TimeoutException.class,
+                        ex -> {
+                            log.warn("[Trend Gemini] timeout=true timeoutMs={}", geminiTimeoutMs);
+                            return new BaseException(TrendErrorStatus._GEMINI_TIMEOUT.getResponse());
+                        }
+                )
+                .onErrorMap(
+                        ex -> !(ex instanceof BaseException),
+                        ex -> {
+                            log.error("[Trend Gemini] internalError=true type={}",
+                                    ex.getClass().getSimpleName());
+                            return new BaseException(TrendErrorStatus._GPT_ERROR.getResponse());
+                        }
+                )
+                .map(this::extractGeminiContent)
+                .block();
+    }
+
+    private Map<String, Object> createGeminiRequestBody(String content, String language) {
+        String systemPrompt = "You are a news summarization assistant. Summarize the following trend article content in "
+                + language + ". The summary should be concise (2 sentences), written in "
+                + language + ", and capture the key points of the article.";
+
+        return Map.of(
                 "system_instruction", Map.of(
-                        "parts", List.of(Map.of("text", "? ??? " + language + "? 2?? ????."))
+                        "parts", List.of(Map.of("text", systemPrompt))
                 ),
                 "contents", List.of(
                         Map.of("parts", List.of(Map.of("text", content)))
                 )
         );
-
-        return geminiWebClient.post()
-                .uri("/v1beta/models/" + GEMINI_MODEL + ":generateContent?key=" + geminiApiKey)
-                .bodyValue(requestBody)
-                .retrieve()
-                .bodyToMono(Map.class)
-                .map(this::extractGeminiContent)
-                .block();
     }
 
     @SuppressWarnings("unchecked")
@@ -105,38 +146,4 @@ public class TrendAiService {
             return String.valueOf(url.hashCode());
         }
     }
-
-
-    // GPT (??? / ?? ??)
-    // private final WebClient openAiWebClient;
-    //
-    // private String callGpt(String content, String language) {
-    //     return openAiWebClient.post()
-    //             .uri("/chat/completions")
-    //             .bodyValue(createGptRequestBody(content, language))
-    //             .retrieve()
-    //             .bodyToMono(Map.class)
-    //             .map(response -> extractGptContent(response))
-    //             .block();
-    // }
-    //
-    // private Map<String, Object> createGptRequestBody(String content, String language) {
-    //     return Map.of(
-    //             "model", "gpt-4o-mini",
-    //             "messages", List.of(
-    //                     Map.of("role", "system", "content", "? ??? " + language + "? 2?? ????."),
-    //                     Map.of("role", "user", "content", content)
-    //             ),
-    //             "stream", false
-    //     );
-    // }
-    //
-    // private String extractGptContent(Map<String, Object> response) {
-    //     List<Map<String, Object>> choices = (List<Map<String, Object>>) response.get("choices");
-    //     if (choices != null && !choices.isEmpty()) {
-    //         Map<String, Object> message = (Map<String, Object>) choices.get(0).get("message");
-    //         return (String) message.get("content");
-    //     }
-    //     throw new BaseException(TrendErrorStatus._GPT_ERROR.getResponse());
-    // }
 }

--- a/src/test/java/com/example/globalTimes_be/domain/trend/service/TrendAiServiceTest.java
+++ b/src/test/java/com/example/globalTimes_be/domain/trend/service/TrendAiServiceTest.java
@@ -1,0 +1,182 @@
+package com.example.globalTimes_be.domain.trend.service;
+
+import com.example.globalTimes_be.global.exception.BaseException;
+import com.example.globalTimes_be.global.redis.RedisUtil;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TrendAiServiceTest {
+
+    private HttpServer mockServer;
+    private RedisUtil redisUtil;
+    private TrendAiService trendAiService;
+    private final AtomicInteger requestCount = new AtomicInteger();
+    private volatile int responseStatus;
+    private volatile long responseDelayMs;
+    private volatile String responseBody;
+    private volatile String requestBody;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        responseStatus = 200;
+        responseDelayMs = 0;
+        responseBody = """
+                {"candidates":[{"content":{"parts":[{"text":"mock trend summary"}]}}]}
+                """;
+        requestBody = "";
+        requestCount.set(0);
+
+        mockServer = HttpServer.create(new InetSocketAddress(0), 0);
+        mockServer.createContext("/v1beta/models/", this::handleGeminiRequest);
+        mockServer.start();
+
+        WebClient webClient = WebClient.builder()
+                .baseUrl("http://127.0.0.1:" + mockServer.getAddress().getPort())
+                .build();
+        redisUtil = mock(RedisUtil.class);
+        trendAiService = new TrendAiService(webClient, redisUtil);
+        ReflectionTestUtils.setField(trendAiService, "geminiApiKey", "dummy");
+        ReflectionTestUtils.setField(trendAiService, "geminiTimeoutMs", 5000L);
+        ReflectionTestUtils.setField(trendAiService, "cacheTtlSeconds", 0L);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockServer.stop(0);
+    }
+
+    @Test
+    void summarizeTrendArticle_restoresPromptAndReturnsSummary() {
+        String result = trendAiService.summarizeTrendArticle(
+                "trend article content",
+                "Korean",
+                "https://example.com/trend"
+        );
+
+        assertThat(result).isEqualTo("mock trend summary");
+        assertThat(requestBody)
+                .contains("trend article content")
+                .contains("Korean")
+                .contains("2 sentences")
+                .doesNotContain("??");
+    }
+
+    @Test
+    void summarizeTrendArticle_returnsCachedSummaryWithoutGeminiCall() {
+        ReflectionTestUtils.setField(trendAiService, "cacheTtlSeconds", 60L);
+        when(redisUtil.getData(anyString())).thenReturn("cached trend summary");
+
+        String result = trendAiService.summarizeTrendArticle(
+                "trend article content",
+                "English",
+                "https://example.com/trend"
+        );
+
+        assertThat(result).isEqualTo("cached trend summary");
+        assertThat(requestCount).hasValue(0);
+        verify(redisUtil, never()).setData(anyString(), anyString(), anyLong());
+    }
+
+    @Test
+    void summarizeTrendArticle_fallsBackToGeminiWhenCacheReadFails() {
+        ReflectionTestUtils.setField(trendAiService, "cacheTtlSeconds", 60L);
+        when(redisUtil.getData(anyString())).thenThrow(new IllegalStateException("redis unavailable"));
+
+        String result = trendAiService.summarizeTrendArticle(
+                "trend article content",
+                "English",
+                "https://example.com/trend"
+        );
+
+        assertThat(result).isEqualTo("mock trend summary");
+        assertThat(requestCount).hasValue(1);
+    }
+
+    @Test
+    void summarizeTrendArticle_preservesSummaryWhenCacheWriteFails() {
+        ReflectionTestUtils.setField(trendAiService, "cacheTtlSeconds", 60L);
+        doThrow(new IllegalStateException("redis unavailable"))
+                .when(redisUtil).setData(anyString(), anyString(), anyLong());
+
+        String result = trendAiService.summarizeTrendArticle(
+                "trend article content",
+                "English",
+                "https://example.com/trend"
+        );
+
+        assertThat(result).isEqualTo("mock trend summary");
+        assertThat(requestCount).hasValue(1);
+    }
+
+    @Test
+    void summarizeTrendArticle_mapsGeminiFailureToBadGateway() {
+        responseStatus = 500;
+        responseBody = "{\"error\":{\"message\":\"mock failure\"}}";
+
+        assertThatThrownBy(() -> trendAiService.summarizeTrendArticle(
+                "trend article content", "English", null))
+                .isInstanceOfSatisfying(BaseException.class, ex ->
+                        assertThat(ex.getHttpStatus()).isEqualTo(HttpStatus.BAD_GATEWAY));
+    }
+
+    @Test
+    void summarizeTrendArticle_mapsTimeoutToGatewayTimeout() {
+        responseDelayMs = 250;
+        ReflectionTestUtils.setField(trendAiService, "geminiTimeoutMs", 50L);
+
+        assertThatThrownBy(() -> trendAiService.summarizeTrendArticle(
+                "trend article content", "English", null))
+                .isInstanceOfSatisfying(BaseException.class, ex ->
+                        assertThat(ex.getHttpStatus()).isEqualTo(HttpStatus.GATEWAY_TIMEOUT));
+    }
+
+    @Test
+    void summarizeTrendArticle_keepsInvalidResponseAsInternalServerError() {
+        responseBody = "{}";
+
+        assertThatThrownBy(() -> trendAiService.summarizeTrendArticle(
+                "trend article content", "English", null))
+                .isInstanceOfSatisfying(BaseException.class, ex ->
+                        assertThat(ex.getHttpStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR));
+    }
+
+    private void handleGeminiRequest(HttpExchange exchange) throws IOException {
+        requestCount.incrementAndGet();
+        requestBody = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+
+        if (responseDelayMs > 0) {
+            try {
+                Thread.sleep(responseDelayMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(responseStatus, body.length);
+        exchange.getResponseBody().write(body);
+        exchange.close();
+    }
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #235

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [x] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- Trend Gemini system prompt를 요청 언어와 2문장 요약 조건이 명확한 문자열로 복구했습니다.
- 기존 `gemini.timeout-ms`를 재사용하고 Gemini 비정상 응답 502, timeout 504, 응답 처리 실패 500으로 분리했습니다.
- cache hit, Redis read fallback, Redis write 실패 시 정상 응답 유지 동작을 회귀 테스트로 고정했습니다.
- Trend Swagger 응답 계약과 백엔드 개선 진척 문서를 갱신했습니다.

## 🔍 기술적 배경
- 기존 Trend 요약 경로는 손상된 prompt를 실제 Gemini 요청에 포함하고 있었습니다.
- `.block()` 외부 호출에 timeout이 없어 Gemini 장애 시 요청 thread가 무기한 대기할 수 있었고, 오류 원인도 HTTP 응답에서 구분되지 않았습니다.
- 기사 요약 `AiService`에 이미 적용된 WebClient timeout·오류 매핑 방식을 재사용해 변경 범위를 줄였습니다.
- 실제 Gemini, 비동기 전환, retry·circuit breaker, queue·Kafka, cache key·TTL 변경은 이번 범위에서 제외했습니다.

## 🧪 테스트/검증 (필수)
- [x] JDK random-port mock HTTP server로 성공, Gemini 500→502, 지연→504, 비정상 응답→500을 검증했습니다.
- [x] 요청 JSON에 기사 본문, 선택 언어, `2 sentences`가 포함되고 손상 문자열이 제거됐는지 검증했습니다.
- [x] Mockito Redis fixture로 cache hit, read 실패 fallback, write 실패 시 응답 유지를 검증했습니다.
- [x] Docker 비의존 14개 클래스 58개 테스트 통과, 실패·오류·skip 0건
- [x] GitHub Backend CI에서 Testcontainers를 포함한 전체 Gradle test 통과
- 로컬 전체 suite는 Docker daemon의 CLI 무응답으로 Testcontainers 실행 전에 중단됐으며, 동일 commit을 GitHub CI에서 검증했습니다.

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop`)
- [x] 변경된 서비스와 Docker 비의존 회귀 테스트를 로컬에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 기존 Redis cache fallback 동작이 유지되는가?

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
- PR diff만 기준으로 prompt 복구, 502/504/500 매핑, timeout 순서와 기존 cache fallback 유지 여부를 확인해주세요.
- 비동기·retry·queue 등 이슈 범위 밖 확장이 없는지 확인해주세요.

## ➕ 추후 계획(선택)
- 다음 Phase 1 이슈에서 Trend Redis 갱신 실패 시 기존 데이터 보존을 검증합니다.
- 이후 Phase 1 구조·정량 근거 맵과 README를 최신화하고 Phase 1 종료 여부를 판단합니다.
