### PR TITLE
🐛 [FIX/#237] Trend Redis 갱신 시 기존 데이터 보존

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -20,9 +20,10 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ### P1. Trend Redis 갱신 시 기존 데이터 보존
 
-- 상태: `Backlog`
+- 상태: `Done` ([#237](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/237), [PR #238](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/238))
 - 근거: scheduler가 국가별 기존 trend key를 DELETE한 뒤 새 값을 SET하므로 직렬화·저장 실패 사이에 기존 데이터가 사라질 수 있다.
 - 범위: 선행 DELETE 제거, 성공 시 단일 SET 교체, 실패 시 기존 값 보존 회귀 테스트로 제한한다. Redis 자료구조 변경과 분산 락은 제외한다.
+- 결과: 선행 DELETE와 삭제 API를 제거하고 직렬화 후 SET 한 번으로 교체했다. 정상·직렬화 실패·write 실패 테스트와 Backend CI 전체 테스트가 통과했다.
 
 ### P1. Phase 1 백엔드 구조·정량 근거 맵 및 README 최신화
 

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -9,12 +9,18 @@
 
 ## Recently Completed
 
+- #237 / PR #238: `Done`
+- 결과: Trend scheduler의 선행 DELETE와 삭제 API를 제거하고, 새 목록 직렬화 후 Redis SET 한 번으로 기존 값을 교체하도록 변경했다.
+- 검증: 정상 교체·직렬화 실패·write 실패 집중 테스트 3개, Docker 비의존 61개 테스트와 Backend CI 전체 테스트가 통과했다. AI Reviewer는 Blocking 없음·MERGE_READY로 판정했다.
+- 경계: mock Redis로 DELETE 미호출과 기존 fixture 조회를 검증했으며 실제 네트워크 장애 재현, TTL·scheduler·flag 변경, Lua/MULTI·분산 락·retry·queue·Kafka·Issue #110은 제외했다.
+- Phase 1 잔여 작업: 백엔드 구조·정량 근거 맵과 README 최신화 후 Phase 1 종료 판단.
+
 - #235 / PR #236: `Done`
 - 결과: 손상된 Trend Gemini prompt를 복구하고 기존 `gemini.timeout-ms`를 적용해 non-2xx 502, timeout 504, 내부 응답 처리 오류 500 계약을 고정했다.
 - 캐시: cache hit는 Gemini를 생략하며 Redis read 실패 fallback과 write 실패 시 정상 summary 반환을 유지했다.
 - 검증: mock HTTP·Redis 집중 테스트 7개, Docker 비의존 58개 테스트와 Backend CI 전체 테스트가 통과했고 AI Reviewer는 Blocking 없음·MERGE_READY로 판정했다.
 - 범위: 실제 Gemini·async·retry·circuit breaker·queue·Kafka·캐시 정책·Issue #110은 제외했다.
-- Phase 1 잔여 순서: Trend Redis 갱신 데이터 보존 → Phase 1 구조·정량 근거 맵과 README 최신화.
+- Phase 1 종료선은 위 #237 완료 결과와 잔여 작업을 기준으로 판단한다.
 
 - #233 / PR #234: `Done`
 - 결과: RSS/News API의 100·500·1,000건 신규 저장·중복 재실행과 mock upstream 순차 지연 전파를 MySQL Testcontainers에서 측정했다.

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -9,6 +9,18 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Recently Completed
 
+### #237 - Trend Redis 갱신 실패 시 기존 데이터 보존
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/237
+- 작업 브랜치: `fix/#237-trend-redis-preserve`
+- 상태: `Done` ([PR #238](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/238))
+- 기준선: 매시간 국가별 Trend 목록을 완성한 뒤에도 기존 Redis key를 먼저 DELETE하고 SET해, 직렬화·저장 실패 시 기존 정상 데이터가 사라질 수 있었다.
+- 결과: 새 목록을 먼저 직렬화하고 Redis SET 한 번으로 교체하도록 변경해 의도적인 빈 key 구간을 제거했다. 명시적 삭제 API도 제거했다.
+- 검증: 정상 교체, 직렬화 실패 시 미변경, Redis write 실패 시 기존 fixture 조회와 DELETE 미호출 테스트 3개, Docker 비의존 61개 테스트와 Backend CI 전체 테스트가 통과했다.
+- 정책 경계: mock Redis는 실제 네트워크 장애를 재현하지 않지만 선행 DELETE 제거와 SET 단일 interaction을 고정한다. TTL, scheduler 주기와 flag는 유지했다.
+- overengineering 판단: Redis 자료구조·Lua/MULTI·분산 락·retry·batch 실패 격리·실제 외부 호출·queue·Kafka와 Issue #110은 제외했다.
+- 작업 문서: `docs/backend-improvement/trend-redis-refresh-preservation.md`
+
 ### #235 - Trend Gemini 프롬프트 인코딩 및 timeout·오류 정책 보강
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/235

--- a/docs/backend-improvement/trend-redis-refresh-preservation.md
+++ b/docs/backend-improvement/trend-redis-refresh-preservation.md
@@ -1,0 +1,39 @@
+# Trend Redis 갱신 데이터 보존
+
+## 문제
+
+Trend scheduler는 국가별 새 목록을 수집하고 DTO로 만든 뒤 기존 `trend:{countryCode}` key를 삭제하고 새 JSON을 저장했다.
+
+새 목록이 준비된 뒤에도 `DELETE → SET`을 수행하므로 두 명령 사이에 조회 공백이 생긴다. 직렬화 또는 Redis write가 실패하면 TTL이 남아 있던 기존 정상 목록까지 잃을 수 있다.
+
+## 변경 정책
+
+1. 국가별 새 목록을 JSON으로 먼저 직렬화한다.
+2. 직렬화가 성공한 경우에만 Redis `SET`을 한 번 호출한다.
+3. 동일 key의 Redis 문자열은 `SET`으로 교체하고 별도 DELETE를 수행하지 않는다.
+4. 직렬화나 write가 실패하면 예외는 기존처럼 호출자에게 전달하되, 선행 DELETE 때문에 기존 데이터를 잃지 않는다.
+
+TTL은 기존 `48시간 + 10분`을 유지한다. `news-fetch.enabled` flag, 시작 시 수집, 매시간 scheduler, 국가 목록과 조회 API도 변경하지 않는다.
+
+## 검증 방법
+
+실제 Google Trends와 운영 Redis는 호출하지 않는다. Mockito Redis fixture로 다음 경계를 검증한다.
+
+- 정상 목록은 `trend:KR` key와 기존 TTL을 사용해 `SET` 한 번으로 저장한다.
+- 직렬화가 실패하면 `SET`과 `DELETE`가 모두 호출되지 않는다.
+- Redis write가 실패하면 DELETE가 호출되지 않고 기존 JSON fixture를 계속 조회한다.
+
+## 제한
+
+클라이언트가 Redis write 결과를 받기 전에 연결이 끊긴 경우에는 서버에 새 값이 반영됐는지 확정할 수 없다. 다만 선행 DELETE를 제거했으므로 결과는 기존 값 또는 완성된 새 값이며, 의도적으로 빈 key를 만드는 단계는 없다.
+
+Redis 자료구조 변경, Lua/MULTI, 분산 락, retry, 국가별 batch 실패 격리, scheduler 병렬화, queue와 Kafka는 이번 범위에 포함하지 않는다.
+
+## 검증 결과
+
+- 정상 교체, 직렬화 실패, Redis write 실패 집중 테스트 3개 통과
+- Docker 비의존 15개 클래스 61개 테스트 통과, 실패·오류·skip 0건
+- GitHub Backend CI 전체 Gradle test 통과
+- AI Reviewer: Blocking 없음, MERGE_READY
+
+write 실패 검증은 mock Redis로 기존 JSON 반환과 DELETE 미호출을 확인한 것이다. 실제 Redis 프로세스 또는 네트워크 장애를 재현한 결과로 해석하지 않는다. 이번 변경의 보장 범위는 애플리케이션이 의도적으로 기존 key를 먼저 삭제하지 않고 완성된 JSON을 SET 한 번으로 전달한다는 점이다.

--- a/src/main/java/com/example/globalTimes_be/domain/trend/scheduler/TrendScheduler.java
+++ b/src/main/java/com/example/globalTimes_be/domain/trend/scheduler/TrendScheduler.java
@@ -56,8 +56,7 @@ public class TrendScheduler {
                 continue;
             }
 
-            trendService.deleteTrendKeywords(countryCode);
-            trendService.saveTrendKeywords(countryCode, trendDTOS);
+            trendService.replaceTrendKeywords(countryCode, trendDTOS);
 
             totalKeywords += trendDTOS.size();
             successCount++;

--- a/src/main/java/com/example/globalTimes_be/domain/trend/service/TrendService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/trend/service/TrendService.java
@@ -18,8 +18,8 @@ public class TrendService {
     private final RedisUtil redisUtil;
     private static final long EXPIRATION_TIME = 86400 * 2 + 600; // 48시간 + 10분 (다음날 실검 없을 경우 대비)
 
-    //검색어 저장
-    public void saveTrendKeywords(String countryCode, List<TrendDTO> keywords) {
+    // 새 목록의 직렬화가 끝난 뒤 Redis SET 한 번으로 기존 값을 교체한다.
+    public void replaceTrendKeywords(String countryCode, List<TrendDTO> keywords) {
         //나라별 코드로 키 값 생성
         String key = "trend:" + countryCode;
 
@@ -32,14 +32,6 @@ public class TrendService {
         } catch (JsonProcessingException e) {
             throw new BaseException(TrendErrorStatus._FAIL_SERIALIZATION.getResponse());
         }
-    }
-
-    //검색어 삭제
-    public void deleteTrendKeywords(String countryCode) {
-        //나라별 코드로 키 값 생성
-        String key = "trend:" + countryCode;
-
-        redisUtil.deleteData(key);
     }
 
     //검색어 조회

--- a/src/test/java/com/example/globalTimes_be/domain/trend/service/TrendServiceTest.java
+++ b/src/test/java/com/example/globalTimes_be/domain/trend/service/TrendServiceTest.java
@@ -1,0 +1,101 @@
+package com.example.globalTimes_be.domain.trend.service;
+
+import com.example.globalTimes_be.domain.trend.dto.resonse.TrendDTO;
+import com.example.globalTimes_be.global.exception.BaseException;
+import com.example.globalTimes_be.global.redis.RedisUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TrendServiceTest {
+
+    private static final String KEY = "trend:KR";
+    private static final long EXPIRATION_TIME = 86400 * 2 + 600;
+
+    private RedisUtil redisUtil;
+    private TrendService trendService;
+
+    @BeforeEach
+    void setUp() {
+        redisUtil = mock(RedisUtil.class);
+        trendService = new TrendService(redisUtil);
+    }
+
+    @Test
+    void replaceTrendKeywords_replacesValueWithSingleSetAfterSerialization() {
+        TrendDTO trend = trend("new keyword");
+        ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
+
+        trendService.replaceTrendKeywords("KR", List.of(trend));
+
+        verify(redisUtil).setData(
+                org.mockito.ArgumentMatchers.eq(KEY),
+                jsonCaptor.capture(),
+                org.mockito.ArgumentMatchers.eq(EXPIRATION_TIME)
+        );
+        verify(redisUtil, never()).deleteData(anyString());
+        assertThat(jsonCaptor.getValue())
+                .contains("\"keyword\":\"new keyword\"")
+                .contains("\"title\":\"title\"");
+    }
+
+    @Test
+    void replaceTrendKeywords_doesNotChangeRedisWhenSerializationFails() {
+        TrendDTO invalidTrend = new TrendDTO() {
+            @Override
+            public String getKeyword() {
+                throw new IllegalStateException("fixture serialization failure");
+            }
+        };
+
+        assertThatThrownBy(() -> trendService.replaceTrendKeywords("KR", List.of(invalidTrend)))
+                .isInstanceOfSatisfying(BaseException.class, ex ->
+                        assertThat(ex.getHttpStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        verify(redisUtil, never()).setData(anyString(), anyString(), anyLong());
+        verify(redisUtil, never()).deleteData(anyString());
+    }
+
+    @Test
+    void replaceTrendKeywords_preservesExistingValueWhenRedisWriteFails() throws Exception {
+        String existingJson = TrendDTO.toJson(List.of(trend("existing keyword")));
+        when(redisUtil.existData(KEY)).thenReturn(true);
+        when(redisUtil.getData(KEY)).thenReturn(existingJson);
+        doThrow(new IllegalStateException("redis write failure"))
+                .when(redisUtil).setData(anyString(), anyString(), anyLong());
+
+        assertThatThrownBy(() -> trendService.replaceTrendKeywords("KR", List.of(trend("new keyword"))))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("redis write failure");
+
+        List<TrendDTO> remaining = trendService.getTrendingKeywords("KR");
+
+        assertThat(remaining).singleElement()
+                .extracting(TrendDTO::getKeyword)
+                .isEqualTo("existing keyword");
+        verify(redisUtil, never()).deleteData(anyString());
+    }
+
+    private TrendDTO trend(String keyword) {
+        return TrendDTO.builder()
+                .keyword(keyword)
+                .title("title")
+                .sourceName("source")
+                .url("https://example.com/" + keyword.replace(" ", "-"))
+                .urlToImage("https://example.com/image.jpg")
+                .build();
+    }
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #237

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [x] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- Trend scheduler의 국가별 `DELETE → SET` 갱신을 `replaceTrendKeywords()` 단일 호출로 변경했습니다.
- 새 목록을 JSON으로 먼저 직렬화한 뒤 Redis `SET` 한 번으로 기존 값을 교체합니다.
- 더 이상 사용하지 않는 `deleteTrendKeywords()`를 제거했습니다.
- 정상 교체, 직렬화 실패, Redis write 실패 시 기존 데이터 보존 테스트와 정책 문서를 추가했습니다.

## 🔍 기술적 배경
- 기존 코드는 새 목록을 완성한 뒤에도 기존 key를 먼저 삭제해 두 명령 사이 조회 공백을 만들었습니다.
- 직렬화나 Redis write가 실패하면 TTL이 남은 기존 정상 목록까지 잃을 수 있었습니다.
- Redis 문자열 `SET`은 동일 key의 기존 값을 새 값으로 교체하므로 선행 DELETE 없이 직렬화 완료 후 한 번만 호출하면 됩니다.
- TTL, 조회 API, 국가 목록, `news-fetch.enabled`와 매시간 scheduler 주기는 유지했습니다.

## 🧪 테스트/검증 (필수)
- [x] 정상 목록이 `trend:KR`, JSON, 기존 `48시간 + 10분` TTL로 SET 한 번만 호출되는지 검증
- [x] 직렬화 실패 시 Redis SET·DELETE가 모두 호출되지 않는지 검증
- [x] Redis write 실패 시 DELETE가 호출되지 않고 기존 JSON fixture가 계속 조회되는지 검증
- [x] Docker 비의존 15개 클래스 61개 테스트 통과, 실패·오류·skip 0건
- [x] GitHub Backend CI에서 Testcontainers 포함 전체 Gradle test 통과

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop`)
- [x] 변경된 서비스와 Docker 비의존 회귀 테스트를 로컬에서 실행했을 때 에러가 발생하지 않았는가?
- [x] TTL, scheduler 주기와 수집 flag가 유지되는가?

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
- 선행 DELETE가 완전히 제거되고 직렬화 후 Redis SET 한 번으로 교체되는지 확인해주세요.
- 직렬화·write 실패 시 기존 데이터 보존 경계와 TTL·scheduler·flag 유지 여부를 확인해주세요.

## ➕ 추후 계획(선택)
- 다음 Phase 1 이슈에서 백엔드 구조·정량 근거 맵과 README를 최신화하고 Phase 1 종료 여부를 판단합니다.
