### PR TITLE
📝 [DOCS/#241] 검색·Perspectives 근거 문서 한국어 정리

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -41,6 +41,14 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## Recently Completed
 
+### P1 문서 후속. 검색·Perspectives 근거 문서 한국어 재정리
+
+- 상태: `Done` ([#241](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/241), [PR #242](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/242))
+- 결과: 영어 중심 문서 10개의 설명과 결론을 한국어로 재정리하되 SQL·명령·로그·metric 식별자, 수치, 표본 ID와 해석 한계를 유지했다.
+- 판단: Phase 1 기술 범위는 `Completed`를 유지한다. 이번 작업은 신규 구현이나 측정이 아니라 기존 근거의 학습 접근성을 높이는 후속 문서 정리다.
+- 검증: 숫자 token·code fence 수 원문 대조, 상대 링크, `git diff --check`, Backend CI가 통과했다.
+- 제외: production code·test·schema·workflow·신규 측정·신규 기술과 Issue #110.
+
 ### P1. RSS/News API 수집 배치 처리량 및 지연 전파 기준선
 
 - 상태: `Done` ([#233](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/233), [PR #234](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/234))

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -9,6 +9,11 @@
 
 ## Recently Completed
 
+- #241 / PR #242: `Done`
+- 결과: 검색 API와 Perspectives의 영어 중심 근거 문서 10개를 한국어 중심으로 재정리했다. SQL·명령·로그·metric 식별자, 측정 수치, 표본 ID와 해석 한계는 유지했다.
+- 검증: 숫자 token과 code fence 수 원문 대조, 상대 링크, `git diff --check`, Backend CI가 통과했다.
+- 범위: production code·test·schema·workflow·신규 측정·신규 기술과 Issue #110은 제외했다.
+
 - #239 / PR #240: `Done`, Backend Phase 1 `Completed`
 - 결과: 14개 섹션의 구조·근거 맵으로 수집부터 CI까지 실행 경로를 문제·해결·수치·검증·원본 MD/PR/코드에 연결하고, #223 이후 정량 인덱스와 README 현재 상태를 갱신했다.
 - 검증: 상대 Markdown·Java·SQL·workflow 링크 150개와 수치·코드 경로를 대조했다. 검색 API 경로 Blocking 수정 후 Backend CI 성공, AI Reviewer Blocking 없음·MERGE_READY.

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -9,6 +9,16 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Recently Completed
 
+### #241 - 검색·Perspectives 영어 문서 한국어 재정리
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/241
+- 작업 브랜치: `docs/#241-search-perspectives-ko`
+- 상태: `Done` ([PR #242](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/242))
+- 결과: 검색 API와 Perspectives의 FULLTEXT 분석·기준선·표본·정렬·캐시·수집 범위·다국어 검증 문서 10개를 한국어 중심으로 재정리했다.
+- 보존 기준: SQL·명령·로그·metric 식별자, 측정 숫자, 표본 ID, code fence와 원래 해석 경계를 유지했다. 일반 검색 경로와 Perspectives 경로도 구분했다.
+- 검증: 대상 문서별 숫자 token과 code fence 수 원문 대조, 상대 링크, `git diff --check`, Backend CI가 통과했다.
+- 범위: production code·test·schema·workflow·신규 측정·신규 기술과 Issue #110은 제외했다.
+
 ### #239 - Phase 1 백엔드 구조·정량 근거 맵 및 README 최신화
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/239

--- a/docs/backend-improvement/perspectives-fulltext-explain.md
+++ b/docs/backend-improvement/perspectives-fulltext-explain.md
@@ -1,13 +1,13 @@
-# Perspectives FULLTEXT EXPLAIN analysis
+# Perspectives FULLTEXT EXPLAIN 분석
 
-## Purpose
+## 목적
 
-This document records the current MySQL execution plan for the Perspectives API cache-miss query.
-The goal is to check whether the query uses the intended FULLTEXT index before introducing heavier search technologies or additional caching layers.
+이 문서는 Perspectives API에서 캐시가 적중하지 않았을 때 실행되는 MySQL 쿼리의 현재 실행 계획을 기록한다.
+더 무거운 검색 기술이나 추가 캐시 계층을 도입하기 전에 의도한 FULLTEXT 인덱스가 사용되는지 확인하는 것이 목적이다.
 
-## Target query
+## 대상 쿼리
 
-`ArticleRepository.findPerspectives` uses this native query:
+`ArticleRepository.findPerspectives`는 다음 native query를 사용한다.
 
 ```sql
 SELECT *
@@ -18,33 +18,33 @@ ORDER BY published_at DESC
 LIMIT 50;
 ```
 
-The query is used by:
+이 쿼리는 다음 API에서 사용한다.
 
 ```text
 GET /api/news/{id}/perspectives
 ```
 
-## Related index
+## 관련 인덱스
 
-`FullTextIndexConfig` creates this index if it does not already exist:
+`FullTextIndexConfig`는 인덱스가 없을 때 다음 인덱스를 생성한다.
 
 ```sql
 CREATE FULLTEXT INDEX ft_article_title_description
 ON article(title, description);
 ```
 
-Local dev DB check:
+로컬 개발 DB 확인 결과:
 
-| Item | Value |
+| 항목 | 값 |
 | --- | --- |
-| Table | `article` |
-| Total rows | `9853` |
-| FULLTEXT index | `ft_article_title_description` |
-| Indexed columns | `title`, `description` |
+| 테이블 | `article` |
+| 전체 행 | `9853` |
+| FULLTEXT 인덱스 | `ft_article_title_description` |
+| 인덱스 대상 컬럼 | `title`, `description` |
 
-## EXPLAIN result
+## EXPLAIN 결과
 
-Representative query:
+대표 쿼리:
 
 ```sql
 EXPLAIN
@@ -56,9 +56,9 @@ ORDER BY published_at DESC
 LIMIT 50;
 ```
 
-Result summary:
+결과 요약:
 
-| Field | Value |
+| 필드 | 값 |
 | --- | --- |
 | `type` | `fulltext` |
 | `possible_keys` | `PRIMARY`, `ft_article_title_description` |
@@ -66,24 +66,24 @@ Result summary:
 | `rows` | `1` |
 | `Extra` | `Using where; Ft_hints: no_ranking; Using filesort` |
 
-Interpretation:
+해석:
 
-- MySQL uses the intended FULLTEXT index.
-- The query does not fall back to a full table scan.
-- `Using filesort` appears because results are ordered by `published_at DESC` after FULLTEXT matching.
-- The optimizer row estimate is not reliable for these FULLTEXT examples: `rows=1` was estimated even when actual matches were larger.
+- MySQL은 의도한 FULLTEXT 인덱스를 사용한다.
+- 쿼리는 전체 테이블 스캔으로 대체되지 않는다.
+- FULLTEXT 매칭 후 `published_at DESC`로 정렬하므로 `Using filesort`가 나타난다.
+- 이 FULLTEXT 예시에서 옵티마이저의 예상 행 수는 신뢰하기 어렵다. 실제 매칭 수가 더 많아도 `rows=1`로 예상했다.
 
-## EXPLAIN ANALYZE result
+## EXPLAIN ANALYZE 결과
 
-### Keyword: `+war`
+### 키워드: `+war`
 
-Match count:
+매칭 수:
 
 ```text
 404 rows
 ```
 
-Execution plan summary:
+실행 계획 요약:
 
 ```text
 Full-text index search on article using ft_article_title_description
@@ -99,15 +99,15 @@ Limit: 50
 actual time=10.2..10.3 rows=50
 ```
 
-### Keyword: `+economy`
+### 키워드: `+economy`
 
-Match count:
+매칭 수:
 
 ```text
 39 rows
 ```
 
-Execution plan summary:
+실행 계획 요약:
 
 ```text
 Full-text index search on article using ft_article_title_description
@@ -123,30 +123,30 @@ Limit: 50
 actual time=1.22..1.37 rows=39
 ```
 
-## Decision
+## 결정
 
-Do not change the query or index in this PR.
+이 PR에서는 쿼리나 인덱스를 변경하지 않는다.
 
-Reasons:
+근거:
 
-- The intended FULLTEXT index is being used.
-- For the current local dataset, representative queries complete in low milliseconds.
-- The current cold cache latency measured in #127 is not explained by this query alone.
-- Query changes that affect ranking, recency, or multilingual matching should be handled with separate quality and performance criteria.
+- 의도한 FULLTEXT 인덱스를 사용하고 있다.
+- 현재 로컬 데이터셋에서 대표 쿼리는 낮은 밀리초 범위로 완료된다.
+- #127에서 측정한 cold cache 지연은 이 쿼리만으로 설명되지 않는다.
+- 순위, 최신성, 다국어 매칭에 영향을 주는 쿼리 변경은 별도의 품질 및 성능 기준으로 다뤄야 한다.
 
-## Follow-up candidates
+## 후속 후보
 
-- Measure more article IDs and extracted keywords, not only manual keywords.
-- Compare FULLTEXT search time with the service log fields `translatedSearchMs` and `originalSearchMs`.
-- Investigate `Using filesort` only if match counts grow enough to make sort time visible in p95.
-- Analyze `searchByDescriptionOrTitleWithExploreFilters` separately because it combines FULLTEXT with optional country/category/date filters.
-- Consider Elasticsearch or vector search only after documenting concrete FULLTEXT quality gaps, such as missing related articles across languages.
+- 수동 키워드뿐 아니라 더 많은 기사 ID와 추출 키워드로 측정한다.
+- FULLTEXT 검색 시간을 서비스 로그의 `translatedSearchMs`, `originalSearchMs`와 비교한다.
+- 매칭 수가 증가해 정렬 시간이 p95에 드러날 때만 `Using filesort`를 조사한다.
+- `searchByDescriptionOrTitleWithExploreFilters`는 국가·카테고리·날짜 선택 조건과 FULLTEXT를 결합하므로 별도로 분석한다.
+- 언어 간 관련 기사 누락처럼 구체적인 FULLTEXT 품질 한계를 문서화한 뒤에만 Elasticsearch나 vector search를 검토한다.
 
-## Safe command template
+## 안전한 명령 템플릿
 
-Use local development credentials from the local environment, not production secrets.
-Avoid placing the password directly in the command because shell history can keep it.
-Use `-p` without the password and enter the password interactively.
+운영 비밀 값이 아니라 로컬 환경의 개발용 인증 정보를 사용한다.
+셸 기록에 비밀번호가 남을 수 있으므로 명령에 비밀번호를 직접 넣지 않는다.
+비밀번호 없이 `-p`를 사용하고 대화형으로 입력한다.
 
 ```powershell
 docker exec -it globaltimes_beside-mysql-1 mysql -uroot -p <database> -e "EXPLAIN SELECT * FROM article WHERE article_id != 8449 AND MATCH(title, description) AGAINST('+war' IN BOOLEAN MODE) ORDER BY published_at DESC LIMIT 50"

--- a/docs/backend-improvement/perspectives-fulltext-generic-token-filter-result.md
+++ b/docs/backend-improvement/perspectives-fulltext-generic-token-filter-result.md
@@ -1,36 +1,35 @@
-# Perspectives FULLTEXT generic-token filter result
+# Perspectives FULLTEXT 일반 token filter 결과
 
-## Purpose
+## 목적
 
-This document records the DB-level FULLTEXT result change after #152.
+이 문서는 #152 이후 DB 수준 FULLTEXT 결과 변화를 기록한다.
 
-#152 changed the Java `KeywordExtractor` policy by filtering sample-based generic tokens:
+#152는 표본에서 확인한 일반 token을 제거하도록 Java `KeywordExtractor` 정책을 변경했다.
 
 - `first`
 - `round`
 - `entre`
 
-This measurement checks whether the generated keyword improvement also changes the local MySQL FULLTEXT candidates.
-It does not change API behavior, DB schema, Redis policy, crawler/RSS feeds, ranking, or the FULLTEXT query shape.
+생성 키워드 개선이 로컬 MySQL FULLTEXT 후보도 바꾸는지 측정한다.
+API 동작, DB schema, Redis 정책, crawler/RSS feed, ranking 또는 FULLTEXT query 형태는 변경하지 않는다.
 
-Interpret this result together with `perspectives-source-coverage-limit-log.md`.
-The collected source data limits what FULLTEXT can return.
+FULLTEXT 반환 범위는 수집 데이터에 제한되므로 `perspectives-source-coverage-limit-log.md`와 함께 해석한다.
 
-## Environment
+## 환경
 
-| Item | Value |
+| 항목 | 값 |
 | --- | --- |
-| Date | 2026-07-04 |
-| Dataset | Local development MySQL via `docker-compose.dev.yml` |
-| Article rows | 9853 |
-| FULLTEXT index | `ft_article_title_description(title, description)` |
-| Query path | MySQL FULLTEXT query shaped like `ArticleRepository.findPerspectives` |
-| External translation API | Not called |
-| Redis cache | Not used |
+| 날짜 | 2026-07-04 |
+| 데이터셋 | `docker-compose.dev.yml`의 로컬 개발 MySQL |
+| 기사 행 | 9853 |
+| FULLTEXT 인덱스 | `ft_article_title_description(title, description)` |
+| 쿼리 경로 | `ArticleRepository.findPerspectives` 형태의 MySQL FULLTEXT query |
+| 외부 번역 API | 호출하지 않음 |
+| Redis cache | 사용하지 않음 |
 
-Sensitive local `.env` values and external API responses are intentionally excluded.
+민감한 로컬 `.env` 값과 외부 API 응답은 의도적으로 제외했다.
 
-## Query Shape
+## 쿼리 형태
 
 ```sql
 SELECT *
@@ -41,33 +40,33 @@ ORDER BY published_at DESC
 LIMIT 50;
 ```
 
-For this measurement, `match count` means the number of rows matching the FULLTEXT predicate before the `LIMIT 50`.
-Country/language spread and returned examples use the same latest-first ordering as `findPerspectives`.
+이 측정에서 `match count`는 `LIMIT 50` 적용 전 FULLTEXT 조건에 맞는 행 수다.
+국가·언어 분포와 반환 예시는 `findPerspectives`와 동일한 최신순을 사용한다.
 
-## Summary
+## 요약
 
 | Base article ID | Base title note | Before keyword | Before count | After keyword | After count | Initial interpretation |
 | --- | --- | --- | ---: | --- | ---: | --- |
-| 8146 | US-Iran talks | `+First +round Iran talks` | 25 | `+Iran +talks ends encouraging` | 27 | Improved: top results move from sports/broad `round` noise to Iran/US talks. |
-| 9440 | Meloni/Trump French sample | `+Entre +Meloni Trump divorce` | 0 | `+Meloni +Trump divorce italienne` | 3 | Improved recall, but still limited by available source coverage. |
+| 8146 | US-Iran talks | `+First +round Iran talks` | 25 | `+Iran +talks ends encouraging` | 27 | 개선: 상위 결과가 스포츠/넓은 `round` 잡음에서 Iran/US 회담으로 이동했다. |
+| 9440 | Meloni/Trump French sample | `+Entre +Meloni Trump divorce` | 0 | `+Meloni +Trump divorce italienne` | 3 | recall이 개선됐지만 가용한 출처 범위에 여전히 제한된다. |
 
-## 8146: US-Iran Talks
+## 8146: US-Iran 회담
 
-Base title:
+기준 제목:
 
 ```text
 First round of US-Iran talks ends with 'encouraging progress', mediators say
 ```
 
-### Before #152
+### #152 이전
 
-Keyword:
+키워드:
 
 ```text
 +First +round Iran talks
 ```
 
-Country/language spread:
+국가·언어 분포:
 
 | Country | Language | Count |
 | --- | --- | ---: |
@@ -76,7 +75,7 @@ Country/language spread:
 | cn | zh | 4 |
 | gb | en | 2 |
 
-Top returned examples:
+상위 반환 예시:
 
 | Article ID | Country | Language | Title note |
 | --- | --- | --- | --- |
@@ -89,21 +88,21 @@ Top returned examples:
 | 6100 | cn | zh | Miami Open |
 | 4427 | us | en | March Madness second round |
 
-Interpretation:
+해석:
 
-- `First` and `round` required broad sports and tournament-style matches.
-- The match count was non-zero, but the first returned examples were mostly weak matches.
-- This looked like a search-side keyword problem rather than only source coverage.
+- 필수어 `First`, `round`가 넓은 스포츠와 토너먼트 결과를 요구했다.
+- 매칭 결과가 존재하지만 첫 반환 예시 대부분은 약한 매칭이다.
+- 출처 범위만의 문제가 아니라 검색 측 키워드 문제로 보였다.
 
-### After #152
+### #152 이후
 
-Keyword:
+키워드:
 
 ```text
 +Iran +talks ends encouraging
 ```
 
-Country/language spread:
+국가·언어 분포:
 
 | Country | Language | Count |
 | --- | --- | ---: |
@@ -114,7 +113,7 @@ Country/language spread:
 | de | en | 1 |
 | global | null | 1 |
 
-Top returned examples:
+상위 반환 예시:
 
 | Article ID | Country | Language | Title note |
 | --- | --- | --- | --- |
@@ -127,55 +126,55 @@ Top returned examples:
 | 8129 | global | en | Israel-Lebanon talks in Washington |
 | 8136 | global | en | Israel attacks Lebanon despite ceasefire |
 
-Interpretation:
+해석:
 
-- The top results became much more centered on Iran/US talks and nearby Middle East diplomacy.
-- Some broader regional diplomacy/noise remains, which is expected because `ORDER BY published_at DESC` is still recency-based, not relevance-based.
-- This supports #152 as a useful keyword-side improvement for this sample.
+- 상위 결과가 Iran/US 회담과 인접한 중동 외교에 훨씬 집중됐다.
+- `ORDER BY published_at DESC`는 관련순이 아닌 최신순이므로 더 넓은 지역 외교 잡음은 일부 남는다.
+- 이 표본에서는 #152가 유효한 키워드 측 개선임을 뒷받침한다.
 
-## 9440: Meloni/Trump French Sample
+## 9440: Meloni/Trump 프랑스어 표본
 
-Base title:
+기준 제목:
 
 ```text
 Entre Meloni et Trump, divorce à l'italienne
 ```
 
-### Before #152
+### #152 이전
 
-Keyword:
+키워드:
 
 ```text
 +Entre +Meloni Trump divorce
 ```
 
-Result:
+결과:
 
 | Metric | Value |
 | --- | ---: |
 | Match count | 0 |
 
-Interpretation:
+해석:
 
-- `Entre` as a required token blocked recall for this sample.
-- Because the result was zero, we cannot tell from this query alone how much of the failure came from keyword choice versus source coverage.
+- 필수 token인 `Entre`가 이 표본의 recall을 막았다.
+- 결과가 없으므로 이 쿼리만으로 키워드 선택과 출처 범위의 영향 비중을 알 수 없다.
 
-### After #152
+### #152 이후
 
-Keyword:
+키워드:
 
 ```text
 +Meloni +Trump divorce italienne
 ```
 
-Country/language spread:
+국가·언어 분포:
 
 | Country | Language | Count |
 | --- | --- | ---: |
 | global | en | 2 |
 | de | de | 1 |
 
-Top returned examples:
+상위 반환 예시:
 
 | Article ID | Country | Language | Title note |
 | --- | --- | --- | --- |
@@ -183,30 +182,30 @@ Top returned examples:
 | 8134 | global | en | Italy diplomat and Meloni/Trump fabricated story |
 | 9517 | de | de | German article about Meloni and Trump |
 
-Interpretation:
+해석:
 
-- Filtering `Entre` produced a small but concrete recall improvement: `0` to `3`.
-- The available matches are related to Meloni/Trump, but the result set remains small.
-- Per `perspectives-source-coverage-limit-log.md`, this should be interpreted as mixed: keyword-side improvement plus likely source coverage/data availability limits.
+- `Entre` 제거로 `0`에서 `3`으로 작지만 구체적인 recall 개선이 생겼다.
+- 가용 결과는 Meloni/Trump와 관련 있지만 결과 집합은 작다.
+- `perspectives-source-coverage-limit-log.md`에 따라 키워드 개선과 출처 범위·데이터 가용성 한계가 섞인 결과로 해석한다.
 
-## Result Interpretation
+## 결과 해석
 
-Observed improvement:
+관찰한 개선:
 
-- #152 improved generated keyword focus for the weak generic-token samples.
-- The DB-level result for 8146 moved away from sports/tournament noise and toward Iran/US talks.
-- The DB-level result for 9440 changed from no match to a small Meloni/Trump candidate set.
+- #152가 약한 일반 token 표본의 생성 키워드 초점을 개선했다.
+- 8146의 DB 수준 결과가 스포츠·토너먼트 잡음에서 Iran/US 회담으로 이동했다.
+- 9440의 DB 수준 결과가 없음에서 작은 Meloni/Trump 후보 집합으로 바뀌었다.
 
-Remaining limits:
+남은 한계:
 
-- Result ordering is still latest-first, not relevance-first.
-- FULLTEXT still requires enough textual overlap in collected `title`/`description`.
-- Missing or delayed RSS/News API source data cannot be recovered by keyword tuning.
-- The measurement does not call the full API path, translation API, or Redis.
+- 결과 정렬은 관련순이 아니라 여전히 최신순이다.
+- FULLTEXT는 수집한 `title`/`description`에서 충분한 text overlap을 요구한다.
+- 누락되거나 지연된 RSS/News API 원본 데이터는 키워드 조정으로 복구할 수 없다.
+- 이 측정은 전체 API 경로, 번역 API 또는 Redis를 호출하지 않는다.
 
-## Follow-Up Candidates
+## 후속 후보
 
-1. Compare latest-first ordering with relevance-first or hybrid ordering for the same samples.
-2. Measure the full API path with translation enabled for non-English base articles, with external API usage explicitly approved.
-3. Add source coverage/freshness metrics for representative issues before choosing Elasticsearch, vector search, or issue clustering.
-4. Expand generic-token filtering only with additional measured samples, not as a broad stop-word list by intuition.
+1. 같은 표본에서 latest-first와 relevance-first 또는 hybrid 정렬을 비교한다.
+2. 외부 API 사용을 명시적으로 승인한 뒤 비영어 기준 기사의 번역을 포함한 전체 API 경로를 측정한다.
+3. Elasticsearch, vector search 또는 issue clustering을 선택하기 전에 대표 이슈의 출처 범위·최신성 지표를 추가한다.
+4. 일반 token filter는 직관적인 대규모 stop-word 목록이 아니라 추가 측정 표본이 있을 때만 확장한다.

--- a/docs/backend-improvement/perspectives-fulltext-ordering-comparison.md
+++ b/docs/backend-improvement/perspectives-fulltext-ordering-comparison.md
@@ -1,40 +1,39 @@
-# Perspectives FULLTEXT ordering comparison
+# Perspectives FULLTEXT 정렬 비교
 
-## Purpose
+## 목적
 
-This document compares ordering strategies for `ArticleRepository.findPerspectives`.
+이 문서는 `ArticleRepository.findPerspectives`의 정렬 전략을 비교한다.
 
-#156 showed that #152 improved generated keyword quality for weak generic-token samples.
-However, sample 8146 still had nearby Middle East diplomacy noise near the top because current results are ordered by recency:
+#156에서 #152의 일반 token 제거가 약한 표본의 생성 키워드 품질을 개선했음을 확인했다.
+하지만 표본 8146은 현재 결과가 최신순이므로 상위에 인접한 중동 외교 잡음이 남았다.
 
 ```sql
 ORDER BY published_at DESC
 ```
 
-This measurement checks whether the remaining noise is better explained as an ordering problem.
-It does not change API behavior, DB schema, Redis policy, crawler/RSS feeds, or `KeywordExtractor`.
+남은 잡음이 정렬 문제로 더 잘 설명되는지 측정한다.
+API 동작, DB schema, Redis 정책, crawler/RSS feed 또는 `KeywordExtractor`는 변경하지 않는다.
 
-Interpret this result together with `perspectives-source-coverage-limit-log.md`.
-FULLTEXT can only rank articles that exist in the collected local dataset.
+FULLTEXT는 수집된 로컬 데이터셋에 존재하는 기사만 정렬할 수 있으므로 `perspectives-source-coverage-limit-log.md`와 함께 해석한다.
 
-## Environment
+## 환경
 
-| Item | Value |
+| 항목 | 값 |
 | --- | --- |
-| Date | 2026-07-08 |
-| Dataset | Local development MySQL via Docker |
+| 날짜 | 2026-07-08 |
+| 데이터셋 | Docker의 로컬 개발 MySQL |
 | MySQL | 8.0.45 |
-| Article rows | 9853 |
-| FULLTEXT index | `ft_article_title_description(title, description)` |
-| Query path | DB-level query shaped like `ArticleRepository.findPerspectives` |
-| External translation API | Not called |
-| Redis cache | Not used |
+| 기사 행 | 9853 |
+| FULLTEXT 인덱스 | `ft_article_title_description(title, description)` |
+| 쿼리 경로 | `ArticleRepository.findPerspectives` 형태의 DB-level query |
+| 외부 번역 API | 호출하지 않음 |
+| Redis cache | 사용하지 않음 |
 
-Sensitive local `.env` values and external API responses are intentionally excluded.
+민감한 로컬 `.env` 값과 외부 API 응답은 의도적으로 제외했다.
 
-## Compared Ordering Strategies
+## 비교 정렬 전략
 
-All strategies use the same candidate predicate:
+모든 전략은 동일한 후보 조건을 사용한다.
 
 ```sql
 WHERE article_id != :baseArticleId
@@ -44,28 +43,28 @@ LIMIT 50
 
 ### Latest-first
 
-Current production ordering:
+현재 운영 정렬:
 
 ```sql
 ORDER BY published_at DESC
 ```
 
-Meaning: prefer the newest matching articles.
+의미: 매칭 기사 중 최신 기사를 우선한다.
 
 ### Relevance-first
 
-FULLTEXT score ordering:
+FULLTEXT score 정렬:
 
 ```sql
 ORDER BY MATCH(title, description) AGAINST(:keywords IN BOOLEAN MODE) DESC,
          article_id DESC
 ```
 
-Meaning: prefer articles with stronger FULLTEXT keyword overlap.
+의미: FULLTEXT 키워드가 더 강하게 겹치는 기사를 우선한다.
 
-### Hybrid candidate
+### Hybrid 후보
 
-Exploratory score plus bounded recency boost:
+탐색용 score와 제한된 최신성 가산점:
 
 ```sql
 hybrid_score =
@@ -79,13 +78,13 @@ ORDER BY hybrid_score DESC,
          published_at DESC
 ```
 
-Meaning: prefer relevant articles, but give a limited boost to articles within 30 days of the newest matched article.
-This is a measurement candidate, not a final ranking policy.
+의미: 관련 기사를 우선하되 매칭 기사 중 가장 최신 시각에서 30일 이내인 기사에 제한된 가산점을 준다.
+최종 ranking 정책이 아닌 측정 후보다.
 
-## Sample Summary
+## 표본 요약
 
-Because all selected samples have fewer than 50 matches, each ordering strategy returns the same candidate set.
-This measurement therefore compares top order, not recall.
+선택한 모든 표본의 매칭 수가 50보다 적어 각 전략은 동일한 후보 집합을 반환한다.
+따라서 이 측정은 recall이 아니라 상위 정렬을 비교한다.
 
 | Base article ID | Keyword | Match count | Country/language spread |
 | --- | --- | ---: | --- |
@@ -94,15 +93,15 @@ This measurement therefore compares top order, not recall.
 | 8147 | `+Trump +backed political outsider` | 4 | cn/zh 2, gb/en 1, us/null 1 |
 | 8149 | `+BTS +fans losing thousands` | 8 | cn/zh 4, gb/en 2, fr/fr 1, us/en 1 |
 
-## 8146: US-Iran Talks
+## 8146: US-Iran 회담
 
-Base title:
+기준 제목:
 
 ```text
 First round of US-Iran talks ends with 'encouraging progress', mediators say
 ```
 
-### Top Results
+### 상위 결과
 
 | Ordering | Top returned examples |
 | --- | --- |
@@ -110,22 +109,22 @@ First round of US-Iran talks ends with 'encouraging progress', mediators say
 | relevance-first | 9667 Iran-US talks continue; 9652 Blockade/assets to Iran; 5219 Iran denies US talks; 1517 Ukraine peace talks amid Iran war; 4276 Iran World Cup |
 | hybrid | 9652 Blockade/assets to Iran; 9667 Iran-US talks continue; 8114 US envoy headed for Switzerland; 8129 Israel-Lebanon talks; 8086 Iran war live and Lebanon |
 
-### Interpretation
+### 해석
 
-- Latest-first keeps the newest Iran/US talks articles high, but also keeps recent Lebanon/ceasefire regional noise near the top.
-- Relevance-first raises strong `Iran`/`talks` overlaps, but it can promote older or broader matches such as Ukraine peace talks or Iran World Cup.
-- The hybrid candidate reduces the pure relevance-first drift toward older March articles while still using score to avoid pure recency ordering.
-- Remaining Lebanon/ceasefire results are not fully solved by ordering because the text overlaps with the same regional diplomacy context.
+- Latest-first는 최신 Iran/US 회담 기사를 높게 유지하지만 최근 Lebanon/ceasefire 지역 잡음도 상위에 둔다.
+- Relevance-first는 강한 `Iran`/`talks` overlap을 올리지만 Ukraine 평화 회담이나 Iran World Cup처럼 오래되거나 넓은 매칭을 높일 수 있다.
+- Hybrid 후보는 score를 쓰면서 순수 relevance-first가 오래된 기사로 치우치는 현상을 줄인다.
+- Lebanon/ceasefire 결과는 동일 지역 외교 문맥과 text가 겹치므로 정렬만으로 완전히 해결되지 않는다.
 
-## 9440: Meloni/Trump French Sample
+## 9440: Meloni/Trump 프랑스어 표본
 
-Base title:
+기준 제목:
 
 ```text
 Entre Meloni et Trump, divorce à l'italienne
 ```
 
-### Top Results
+### 상위 결과
 
 | Ordering | Top returned examples |
 | --- | --- |
@@ -133,21 +132,21 @@ Entre Meloni et Trump, divorce à l'italienne
 | relevance-first | 9517 German Meloni/Trump article; 8134 Meloni says Trump fabricated story; 8096 Trump/Meloni photos |
 | hybrid | 9517 German Meloni/Trump article; 8134 Meloni says Trump fabricated story; 8096 Trump/Meloni photos |
 
-### Interpretation
+### 해석
 
-- The candidate set is only 3 rows, so ordering cannot solve source coverage limits.
-- Relevance-first and hybrid both move the highest FULLTEXT score article to the top.
-- This sample is useful for recall tracking after #152, but it is too small to justify a ranking policy alone.
+- 후보가 3행뿐이므로 정렬로 출처 범위 한계를 해결할 수 없다.
+- Relevance-first와 hybrid 모두 FULLTEXT score가 가장 높은 기사를 첫 번째로 옮긴다.
+- #152 이후 recall 추적에는 유용하지만 이 표본만으로 ranking 정책을 정당화하기에는 너무 작다.
 
-## 8147: Trump-backed Political Outsider
+## 8147: Trump-backed 정치 신인
 
-Base title note:
+기준 제목 메모:
 
 ```text
 Trump-backed political outsider
 ```
 
-### Top Results
+### 상위 결과
 
 | Ordering | Top returned examples |
 | --- | --- |
@@ -155,22 +154,22 @@ Trump-backed political outsider
 | relevance-first | 4941 Iran awaits Trump threat; 9658 Trump-backed Colombia election; 778 Trump allies/Iran; 3258 Trump-backed television merger |
 | hybrid | 9658 Trump-backed Colombia election; 4941 Iran awaits Trump threat; 778 Trump allies/Iran; 3258 Trump-backed television merger |
 
-### Interpretation
+### 해석
 
-- Latest-first already puts the most likely same-issue article first because it is much newer.
-- Relevance-first over-promotes a higher-score but wrong-context Iran/Trump article.
-- Hybrid keeps the Colombia election article first while still preserving score as a ranking signal.
-- This sample argues against switching directly to pure relevance-first.
+- Latest-first는 동일 이슈일 가능성이 가장 큰 최신 기사를 이미 첫 번째로 둔다.
+- Relevance-first는 score가 높지만 문맥이 틀린 Iran/Trump 기사를 지나치게 올린다.
+- Hybrid는 score를 ranking 신호로 유지하면서 Colombia 선거 기사를 첫 번째에 둔다.
+- 이 표본은 pure relevance-first로 즉시 전환하면 안 된다는 근거다.
 
-## 8149: BTS Fans
+## 8149: BTS 팬
 
-Base title note:
+기준 제목 메모:
 
 ```text
 BTS fans losing thousands
 ```
 
-### Top Results
+### 상위 결과
 
 | Ordering | Top returned examples |
 | --- | --- |
@@ -178,27 +177,27 @@ BTS fans losing thousands
 | relevance-first | 3008 BTS comeback concert; 6014 BTS fans/Arirang credits; 3246 K-pop fans in Seoul; 2874 BTS first show; 4935 BTS comeback crowd |
 | hybrid | 3008 BTS comeback concert; 6014 BTS fans/Arirang credits; 3246 K-pop fans in Seoul; 2874 BTS first show; 4935 BTS comeback crowd |
 
-### Interpretation
+### 해석
 
-- This is a good-match control sample: most returned rows are BTS-related under all strategies.
-- Relevance-first and hybrid surface stronger BTS event matches than latest-first.
-- The result suggests ordering can improve top position quality when the candidate set is already coherent.
+- 모든 전략에서 대부분 BTS 관련 행인 good-match 대조 표본이다.
+- Relevance-first와 hybrid가 latest-first보다 강한 BTS 사건 매칭을 상위에 둔다.
+- 후보 집합이 이미 일관될 때 정렬로 상위 결과 품질을 개선할 수 있음을 보여준다.
 
-## Findings
+## 관찰 결과
 
-- Pure latest-first is simple and freshness-friendly, but it can keep nearby topical noise high.
-- Pure relevance-first can improve exact keyword overlap, but it may over-promote older or wrong-context articles with strong token overlap.
-- The measured hybrid candidate looks safer than pure relevance-first for samples 8146 and 8147 because it keeps recency as a bounded signal.
-- Since all measured candidate sets are under 50 rows, this comparison does not evaluate recall. It evaluates top ordering only.
-- Source coverage remains a hard boundary. If the collected DB lacks same-issue articles, no ordering policy can recover them.
+- Pure latest-first는 단순하고 최신성에 유리하지만 인접 주제 잡음을 높게 유지할 수 있다.
+- Pure relevance-first는 정확한 키워드 overlap을 개선할 수 있지만 강한 token overlap을 가진 오래되거나 잘못된 문맥의 기사를 지나치게 올릴 수 있다.
+- 측정한 hybrid 후보는 최신성을 제한된 신호로 유지하므로 표본 8146과 8147에서 pure relevance-first보다 안전해 보인다.
+- 모든 측정 후보 집합이 50행 미만이므로 recall이 아닌 상위 정렬만 평가했다.
+- 출처 범위는 명확한 경계다. 수집 DB에 동일 이슈 기사가 없다면 어떤 정렬도 복구할 수 없다.
 
-## Recommendation
+## 권고
 
-Do not directly replace `ORDER BY published_at DESC` with pure relevance-first.
+`ORDER BY published_at DESC`를 pure relevance-first로 즉시 교체하지 않는다.
 
-If code changes are attempted later, prefer a small, explicit hybrid experiment with tests and before/after measurement:
+나중에 코드 변경을 시도한다면 테스트와 전후 측정을 포함한 작고 명시적인 hybrid 실험을 우선한다.
 
-1. Select representative samples and expected top-result intent.
-2. Add a repository method or query variant for hybrid ranking.
-3. Compare API response order against this DB-level baseline.
-4. Keep source coverage limitations documented separately from ranking failures.
+1. 대표 표본과 기대 상위 결과 의도를 선정한다.
+2. Hybrid ranking용 repository method 또는 query variant를 추가한다.
+3. 이 DB 수준 기준선과 API 응답 순서를 비교한다.
+4. 출처 범위 한계와 ranking 실패를 별도로 기록한다.

--- a/docs/backend-improvement/perspectives-matching-quality-baseline.md
+++ b/docs/backend-improvement/perspectives-matching-quality-baseline.md
@@ -1,16 +1,16 @@
-# Perspectives matching quality baseline
+# Perspectives 매칭 품질 기준선
 
-## Purpose
+## 목적
 
-`GET /api/news/{id}/perspectives` is intended to show articles from multiple countries about a similar issue.
-The current implementation uses title keywords, optional English translation, and MySQL FULLTEXT search.
+`GET /api/news/{id}/perspectives`는 유사한 이슈를 다루는 여러 국가의 기사를 보여주기 위한 API다.
+현재 구현은 제목 키워드, 선택적 영어 번역, MySQL FULLTEXT 검색을 사용한다.
 
-This document defines a small baseline for measuring the current matching quality before introducing heavier search layers such as Elasticsearch, vector search, RAG, or issue clustering.
+이 문서는 Elasticsearch, vector search, RAG, issue clustering처럼 더 무거운 검색 계층을 도입하기 전에 현재 매칭 품질을 측정할 작은 기준선을 정의한다.
 
-The first local MySQL snapshot is recorded in `perspectives-matching-sample-snapshot.md`.
-When interpreting any snapshot, also apply `perspectives-source-coverage-limit-log.md` to separate search quality from source coverage and freshness limits.
+첫 로컬 MySQL snapshot은 `perspectives-matching-sample-snapshot.md`에 기록한다.
+Snapshot을 해석할 때는 `perspectives-source-coverage-limit-log.md`도 적용해 검색 품질과 출처 범위·최신성 한계를 분리한다.
 
-## Current Flow
+## 현재 흐름
 
 ```text
 PerspectivesService.getPerspectives(articleId)
@@ -26,9 +26,9 @@ PerspectivesService.getPerspectives(articleId)
 -> cache response in Redis
 ```
 
-## Current Search Shape
+## 현재 검색 형태
 
-`ArticleRepository.findPerspectives` uses the following FULLTEXT query:
+`ArticleRepository.findPerspectives`는 다음 FULLTEXT 쿼리를 사용한다.
 
 ```sql
 SELECT *
@@ -39,55 +39,55 @@ ORDER BY published_at DESC
 LIMIT 50;
 ```
 
-Known behavior:
+확인된 동작:
 
-- The query uses the `ft_article_title_description(title, description)` FULLTEXT index on the local development dataset.
-- Results are ordered by `published_at DESC`, not by semantic similarity.
-- `KeywordExtractor` keeps at most 4 title tokens and makes the first 2 required terms in BOOLEAN MODE.
-- Non-English base articles are searched once with translated English keywords and, when different, once with original keywords.
-- The response groups the retrieved articles by country and keeps up to 3 articles per country.
+- 로컬 개발 데이터셋에서 `ft_article_title_description(title, description)` FULLTEXT 인덱스를 사용한다.
+- 결과는 의미 유사도가 아니라 `published_at DESC`로 정렬한다.
+- `KeywordExtractor`는 제목 token을 최대 4개 유지하고 BOOLEAN MODE에서 앞의 2개를 필수 검색어로 만든다.
+- 영어가 아닌 기준 기사는 번역한 영어 키워드로 검색하고, 원문과 다르면 원문 키워드로도 검색한다.
+- 검색 기사를 국가별로 묶고 국가당 최대 3개를 유지한다.
 
-## Known Limits
+## 확인된 한계
 
-- Similar issues can be missed when titles use different expressions, entities, or languages.
-- FULLTEXT matching does not guarantee that articles describe the same event.
-- Search results can be recent but weakly related because the final ordering is recency-based.
-- The current model has no stable `issue_id` or article cluster identity.
-- Translating only the extracted base keywords to English favors English matching and does not fully cover all article languages.
-- Matching quality is bounded by collected source coverage; missing or delayed RSS/News API articles cannot be recovered by FULLTEXT or semantic search alone.
+- 제목의 표현, entity 또는 언어가 다르면 유사한 이슈를 놓칠 수 있다.
+- FULLTEXT 매칭은 기사가 동일 사건을 설명한다고 보장하지 않는다.
+- 최종 정렬이 최신순이므로 결과가 최신이지만 관련성이 약할 수 있다.
+- 현재 모델에는 안정적인 `issue_id`나 기사 cluster 식별자가 없다.
+- 기준 기사에서 추출한 키워드만 영어로 번역하므로 영어 매칭에 유리하고 모든 기사 언어를 완전히 다루지 못한다.
+- 매칭 품질은 수집 출처 범위에도 제한된다. 누락되거나 늦게 들어온 RSS/News API 기사는 FULLTEXT나 semantic search만으로 복구할 수 없다.
 
-## Sample Selection Criteria
+## 표본 선정 기준
 
-Use representative article samples instead of cherry-picking only successful matches.
+성공 사례만 의도적으로 고르지 않고 대표 기사 표본을 사용한다.
 
-Recommended sample set:
+권장 표본:
 
-| Sample type | Minimum count | Why |
+| 표본 유형 | 최소 개수 | 이유 |
 | --- | ---: | --- |
-| English global issue | 2 | Checks common high-volume FULLTEXT behavior. |
-| Korean or other non-English base article | 2 | Checks translation plus original keyword fallback. |
-| Low-match or zero-match issue | 2 | Exposes recall gaps. |
-| Multi-country breaking/news topic | 2 | Checks whether different country sources appear. |
-| Broad category term issue | 1 | Exposes noisy matches and recency bias. |
+| 영어 국제 이슈 | 2 | 일반적인 대량 FULLTEXT 동작을 확인한다. |
+| 한국어 또는 다른 비영어 기준 기사 | 2 | 번역과 원문 키워드 fallback을 확인한다. |
+| 매칭이 적거나 없는 이슈 | 2 | recall 한계를 드러낸다. |
+| 여러 국가의 속보/뉴스 주제 | 2 | 서로 다른 국가 출처가 나타나는지 확인한다. |
+| 넓은 카테고리 용어 이슈 | 1 | 잡음 매칭과 최신순 편향을 드러낸다. |
 
-For each sample, record the base article ID, title, country, language, category, extracted keywords, and observed result summary.
-Do not include private data, API keys, or full external API responses.
+표본마다 기준 기사 ID, 제목, 국가, 언어, 카테고리, 추출 키워드와 관찰 결과를 기록한다.
+개인정보, API key 또는 외부 API 전체 응답은 포함하지 않는다.
 
-## Measurement Procedure
+## 측정 절차
 
-1. Clear the Redis key for the sample article when measuring the cold path:
+1. Cold path를 측정할 때 표본 기사의 Redis key를 삭제한다.
 
 ```text
 perspectives:article:{articleId}
 ```
 
-2. Call the API:
+2. API를 호출한다.
 
 ```http
 GET /api/news/{articleId}/perspectives
 ```
 
-3. Capture the response summary and service log fields:
+3. 응답 요약과 서비스 log field를 수집한다.
 
 ```text
 keywordLength
@@ -101,39 +101,39 @@ totalArticles
 totalMs
 ```
 
-4. Review the returned country groups manually and classify each sample:
+4. 반환 국가 그룹을 수동 검토하고 각 표본을 분류한다.
 
-| Classification | Meaning |
+| 분류 | 의미 |
 | --- | --- |
-| `good_match` | Most returned articles appear to describe the same issue. |
-| `partial_match` | Some useful related articles appear, but important countries or articles are missing. |
-| `weak_match` | Results are mostly broad-topic matches rather than the same issue. |
-| `no_match` | The API returns no useful related articles. |
+| `good_match` | 반환 기사 대부분이 동일 이슈를 다루는 것으로 보인다. |
+| `partial_match` | 유용한 관련 기사가 있지만 중요한 국가나 기사가 누락된다. |
+| `weak_match` | 동일 이슈보다 넓은 주제 매칭이 대부분이다. |
+| `no_match` | API가 유용한 관련 기사를 반환하지 않는다. |
 
-## Baseline Result Template
+## 기준선 결과 템플릿
 
 | Article ID | Base country | Language | Category | Keyword | countriesFound | totalArticles | Classification | Notes |
 | --- | --- | --- | --- | --- | ---: | ---: | --- | --- |
 | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
 
-Country breakdown template:
+국가별 결과 템플릿:
 
 | Article ID | Country | Returned count | Match notes |
 | --- | --- | ---: | --- |
 | TBD | TBD | TBD | TBD |
 
-## Decision Boundary
+## 결정 경계
 
-This baseline does not introduce Elasticsearch, vector search, RAG, Kafka, or a new schema.
-Those options should be considered only after the baseline shows concrete quality gaps that cannot be addressed with small FULLTEXT or keyword improvements.
+이 기준선에서는 Elasticsearch, vector search, RAG, Kafka 또는 새 schema를 도입하지 않는다.
+작은 FULLTEXT 또는 키워드 개선으로 해결할 수 없는 구체적인 품질 한계가 기준선에서 확인된 뒤에만 검토한다.
 
-Potential follow-up decisions:
+후속 결정 후보:
 
-| Option | Consider when |
+| 선택지 | 검토 조건 |
 | --- | --- |
-| FULLTEXT query tuning | Good keywords exist but query shape or ordering loses useful results. |
-| Better keyword extraction | Current title tokens are too noisy or miss entities. |
-| Multilingual query expansion | Non-English article recall is consistently poor. |
-| Vector search or embeddings | Same-issue articles use different wording and FULLTEXT misses them. |
-| Issue clustering / `issue_id` | The product needs stable event-level grouping across article ingestion. |
-| Elasticsearch | Keyword search, filtering, ranking, and multilingual analysis need a dedicated search layer. |
+| FULLTEXT query tuning | 좋은 키워드가 있지만 query 형태나 정렬이 유용한 결과를 놓친다. |
+| 더 나은 keyword extraction | 현재 제목 token의 잡음이 크거나 entity를 놓친다. |
+| Multilingual query expansion | 비영어 기사 recall이 일관되게 낮다. |
+| Vector search 또는 embeddings | 같은 이슈의 표현이 달라 FULLTEXT가 놓친다. |
+| Issue clustering / `issue_id` | 수집 전반에서 안정적인 사건 단위 그룹이 필요하다. |
+| Elasticsearch | 키워드 검색, 필터, 순위, 다국어 분석에 전용 검색 계층이 필요하다. |

--- a/docs/backend-improvement/perspectives-matching-sample-snapshot.md
+++ b/docs/backend-improvement/perspectives-matching-sample-snapshot.md
@@ -1,29 +1,29 @@
-# Perspectives matching sample snapshot
+# Perspectives 매칭 표본 snapshot
 
-## Purpose
+## 목적
 
-This document records a first local snapshot for the Perspectives matching quality baseline.
-It follows `perspectives-matching-quality-baseline.md` and uses the local development MySQL data to identify representative samples before introducing heavier search technology.
+이 문서는 Perspectives 매칭 품질 기준선의 첫 로컬 snapshot을 기록한다.
+`perspectives-matching-quality-baseline.md`를 따르며, 더 무거운 검색 기술을 도입하기 전에 로컬 개발 MySQL 데이터에서 대표 표본을 찾는다.
 
-This snapshot does not change API behavior, DB schema, Redis policy, or search logic.
-Interpret this snapshot together with `perspectives-source-coverage-limit-log.md`, because some low-match cases can be caused by source coverage or feed freshness rather than only FULLTEXT behavior.
+이 snapshot은 API 동작, DB schema, Redis 정책 또는 검색 로직을 변경하지 않는다.
+매칭이 적은 사례 일부는 FULLTEXT뿐 아니라 출처 범위나 feed 최신성에서 비롯될 수 있으므로 `perspectives-source-coverage-limit-log.md`와 함께 해석한다.
 
-## Environment
+## 환경
 
-| Item | Value |
+| 항목 | 값 |
 | --- | --- |
-| Date | 2026-07-03 |
-| Dataset | Local development MySQL |
-| Article rows | 9853 |
-| Query path | MySQL FULLTEXT query shaped like `ArticleRepository.findPerspectives` |
-| External translation API | Not called |
-| Redis cache | Not used for this snapshot |
+| 날짜 | 2026-07-03 |
+| 데이터셋 | 로컬 개발 MySQL |
+| 기사 행 | 9853 |
+| 쿼리 경로 | `ArticleRepository.findPerspectives` 형태의 MySQL FULLTEXT query |
+| 외부 번역 API | 호출하지 않음 |
+| Redis cache | 이 snapshot에서 사용하지 않음 |
 
-Sensitive local `.env` values and external API responses are intentionally excluded.
+민감한 로컬 `.env` 값과 외부 API 응답은 의도적으로 제외했다.
 
-## Dataset Distribution
+## 데이터셋 분포
 
-Top local article groups:
+로컬 기사 상위 그룹:
 
 | Country | Language | Category | Count |
 | --- | --- | --- | ---: |
@@ -40,12 +40,12 @@ Top local article groups:
 | de | de | general | 272 |
 | jp | ja | sports | 248 |
 
-The dataset is large enough to test English and non-English candidate behavior, but this snapshot is still a local development sample and should not be treated as production quality evidence.
-It also does not prove that every country/source had a comparable opportunity to publish and be collected for the same issue.
+영어와 비영어 후보 동작을 확인하기에 충분하지만 로컬 개발 표본이므로 운영 품질 근거로 해석하면 안 된다.
+또한 모든 국가와 출처가 동일 이슈를 게시하고 수집될 기회를 비슷하게 가졌음을 증명하지 않는다.
 
-## Method
+## 방법
 
-For each sample, this snapshot uses:
+각 표본에 다음 쿼리를 사용했다.
 
 ```sql
 SELECT *
@@ -56,35 +56,35 @@ ORDER BY published_at DESC
 LIMIT 50;
 ```
 
-Keywords were manually derived from the title using the same broad rule as `KeywordExtractor`:
+`KeywordExtractor`와 같은 넓은 규칙으로 제목에서 키워드를 수동 도출했다.
 
-- split by whitespace and punctuation
-- remove tokens of length 2 or less
-- remove configured English stop words
-- keep up to 4 distinct tokens
-- make the first 2 tokens required with `+`
+- 공백과 문장부호로 분리
+- 길이가 2 이하인 token 제거
+- 설정된 영어 stop word 제거
+- 중복 없는 token 최대 4개 유지
+- 앞의 2개 token에 `+`를 붙여 필수화
 
-For non-English samples, this snapshot records original keyword behavior only.
-The full API path may translate non-English plain keywords to English, but that requires external API calls and is intentionally left for a separate measurement.
+비영어 표본은 원문 키워드 동작만 기록한다.
+전체 API 경로에서는 비영어 plain keyword를 영어로 번역할 수 있지만 외부 API 호출이 필요하므로 별도 측정으로 남겼다.
 
-## Sample Summary
+## 표본 요약
 
 | Base article ID | Country | Language | Category | Keyword used | Match count | Country/language spread | Initial classification | Notes |
 | --- | --- | --- | --- | --- | ---: | --- | --- | --- |
-| 8146 | gb | en | general | `+First +round Iran talks` | 25 | us/en 14, us/null 5, cn/zh 4, gb/en 2 | `weak_match` | Required terms `First` and `round` produce broad sports and unrelated matches despite an Iran diplomacy base article. |
-| 8148 | gb | en | general | `+Russian +troop build threatens` | 0 | none | `no_match` | A Ukraine/Donbas topic returns no matches with the extracted title keywords. |
-| 8149 | gb | en | general | `+BTS +fans losing thousands` | 8 | cn/zh 4, gb/en 2, us/en 1, fr/fr 1 | `good_match` | BTS-related results appear across countries/languages. |
-| 8147 | gb | en | general | `+Trump +backed political outsider` | 4 | cn/zh 2, us/null 1, gb/en 1 | `partial_match` | Includes a directly related Colombia election article, but also broader Trump/Iran noise. |
-| 9638 | cn | zh | general | `+China +defends role global` | 0 | none | `no_match` | English title text exists, but required terms are too specific for current FULLTEXT recall. |
-| 8468 | kr | ko | general | `+AI +반도체 붐에` | 0 | none | `no_match` | Korean FULLTEXT behavior and short token handling make original keyword matching ineffective. |
-| 8461 | kr | ko | general | `+이란 +원유시장 복귀 합의에` | 0 | none | `no_match` | Korean original keywords do not produce related Iran/oil matches in this query shape. |
-| 9440 | fr | fr | general | `+Entre +Meloni Trump divorce` | 0 | none | `no_match` | A general French token becomes required and blocks potentially relevant Trump/Meloni matches. |
+| 8146 | gb | en | general | `+First +round Iran talks` | 25 | us/en 14, us/null 5, cn/zh 4, gb/en 2 | `weak_match` | 이란 외교 기사지만 필수어 `First`, `round`가 스포츠 등 관련 없는 결과를 만든다. |
+| 8148 | gb | en | general | `+Russian +troop build threatens` | 0 | none | `no_match` | Ukraine/Donbas 주제가 추출 키워드로 결과를 얻지 못한다. |
+| 8149 | gb | en | general | `+BTS +fans losing thousands` | 8 | cn/zh 4, gb/en 2, us/en 1, fr/fr 1 | `good_match` | 여러 국가와 언어에서 BTS 관련 결과가 나타난다. |
+| 8147 | gb | en | general | `+Trump +backed political outsider` | 4 | cn/zh 2, us/null 1, gb/en 1 | `partial_match` | 직접 관련된 Colombia 선거 기사와 넓은 Trump/Iran 잡음이 함께 있다. |
+| 9638 | cn | zh | general | `+China +defends role global` | 0 | none | `no_match` | 영어 제목이 있지만 필수어가 너무 구체적이어서 현재 FULLTEXT recall이 없다. |
+| 8468 | kr | ko | general | `+AI +반도체 붐에` | 0 | none | `no_match` | 한국어 FULLTEXT 동작과 짧은 token 처리 때문에 원문 매칭이 유효하지 않다. |
+| 8461 | kr | ko | general | `+이란 +원유시장 복귀 합의에` | 0 | none | `no_match` | 한국어 원문 키워드로 관련 Iran/oil 결과가 나오지 않는다. |
+| 9440 | fr | fr | general | `+Entre +Meloni Trump divorce` | 0 | none | `no_match` | 일반적인 프랑스어 token이 필수어가 되어 관련 Trump/Meloni 결과를 막는다. |
 
-## Returned Examples
+## 반환 예시
 
 ### 8146: `+First +round Iran talks`
 
-This base article is about US-Iran talks, but the latest returned rows include unrelated sports or broad-topic matches.
+기준 기사는 US-Iran 회담을 다루지만 최신 반환 행에는 관련 없는 스포츠나 넓은 주제 결과가 포함된다.
 
 | Returned article ID | Country | Language | Title note |
 | --- | --- | --- | --- |
@@ -93,11 +93,11 @@ This base article is about US-Iran talks, but the latest returned rows include u
 | 9744 | cn | zh | China AI rivalry funding |
 | 7667 | cn | zh | New Zealand players facing Iran |
 
-This is a useful example where match count is non-zero but issue quality is weak.
+매칭 결과가 있어도 이슈 품질이 약한 유용한 사례다.
 
 ### 8149: `+BTS +fans losing thousands`
 
-This sample returns BTS-related results across multiple countries and languages.
+여러 국가와 언어에서 BTS 관련 결과가 반환된다.
 
 | Returned article ID | Country | Language | Title note |
 | --- | --- | --- | --- |
@@ -107,11 +107,11 @@ This sample returns BTS-related results across multiple countries and languages.
 | 3008 | us | en | BTS comeback concert |
 | 2104 | fr | fr | BTS album comeback |
 
-This is a useful example where current FULLTEXT behavior can find a coherent topic.
+현재 FULLTEXT가 일관된 주제를 찾는 긍정 표본이다.
 
 ### 8147: `+Trump +backed political outsider`
 
-This sample returns a small mix of related and noisy results.
+관련 결과와 잡음이 소수 섞여 반환된다.
 
 | Returned article ID | Country | Language | Title note |
 | --- | --- | --- | --- |
@@ -120,41 +120,41 @@ This sample returns a small mix of related and noisy results.
 | 3258 | gb | en | Trump-backed television merger |
 | 778 | us | null | Trump allies and Iran |
 
-This is a useful partial-match sample for evaluating future ranking or entity filtering.
+향후 순위 또는 entity filter를 평가하기 좋은 partial-match 표본이다.
 
-## Findings
+## 관찰 결과
 
-- Current FULLTEXT count alone is not enough to judge quality.
-- Required first tokens can be too generic, for example `First` and `round`.
-- English samples can still produce weak matches when title-leading tokens are not core entities.
-- BTS is a good positive sample because the extracted keyword is a strong entity.
-- Korean and French original keyword samples often return zero in this local query snapshot.
-- Some `language='zh'` rows contain English titles, so the `language` field alone does not fully describe search text language.
-- The manual keyword examples in this snapshot are measurement aids, not a replacement for the Java policy.
-  `KeywordExtractorTest` fixes the current Java behavior before any token policy changes are attempted.
-- The regression tests exposed formatting/tokenization quirks, such as compacted `+first+second` BOOLEAN MODE output and Korean tokens joined by the Unicode ellipsis character.
-  The compacted BOOLEAN MODE formatting is normalized in #150; token policy changes remain separate follow-up work.
+- 현재 FULLTEXT 매칭 수만으로 품질을 판단할 수 없다.
+- `First`, `round`처럼 앞쪽 필수 token이 너무 일반적일 수 있다.
+- 영어 표본도 제목 앞 token이 핵심 entity가 아니면 약한 결과가 나올 수 있다.
+- BTS는 추출 키워드가 강한 entity이므로 좋은 긍정 표본이다.
+- 이 로컬 쿼리 snapshot에서 한국어와 프랑스어 원문 표본은 자주 결과를 반환하지 않는다.
+- 일부 `language='zh'` 행은 영어 제목을 가지므로 `language` field만으로 검색 text 언어를 완전히 설명할 수 없다.
+- 이 snapshot의 수동 키워드 예시는 Java 정책을 대체하지 않는 측정 보조 자료다.
+  `KeywordExtractorTest`가 token 정책 변경 전의 Java 동작을 고정한다.
+- 회귀 테스트에서 붙어 있는 `+first+second` BOOLEAN MODE 출력과 Unicode ellipsis로 연결된 한국어 token 같은 형식·tokenization 특성이 드러났다.
+  붙어 있는 BOOLEAN MODE 형식은 #150에서 정규화했으며 token 정책 변경은 별도 후속 작업이다.
 
-## Java Policy Follow-up
+## Java 정책 후속 결과
 
-The snapshot table above preserves the original local measurement keywords and match counts.
-After #150 and #152, the Java `KeywordExtractor` policy changes the generated keywords for the weakest generic-token samples:
+위 snapshot 표는 최초 로컬 측정 키워드와 매칭 수를 보존한다.
+#150과 #152 이후 Java `KeywordExtractor` 정책은 가장 약한 일반 token 표본의 생성 키워드를 다음과 같이 변경한다.
 
 | Base article ID | Previous keyword | #152 Java keyword | Reason |
 | --- | --- | --- | --- |
-| 8146 | `+First +round Iran talks` | `+Iran +talks ends encouraging` | `First` and `round` are filtered as sample-based generic tokens. |
-| 9440 | `+Entre +Meloni Trump divorce` | `+Meloni +Trump divorce italienne` | `Entre` is filtered as a sample-based generic token. |
+| 8146 | `+First +round Iran talks` | `+Iran +talks ends encouraging` | 표본 기반 일반 token인 `First`, `round`를 제거한다. |
+| 9440 | `+Entre +Meloni Trump divorce` | `+Meloni +Trump divorce italienne` | 표본 기반 일반 token인 `Entre`를 제거한다. |
 
-This section documents generated keyword changes only.
-It does not replace the original match counts, because DB-level FULLTEXT result quality should be measured separately after the code change is merged.
-If all extracted candidates are removed by the generic-token filter, both `extract()` and `extractPlain()` return an empty string instead of falling back to the original title.
-The DB-level FULLTEXT result change after #152 is recorded in `perspectives-fulltext-generic-token-filter-result.md`.
+이 절은 생성 키워드 변경만 기록한다.
+DB 수준 FULLTEXT 결과 품질은 코드 변경 merge 후 별도로 측정해야 하므로 최초 매칭 수를 대체하지 않는다.
+일반 token filter로 추출 후보가 모두 제거되면 원래 제목으로 fallback하지 않고 `extract()`와 `extractPlain()` 모두 빈 문자열을 반환한다.
+#152 이후 DB 수준 FULLTEXT 결과 변화는 `perspectives-fulltext-generic-token-filter-result.md`에 기록한다.
 
-## Follow-up Candidates
+## 후속 후보
 
-1. Measure the full API path for the same samples, including translation behavior, with external API usage explicitly approved.
-2. Measure DB-level result changes for #152 generic-token filtering on the representative samples.
-3. Add entity-aware keyword extraction only after comparing against the fixed regression tests.
-4. Compare the current recency ordering with a relevance-first or hybrid ranking strategy.
-5. Define expected countries per sample before trying vector search or Elasticsearch.
-6. Keep `issue_id` or clustering as an ADR-level option until concrete sample failures justify the added model.
+1. 외부 API 사용을 명시적으로 승인한 뒤 동일 표본으로 번역을 포함한 전체 API 경로를 측정한다.
+2. 대표 표본에서 #152 일반 token filtering의 DB 수준 결과 변화를 측정한다.
+3. 고정된 회귀 테스트와 비교한 뒤에만 entity-aware keyword extraction을 추가한다.
+4. 현재 최신순 정렬과 relevance-first 또는 hybrid ranking을 비교한다.
+5. Vector search나 Elasticsearch를 시도하기 전에 표본별 기대 국가를 정의한다.
+6. 구체적인 표본 실패가 추가 모델을 정당화할 때까지 `issue_id` 또는 clustering은 ADR 선택지로 유지한다.

--- a/docs/backend-improvement/perspectives-multilingual-fulltext-integration.md
+++ b/docs/backend-improvement/perspectives-multilingual-fulltext-integration.md
@@ -1,8 +1,8 @@
-# Perspectives Multilingual FULLTEXT Integration
+# Perspectives 다국어 FULLTEXT 통합 검증
 
-## Purpose
+## 목적
 
-This verification fixes the backend behavior of the controlled non-English Perspectives search path:
+이 검증은 영어가 아닌 기준 기사에 대한 Perspectives 검색 경로의 백엔드 동작을 통제된 조건에서 확정한다.
 
 ```text
 non-English base article
@@ -13,58 +13,58 @@ non-English base article
 -> deduplication and country grouping
 ```
 
-It does not measure semantic similarity or improve matching quality. Its purpose is to distinguish deterministic backend-path failures from conditions where a related article is absent or the supplied translation keyword is wrong.
+이 검증은 의미 유사도를 측정하거나 매칭 품질을 개선하지 않는다. 결정적인 백엔드 경로 실패와 관련 기사 부재 또는 잘못된 번역 키워드 조건을 구분하는 것이 목적이다.
 
-## Test Boundary
+## 테스트 경계
 
-| Component | Test behavior |
+| 구성 요소 | 테스트 동작 |
 | --- | --- |
-| `PerspectivesService` | Real service implementation |
-| `KeywordExtractor` | Real keyword extraction |
-| `ArticleRepository.findPerspectives` | Real native query |
-| Database | MySQL 8 Testcontainers with Flyway FULLTEXT schema |
-| Translation | Mockito-controlled result or exception |
-| Redis | Cache TTL set to zero; no read or write |
-| Article data | Test-only Source and Article fixtures |
+| `PerspectivesService` | 실제 서비스 구현 |
+| `KeywordExtractor` | 실제 키워드 추출 |
+| `ArticleRepository.findPerspectives` | 실제 native query |
+| Database | Flyway FULLTEXT schema를 적용한 MySQL 8 Testcontainers |
+| Translation | Mockito로 통제한 결과 또는 예외 |
+| Redis | Cache TTL을 zero로 설정해 읽기·쓰기 없음 |
+| Article data | 테스트 전용 Source 및 Article fixture |
 
-The test does not call Google Translation, News API, RSS, the compose database, or any deployed service.
+이 테스트는 Google Translation, News API, RSS, compose database 또는 배포 서비스를 호출하지 않는다.
 
-## Controlled Scenarios
+## 통제 시나리오
 
-| Scenario | Related row in MySQL | Translation condition | Expected result |
+| 시나리오 | MySQL 관련 행 | 번역 조건 | 기대 결과 |
 | --- | --- | --- | --- |
-| translated success | present | `Lunaris Summit Joint Statement` | English related article returned |
-| source coverage absence | absent | same correct translation | zero articles |
-| wrong translation | present | `Football Transfer Market Opens` | zero articles |
-| translation failure | French related row present | translation exception | original French FULLTEXT result returned |
-| translated/original overlap | one row matches both keyword sets | valid translated keyword | one final article, not two |
+| 번역 성공 | 존재 | `Lunaris Summit Joint Statement` | 영어 관련 기사 반환 |
+| 수집 범위 부재 | 없음 | 동일한 올바른 번역 | 기사 없음 |
+| 잘못된 번역 | 존재 | `Football Transfer Market Opens` | 기사 없음 |
+| 번역 실패 | 프랑스어 관련 행 존재 | 번역 예외 | 원문 프랑스어 FULLTEXT 결과 반환 |
+| 번역/원문 중복 | 한 행이 두 키워드 집합에 모두 매칭 | 유효한 번역 키워드 | 최종 기사는 한 건이며 두 건이 아님 |
 
-The absence and wrong-translation scenarios intentionally produce the same zero-result response under different controlled inputs. This shows why a real zero-result response cannot be assigned to FULLTEXT, translation, or source coverage without additional evidence.
+수집 범위 부재와 잘못된 번역 시나리오는 서로 다른 통제 입력에서 의도적으로 동일한 결과 없음 응답을 만든다. 실제 결과 없음 응답만으로는 추가 근거 없이 원인을 FULLTEXT, 번역, 수집 범위 중 하나로 단정할 수 없음을 보여준다.
 
-## Fixture Interpretation
+## Fixture 해석
 
-The fixture text is written to make each expected FULLTEXT boundary deterministic. It is not a sample of real editorial content and is not evidence that the same query will find semantically related articles in the collected dataset.
+fixture 텍스트는 각 FULLTEXT 경계를 결정적으로 재현하도록 작성했다. 실제 편집 기사 표본이 아니며, 동일 쿼리가 수집 데이터셋에서 의미상 관련된 기사를 찾는다는 근거가 아니다.
 
-The French fallback fixture uses whitespace-separated Latin tokens so the test focuses on fallback orchestration rather than introducing Korean tokenizer behavior into the same assertion.
+프랑스어 fallback fixture는 공백으로 분리된 라틴 문자를 사용한다. 같은 검증에 한국어 tokenizer 동작까지 포함하지 않고 fallback orchestration에 집중하기 위해서다.
 
-Fixtures are committed before the service query runs. The service call runs in a transaction so the native query and lazy `Source` access use the real persistence path.
+서비스 쿼리를 실행하기 전에 fixture를 commit한다. 서비스 호출은 transaction 안에서 실행하므로 native query와 lazy `Source` 접근이 실제 persistence 경로를 사용한다.
 
-## Claims And Non-Claims
+## 검증 가능한 주장과 불가능한 주장
 
-This verification supports the following claims:
+이 검증으로 확인할 수 있는 내용:
 
-- non-English inputs request translation
-- a supplied translated keyword reaches MySQL BOOLEAN MODE FULLTEXT
-- translation failure retains the original-keyword fallback
-- translated and original query results are merged without duplicate article IDs
-- country grouping and total counts reflect the merged result
+- 영어가 아닌 입력에서 번역을 요청한다.
+- 주어진 번역 키워드가 MySQL BOOLEAN MODE FULLTEXT까지 전달된다.
+- 번역 실패 시 원문 키워드 fallback을 유지한다.
+- 번역 결과와 원문 쿼리 결과를 기사 ID 중복 없이 병합한다.
+- 국가별 그룹과 전체 개수가 병합 결과를 반영한다.
 
-It does not support these claims:
+이 검증만으로 확인할 수 없는 내용:
 
-- Google Translation produces an accurate keyword
-- configured RSS or News API sources contain the related event
-- returned articles describe the same real-world event
-- multilingual recall, precision, or semantic similarity improved
-- Elasticsearch, embeddings, Vector DB, or translation persistence is required
+- Google Translation이 정확한 키워드를 생성한다.
+- 설정한 RSS 또는 News API 출처에 관련 사건 기사가 존재한다.
+- 반환 기사가 실제 세계의 같은 사건을 다룬다.
+- 다국어 recall, precision 또는 semantic similarity가 개선됐다.
+- Elasticsearch, embeddings, Vector DB 또는 번역 결과 영속화가 필요하다.
 
-Real matching quality requires a separately labeled sample containing expected related article IDs. Source freshness and local coverage must also be recorded before interpreting missing results.
+실제 매칭 품질을 평가하려면 기대 관련 기사 ID를 포함한 별도 라벨 표본이 필요하다. 누락 결과를 해석하기 전에 출처 최신성과 로컬 수집 범위도 함께 기록해야 한다.

--- a/docs/backend-improvement/perspectives-redis-cache-policy.md
+++ b/docs/backend-improvement/perspectives-redis-cache-policy.md
@@ -1,122 +1,122 @@
-# Perspectives Redis cache policy
+# Perspectives Redis 캐시 정책
 
-## Purpose
+## 목적
 
-`GET /api/news/{id}/perspectives` groups related articles by country after keyword extraction, optional translation, and MySQL FULLTEXT search.
-Because this path is more expensive than a simple article lookup, `PerspectivesService` stores the computed response in Redis.
+`GET /api/news/{id}/perspectives`는 키워드 추출, 선택적 번역, MySQL FULLTEXT 검색 후 관련 기사를 국가별로 묶는다.
+이 경로는 단순 기사 조회보다 비용이 크므로 `PerspectivesService`가 계산 결과를 Redis에 저장한다.
 
-This document records the current cache policy, failure behavior, and stale data trade-off so later performance work can change it deliberately.
+이 문서는 이후 성능 작업에서 의도적으로 정책을 변경할 수 있도록 현재 캐시 정책, 실패 동작, stale data의 trade-off를 기록한다.
 
-## Terms
+## 용어
 
-| Term | Meaning in this project |
+| 용어 | 이 프로젝트에서의 의미 |
 | --- | --- |
-| Cache deletion | Directly removing a Redis key, for example deleting `perspectives:article:8449`. This is useful for tests or manual cleanup. |
-| Cache invalidation | Removing or refreshing cache automatically when source data changes in a way that makes the cached value outdated. |
-| Stale cache | A cached response that is still served even though the underlying DB data changed after it was cached. |
-| Stale allowance | A deliberate decision to tolerate stale cache for a bounded time, usually controlled by TTL, because the data is read-heavy and not mission critical. |
+| Cache deletion | `perspectives:article:8449` 삭제처럼 Redis key를 직접 제거한다. 테스트나 수동 정리에 유용하다. |
+| Cache invalidation | 원본 데이터가 변경돼 캐시가 오래된 값이 될 때 자동으로 제거하거나 갱신한다. |
+| Stale cache | 캐시 저장 후 DB 데이터가 바뀌었지만 계속 제공되는 캐시 응답이다. |
+| Stale allowance | 조회가 많고 핵심 정합성 데이터가 아닐 때, 보통 TTL로 제한된 시간 동안 오래된 값을 허용하는 의도적인 결정이다. |
 
-## Current policy
+## 현재 정책
 
-| Item | Current behavior |
+| 항목 | 현재 동작 |
 | --- | --- |
 | Key prefix | `perspectives:article:` |
-| Key shape | `perspectives:article:{articleId}` |
-| Value | Serialized `PerspectivesResDTO` JSON |
+| Key 형태 | `perspectives:article:{articleId}` |
+| Value | 직렬화한 `PerspectivesResDTO` JSON |
 | TTL property | `perspectives.cache-ttl-seconds` |
-| Default TTL | `3600` seconds |
-| Cache disabled condition | `perspectives.cache-ttl-seconds=0` |
-| Explicit invalidation | Not implemented |
+| 기본 TTL | `3600` seconds |
+| 캐시 비활성 조건 | `perspectives.cache-ttl-seconds=0` |
+| 명시적 invalidation | 구현하지 않음 |
 
-Configuration:
+설정:
 
 ```yaml
 perspectives:
   cache-ttl-seconds: 3600
 ```
 
-## Runtime flow
+## 실행 흐름
 
 ### Cache hit
 
-1. Read `perspectives:article:{articleId}` from Redis.
-2. Deserialize JSON into `PerspectivesResDTO`.
-3. Return the cached response.
-4. Log `cacheHit=true`, `cacheReadMs`, `totalMs`, `countriesFound`, and `totalArticles`.
+1. Redis에서 `perspectives:article:{articleId}`를 읽는다.
+2. JSON을 `PerspectivesResDTO`로 역직렬화한다.
+3. 캐시 응답을 반환한다.
+4. `cacheHit=true`, `cacheReadMs`, `totalMs`, `countriesFound`, `totalArticles`를 로그로 남긴다.
 
 ### Cache miss
 
-1. Load base article from MySQL.
-2. Extract plain and FULLTEXT boolean keywords from the title.
-3. Translate non-English article keywords to English.
-4. Search related articles with MySQL FULLTEXT.
-5. Group results by country and limit each country to 3 articles.
-6. Serialize the response and store it in Redis with TTL.
-7. Log `cacheHit=false` and step-level timings.
+1. MySQL에서 기준 기사를 조회한다.
+2. 제목에서 일반 키워드와 FULLTEXT boolean 키워드를 추출한다.
+3. 영어가 아닌 기사 키워드를 영어로 번역한다.
+4. MySQL FULLTEXT로 관련 기사를 검색한다.
+5. 결과를 국가별로 묶고 국가당 기사 수를 3개로 제한한다.
+6. 응답을 직렬화해 TTL과 함께 Redis에 저장한다.
+7. `cacheHit=false`와 단계별 시간을 로그로 남긴다.
 
-## Failure behavior
+## 실패 동작
 
-| Failure case | Current behavior | API impact |
+| 실패 상황 | 현재 동작 | API 영향 |
 | --- | --- | --- |
-| Redis read failure | Warn and recompute from DB/FULLTEXT | Response can still succeed |
-| Cache JSON deserialize failure | Warn and recompute from DB/FULLTEXT | Response can still succeed |
-| Redis write failure | Warn and ignore | Response succeeds, next request may be cold again |
-| Base article missing | Throw domain exception | Response fails as before |
+| Redis 읽기 실패 | 경고 후 DB/FULLTEXT에서 재계산 | 응답 성공 가능 |
+| Cache JSON 역직렬화 실패 | 경고 후 DB/FULLTEXT에서 재계산 | 응답 성공 가능 |
+| Redis 쓰기 실패 | 경고 후 무시 | 응답은 성공하고 다음 요청도 cold일 수 있음 |
+| 기준 기사 없음 | 도메인 예외 발생 | 기존과 동일하게 응답 실패 |
 
-Redis is treated as an optimization layer, not the source of truth.
-The source of truth remains MySQL.
+Redis는 원본 데이터가 아니라 최적화 계층으로 취급한다.
+원본 데이터의 기준은 MySQL이다.
 
-## Stale cache analysis
+## Stale cache 분석
 
-The current service is mostly read-heavy after news ingestion.
-For this reason, bounded stale cache is acceptable for Perspectives responses as long as TTL remains short enough for the product expectation.
+현재 서비스는 뉴스 수집 후 조회 비중이 높다.
+따라서 TTL이 제품 기대에 맞게 충분히 짧다면 Perspectives 응답의 제한된 stale cache를 허용할 수 있다.
 
-| Data change | Can affect Perspectives response? | Current handling | Notes |
+| 데이터 변경 | Perspectives 응답에 영향? | 현재 처리 | 참고 |
 | --- | --- | --- | --- |
-| New related articles inserted | Yes | Existing cache remains until TTL expires | Newly inserted related articles may not appear immediately. |
-| Base article title changed | Yes | Existing cache remains until TTL expires | Keyword extraction result can become outdated. |
-| Article country/category changed | Yes | Existing cache remains until TTL expires | Country grouping can become outdated. |
-| Article source changed | Maybe | Existing cache remains until TTL expires | Source name is included in child article DTOs. |
-| View count increased | No | No invalidation needed | View count is not part of Perspectives response. |
-| Summary updated | No | No invalidation needed | Summary is not part of Perspectives response. |
-| Crawled content updated | No | No invalidation needed | Crawled content is not part of Perspectives response. |
-| Scrap/chat data changed | No | No invalidation needed | Not used by Perspectives response. |
+| 새 관련 기사 삽입 | 예 | TTL 만료까지 기존 캐시 유지 | 새 관련 기사가 즉시 나타나지 않을 수 있다. |
+| 기준 기사 제목 변경 | 예 | TTL 만료까지 기존 캐시 유지 | 키워드 추출 결과가 오래된 값일 수 있다. |
+| 기사 국가/카테고리 변경 | 예 | TTL 만료까지 기존 캐시 유지 | 국가 그룹이 오래된 값일 수 있다. |
+| 기사 출처 변경 | 가능 | TTL 만료까지 기존 캐시 유지 | 하위 기사 DTO에 출처 이름이 포함된다. |
+| 조회 수 증가 | 아니요 | invalidation 불필요 | 조회 수는 Perspectives 응답에 없다. |
+| 요약 갱신 | 아니요 | invalidation 불필요 | 요약은 Perspectives 응답에 없다. |
+| 크롤링 본문 갱신 | 아니요 | invalidation 불필요 | 크롤링 본문은 Perspectives 응답에 없다. |
+| 스크랩/채팅 데이터 변경 | 아니요 | invalidation 불필요 | Perspectives 응답에서 사용하지 않는다. |
 
-## Decision
+## 결정
 
-For the current project stage, keep TTL-based stale allowance instead of adding explicit invalidation.
+현재 프로젝트 단계에서는 명시적 invalidation을 추가하지 않고 TTL 기반 stale allowance를 유지한다.
 
-Reasons:
+근거:
 
-- Perspectives is a read-heavy derived response.
-- Article edits that affect Perspectives appear rare in the current API surface.
-- News ingestion can add related articles, but showing them after at most the TTL window is acceptable for this feature.
-- Explicit invalidation would require wiring cache deletion into every write path that can affect related article matching.
-- The current 1-hour TTL bounds stale responses while preserving the measured warm cache benefit.
+- Perspectives는 조회가 많은 파생 응답이다.
+- 현재 API 표면에서 Perspectives에 영향을 주는 기사 수정은 드물다.
+- 뉴스 수집으로 관련 기사가 추가될 수 있지만, 이 기능에서는 최대 TTL 시간 뒤 노출되어도 허용할 수 있다.
+- 명시적 invalidation은 관련 기사 매칭에 영향을 주는 모든 쓰기 경로에 캐시 삭제를 연결해야 한다.
+- 현재 1시간 TTL은 측정된 warm cache 이점을 유지하면서 오래된 응답 시간을 제한한다.
 
-## When to add invalidation
+## Invalidation 추가 조건
 
-Add explicit invalidation if one of these becomes true:
+다음 중 하나가 성립하면 명시적 invalidation을 추가한다.
 
-- Admin APIs start editing article title, country, category, source, or language.
-- News ingestion becomes frequent enough that newly inserted related articles must appear immediately.
-- Users report stale Perspectives results as a correctness issue.
-- Cache TTL needs to be raised significantly beyond the current 1-hour window.
+- 관리 API가 기사 제목, 국가, 카테고리, 출처 또는 언어를 수정하기 시작한다.
+- 뉴스 수집이 잦아져 새 관련 기사를 즉시 표시해야 한다.
+- 사용자가 오래된 Perspectives 결과를 정합성 문제로 보고한다.
+- Cache TTL을 현재 1시간보다 크게 늘려야 한다.
 
-Potential invalidation targets:
+invalidation 대상 후보:
 
 ```text
 perspectives:article:{baseArticleId}
 ```
 
-Full correctness is harder than deleting only the changed article key.
-If a newly inserted article is related to many existing base articles, those existing base article caches can also become stale.
-That broader invalidation problem should be handled in a separate design issue.
+변경된 기사 key만 삭제하는 것으로 완전한 정합성을 보장하기는 어렵다.
+새 기사가 기존 여러 기준 기사와 관련 있다면 해당 기준 기사 캐시도 오래된 값이 된다.
+이 광범위한 invalidation 문제는 별도 설계 이슈로 다뤄야 한다.
 
-## Follow-up candidates
+## 후속 후보
 
-- Measure cold cache with multiple article IDs to understand FULLTEXT variance.
-- Use MySQL `EXPLAIN` on `ArticleRepository.findPerspectives`.
-- Revisit TTL after measuring warm cache hit ratio and stale tolerance.
-- Consider local cache only if Redis hit path itself becomes a bottleneck.
-- Consider asynchronous precomputation only if cold cache latency becomes user-visible at higher traffic.
+- 여러 기사 ID로 cold cache를 측정해 FULLTEXT 편차를 파악한다.
+- `ArticleRepository.findPerspectives`에 MySQL `EXPLAIN`을 수행한다.
+- Warm cache hit ratio와 stale 허용 범위를 측정한 뒤 TTL을 재검토한다.
+- Redis hit 경로 자체가 병목이 될 때만 local cache를 검토한다.
+- 높은 트래픽에서 cold cache 지연이 사용자에게 드러날 때만 비동기 사전 계산을 검토한다.

--- a/docs/backend-improvement/perspectives-source-coverage-limit-log.md
+++ b/docs/backend-improvement/perspectives-source-coverage-limit-log.md
@@ -1,97 +1,96 @@
-# Perspectives source coverage limit log
+# Perspectives 수집 범위 한계 기록
 
-## Purpose
+## 목적
 
-This log records a data-side limitation that must be considered when interpreting Perspectives matching quality.
+이 기록은 Perspectives 매칭 품질을 해석할 때 고려해야 하는 데이터 측 한계를 남긴다.
 
-Perspectives matching is affected not only by keyword extraction, MySQL FULLTEXT, translation, ranking, or future semantic similarity.
-It is also constrained by the article data that has actually been collected from RSS and News API sources.
+Perspectives 매칭은 키워드 추출, MySQL FULLTEXT, 번역, 순위 또는 향후 semantic similarity뿐 아니라 RSS와 News API에서 실제 수집된 기사 데이터에도 제한된다.
 
-This document is a measurement and ADR interpretation aid.
-It does not change crawler behavior, RSS feeds, DB schema, FULLTEXT query shape, ranking, or cache policy.
+이 문서는 측정 및 ADR 해석을 돕는다.
+크롤러 동작, RSS feed, DB schema, FULLTEXT query 형태, 순위 또는 캐시 정책은 변경하지 않는다.
 
-## Background
+## 배경
 
-The project collects articles from multiple external sources.
-Those sources do not behave like a balanced event dataset:
+프로젝트는 여러 외부 출처에서 기사를 수집한다.
+이 출처들은 균형 잡힌 사건 데이터셋처럼 동작하지 않는다.
 
-- each RSS feed can have a different update interval
-- each media source can choose different stories for its RSS feed
-- some countries, languages, or categories can have more collected articles than others
-- a same global issue can appear in one source earlier than another
-- some sources may publish a related article outside the categories or feeds currently collected
-- News API free-plan limitations and RSS feed coverage affect which articles enter the DB
+- RSS feed마다 갱신 주기가 다를 수 있다.
+- 각 언론사는 RSS feed에 서로 다른 기사를 선택할 수 있다.
+- 국가·언어·카테고리별 수집 기사 수가 다를 수 있다.
+- 같은 국제 이슈도 출처마다 게시 시점이 다를 수 있다.
+- 관련 기사가 현재 수집하는 카테고리나 feed 밖에 게시될 수 있다.
+- News API 무료 요금제 제한과 RSS feed 범위가 DB에 들어오는 기사에 영향을 준다.
 
-Therefore, Perspectives quality is bounded by both search quality and data coverage.
+따라서 Perspectives 품질은 검색 품질과 데이터 수집 범위 모두에 제한된다.
 
-## Interpretation Rule
+## 해석 규칙
 
-When measuring FULLTEXT, keyword, vector, embedding, or future issue-clustering quality, separate these two causes:
+FULLTEXT, keyword, vector, embedding 또는 향후 issue clustering 품질을 측정할 때 다음 두 원인을 분리한다.
 
-| Observation | Search-side interpretation | Data-side interpretation |
+| 관찰 | 검색 측 해석 | 데이터 측 해석 |
 | --- | --- | --- |
-| `0` matches | Query terms, language, tokenization, or ranking may be poor. | Related articles may not exist in the collected DB yet. |
-| Low country diversity | Matching may over-focus on one language or source. | Some country feeds may not have supplied the issue. |
-| No related non-English result | Translation or multilingual search may be insufficient. | Non-English sources may not have published or been collected for that issue. |
-| Noisy matches | Keywords may be too broad or ordering may be recency-biased. | The DB may contain many broad-topic articles but few exact same-issue articles. |
-| Apparent improvement after query tuning | Search terms may be better. | The sample may simply have better available coverage than other issues. |
+| `0` matches | Query term, language, tokenization 또는 ranking이 좋지 않을 수 있다. | 관련 기사가 아직 수집 DB에 없을 수 있다. |
+| 낮은 국가 다양성 | 한 언어나 출처에 매칭이 치우칠 수 있다. | 일부 국가 feed가 해당 이슈를 제공하지 않았을 수 있다. |
+| 영어 외 관련 결과 없음 | 번역 또는 다국어 검색이 불충분할 수 있다. | 비영어 출처가 기사를 게시하지 않았거나 수집되지 않았을 수 있다. |
+| 잡음 결과 | 키워드가 너무 넓거나 최신순 정렬에 치우칠 수 있다. | DB에 넓은 주제 기사는 많고 정확히 같은 이슈 기사는 적을 수 있다. |
+| 쿼리 조정 후 겉보기 개선 | 검색어가 개선됐을 수 있다. | 해당 표본의 수집 범위가 다른 이슈보다 좋았을 뿐일 수 있다. |
 
-## FULLTEXT-Specific Limit
+## FULLTEXT 고유 한계
 
-MySQL FULLTEXT can only search text that exists in the local `article` table.
-It cannot find:
+MySQL FULLTEXT는 로컬 `article` 테이블에 존재하는 텍스트만 검색할 수 있다.
+다음 기사는 찾을 수 없다.
 
-- articles that have not been collected yet
-- articles from feeds that do not expose the issue
-- articles from sources outside the configured RSS/News API list
-- same-issue articles written with words that do not overlap enough with the generated query
+- 아직 수집되지 않은 기사
+- feed가 해당 이슈를 노출하지 않은 기사
+- 설정된 RSS/News API 목록 밖의 출처 기사
+- 생성 쿼리와 단어가 충분히 겹치지 않는 동일 이슈 기사
 
-For this reason, a FULLTEXT result change measurement should not conclude "the algorithm is bad" or "the algorithm is fixed" from match count alone.
-It should record returned examples and distinguish search failure from possible source coverage gaps.
+따라서 FULLTEXT 결과 변화 측정에서 매칭 수만으로 "알고리즘이 나쁘다" 또는 "알고리즘을 해결했다"고 결론 내리면 안 된다.
+반환 예시를 기록하고 검색 실패와 수집 범위 부족 가능성을 구분해야 한다.
 
-## ADR Implication
+## ADR에 미치는 영향
 
-Future ADRs for Elasticsearch, vector search, embeddings, RAG, or issue clustering should use this boundary:
+Elasticsearch, vector search, embeddings, RAG 또는 issue clustering ADR은 다음 경계를 사용해야 한다.
 
-| Candidate | Can help with | Cannot solve by itself |
+| 후보 | 개선 가능한 부분 | 단독으로 해결할 수 없는 부분 |
 | --- | --- | --- |
-| FULLTEXT tuning | Token/query shape, index use, simple keyword recall | Missing articles or uncollected sources |
-| Better keyword extraction | Noisy title tokens and weak required terms | Source update delay or feed selection bias |
-| Elasticsearch | Search analyzers, ranking, multilingual text handling | Lack of collected same-issue articles |
-| Vector/embedding search | Different wording for the same issue | Articles absent from the DB |
-| Issue clustering | Stable grouping of collected articles | External source coverage and freshness |
-| RAG | Explanation over retrieved content | Retrieval gaps caused by missing source data |
+| FULLTEXT tuning | Token/query 형태, index 사용, 단순 keyword recall | 누락 기사 또는 수집하지 않은 출처 |
+| 더 나은 keyword extraction | 불필요한 제목 token과 약한 필수 검색어 | 출처 갱신 지연 또는 feed 선택 편향 |
+| Elasticsearch | Search analyzer, ranking, 다국어 text 처리 | 수집된 동일 이슈 기사 자체의 부재 |
+| Vector/embedding search | 같은 이슈의 서로 다른 표현 | DB에 없는 기사 |
+| Issue clustering | 수집 기사의 안정적인 그룹화 | 외부 출처 범위와 최신성 |
+| RAG | 검색된 콘텐츠에 대한 설명 | 원본 데이터 누락으로 인한 retrieval gap |
 
-If a representative issue is absent from the collected dataset, search-layer technology cannot recover it.
-The correct follow-up may be source coverage analysis, ingestion scheduling, feed expansion, or data freshness tracking rather than search ranking.
+대표 이슈가 수집 데이터셋에 없다면 검색 계층 기술로 복원할 수 없다.
+올바른 후속 작업은 검색 순위가 아니라 출처 범위 분석, 수집 일정, feed 확장 또는 데이터 최신성 추적일 수 있다.
 
-## Measurement Guidance
+## 측정 지침
 
-For every future Perspectives quality snapshot, record:
+향후 모든 Perspectives 품질 snapshot에는 다음을 기록한다.
 
-- measurement date and local dataset size
-- sample article ID, country, language, category, source, and published time when available
-- generated keyword before and after the change
-- match count and returned country/language spread
-- a few returned title notes for manual quality review
-- whether `0` or low-diversity results may be caused by source coverage rather than search behavior
+- 측정일과 로컬 데이터셋 크기
+- 가능한 경우 표본 기사 ID, 국가, 언어, 카테고리, 출처, 게시 시각
+- 변경 전후 생성 keyword
+- 매칭 수와 반환 국가/언어 분포
+- 수동 품질 검토를 위한 일부 반환 제목 메모
+- `0`건 또는 낮은 다양성이 검색 동작이 아닌 수집 범위에서 비롯됐을 가능성
 
-Avoid using match count alone as the success metric.
-Prefer a short interpretation that says whether the result looks like:
+매칭 수만 성공 지표로 사용하지 않는다.
+결과가 다음 중 어디에 가까운지 짧게 해석한다.
 
-- search/query limitation
-- data coverage limitation
-- mixed limitation
-- insufficient evidence
+- 검색/쿼리 한계
+- 데이터 수집 범위 한계
+- 혼합 한계
+- 근거 부족
 
-## Link To Current P3 Flow
+## 현재 P3 흐름과의 연결
 
-Current P3 work has already created:
+현재 P3 작업에서 이미 다음을 만들었다.
 
-- a matching quality baseline
-- a local FULLTEXT sample snapshot
-- `KeywordExtractor` regression tests
-- BOOLEAN MODE formatting normalization
-- sample-based generic-token filtering
+- 매칭 품질 기준선
+- 로컬 FULLTEXT 표본 snapshot
+- `KeywordExtractor` 회귀 테스트
+- BOOLEAN MODE 형식 정규화
+- 표본 기반 일반 token 필터링
 
-The next DB-level FULLTEXT result measurement should use this log as an interpretation guardrail before deciding whether keyword tuning is enough or whether an ADR is needed.
+다음 DB 수준 FULLTEXT 결과 측정에서는 keyword 조정으로 충분한지 ADR이 필요한지 결정하기 전에 이 기록을 해석 guardrail로 사용해야 한다.

--- a/docs/backend-improvement/search-fulltext-analysis.md
+++ b/docs/backend-improvement/search-fulltext-analysis.md
@@ -1,11 +1,10 @@
-# Search API FULLTEXT analysis
+# 검색 API FULLTEXT 분석
 
-## Purpose
+## 목적
 
-This document records the current MySQL FULLTEXT behavior of `GET /api/search`.
-The goal is to explain how the search query behaves by keyword and to document a small optimization for cases where the original search text and translated text are the same.
+이 문서는 `GET /api/search`의 현재 MySQL FULLTEXT 동작을 기록한다. 검색어에 따라 쿼리가 어떻게 실행되는지 설명하고, 원문 검색어와 번역 검색어가 같은 경우의 작은 최적화를 문서화하는 것이 목적이다.
 
-## Target flow
+## 대상 흐름
 
 ```text
 SearchController
@@ -14,11 +13,11 @@ SearchController
 -> ArticleRepository.searchByDescriptionOrTitleWithExploreFilters(...)
 ```
 
-The API searches both the original text and the English translation.
+API는 원문과 영어 번역문을 모두 검색한다.
 
-## Previous query shape
+## 기존 쿼리 형태
 
-`searchByDescriptionOrTitleWithExploreFilters` used two FULLTEXT predicates joined by `OR`:
+`searchByDescriptionOrTitleWithExploreFilters`는 두 FULLTEXT 조건을 `OR`로 연결했다.
 
 ```sql
 SELECT *
@@ -35,40 +34,37 @@ ORDER BY published_at DESC
 LIMIT 100;
 ```
 
-This is necessary when the original text and translated text differ.
-However, for English inputs such as `war`, translation can return the same text.
-In that case, the previous query effectively repeated the same FULLTEXT predicate:
+원문과 번역문이 다를 때는 이 형태가 필요하다. 하지만 `war` 같은 영어 입력은 번역 결과가 원문과 같을 수 있다. 이 경우 기존 쿼리는 사실상 같은 FULLTEXT 조건을 반복한다.
 
 ```sql
 MATCH(...) AGAINST('war' ...)
 OR MATCH(...) AGAINST('war' ...)
 ```
 
-## Finding
+## 확인 결과
 
-On the local development dataset, a single `MATCH` query used the FULLTEXT index.
-The duplicated `OR MATCH` query chose a reverse scan on `idx_article_published_at` and applied MATCH as a filter.
-The representative `EXPLAIN ANALYZE` examples below use the default search path without optional `country`, `category`, or `date` filters.
-Queries with those filters can choose different execution plans depending on selectivity.
+로컬 개발 데이터에서 단일 `MATCH` 쿼리는 FULLTEXT index를 사용했다. 중복 `OR MATCH` 쿼리는 `idx_article_published_at` 역방향 scan을 선택하고 `MATCH`를 filter로 적용했다.
 
-Dataset:
+아래 대표 `EXPLAIN ANALYZE`는 선택적인 `country`, `category`, `date` filter가 없는 기본 검색 경로다. 해당 filter를 사용하면 선택도에 따라 다른 실행 계획이 선택될 수 있다.
 
-| Item | Value |
+데이터:
+
+| 항목 | 값 |
 | --- | --- |
 | Table | `article` |
-| Total rows | `9853` |
+| 전체 row | `9853` |
 | FULLTEXT index | `ft_article_title_description(title, description)` |
 
-Keyword match counts:
+검색어별 일치 수:
 
-| Keyword | Match count |
+| 검색어 | 일치 수 |
 | --- | --- |
 | `war` | 404 |
 | `technology` | 82 |
 | `economy` | 39 |
 | `대구` OR `daegu` | 0 |
 
-### Single MATCH
+### 단일 MATCH
 
 ```sql
 EXPLAIN ANALYZE
@@ -79,7 +75,7 @@ ORDER BY published_at DESC
 LIMIT 100;
 ```
 
-Summary:
+요약:
 
 ```text
 Full-text index search on article using ft_article_title_description
@@ -89,7 +85,7 @@ Sort row IDs: article.published_at DESC
 actual time=10.3..10.7 rows=100
 ```
 
-### Duplicated OR MATCH
+### 중복 OR MATCH
 
 ```sql
 EXPLAIN ANALYZE
@@ -103,7 +99,7 @@ ORDER BY published_at DESC
 LIMIT 100;
 ```
 
-Summary:
+요약:
 
 ```text
 Index scan on article using idx_article_published_at (reverse)
@@ -113,47 +109,47 @@ Filter
 actual time=2.75..27.1 rows=100
 ```
 
-Interpretation:
+해석:
 
-- Single MATCH uses the intended FULLTEXT index.
-- Duplicated OR MATCH can make MySQL prefer the `published_at` index and evaluate MATCH as a filter.
-- This is visible for English inputs where original and translated text are effectively the same.
+- 단일 `MATCH`는 의도한 FULLTEXT index를 사용한다.
+- 중복 `OR MATCH`는 MySQL이 `published_at` index를 선택하고 `MATCH`를 filter로 평가하게 만들 수 있다.
+- 이 차이는 원문과 번역문이 사실상 같은 영어 입력에서 나타난다.
 
-## Change
+## 변경
 
-`SearchArticlesService` now checks whether `text` and `translatedText` are the same after trimming and case-insensitive comparison.
+`SearchArticlesService`는 `text`와 `translatedText`를 trim하고 대소문자를 무시해 비교한다.
 
-- If they are the same, it calls a single-MATCH repository query.
-- If they differ, it keeps the existing OR-MATCH query to preserve multilingual search behavior.
+- 두 값이 같으면 단일 `MATCH` repository query를 호출한다.
+- 두 값이 다르면 기존 다국어 검색 동작을 유지하기 위해 `OR MATCH` query를 사용한다.
 
-No API response structure changed.
+API 응답 구조는 변경하지 않았다.
 
-## API check
+## API 확인
 
-Representative API calls after the previous #123 fix:
+#123 수정 이후의 대표 호출:
 
-| Request | Status | Notes |
+| 요청 | 상태 | 설명 |
 | --- | --- | --- |
-| `/api/search?text=war` | 200 | English, many matches |
-| `/api/search?text=economy` | 200 | English, fewer matches |
-| `/api/search?text=technology` | 200 | English, medium matches |
-| `/api/search?text=대구` | 200 | Translates to `daegu`, zero current FULLTEXT matches |
+| `/api/search?text=war` | 200 | 영어, 다수 결과 |
+| `/api/search?text=economy` | 200 | 영어, 비교적 적은 결과 |
+| `/api/search?text=technology` | 200 | 영어, 중간 규모 결과 |
+| `/api/search?text=대구` | 200 | `daegu`로 번역되지만 현재 FULLTEXT 결과는 없음 |
 
-## Decision
+## 판단
 
-Keep the OR-MATCH query for different original/translated terms, but avoid duplicated OR-MATCH when both terms are the same.
+원문과 번역문이 다르면 `OR MATCH`를 유지하되, 두 값이 같을 때는 중복 `OR MATCH`를 피한다.
 
-Reasons:
+근거:
 
-- It is a small scoped change.
-- It preserves the response shape and existing multilingual search behavior.
-- It lets English same-term searches use the intended FULLTEXT index.
-- Broader search quality topics, such as Korean morphology, multilingual ranking, Elasticsearch, or vector search, remain separate follow-up work.
+- 범위가 작은 변경이다.
+- 응답 구조와 기존 다국어 검색 동작을 유지한다.
+- 영어 동일 검색어가 의도한 FULLTEXT index를 사용할 수 있다.
+- 한국어 형태소, 다국어 ranking, Elasticsearch, vector search 같은 검색 품질 주제는 별도 후속 작업으로 남긴다.
 
-## Follow-up candidates
+## 후속 후보
 
-- Measure `/api/search` p95 before/after for same-term English searches with k6.
-- Analyze OR-MATCH cases where original and translated terms differ.
-- Compare current FULLTEXT results with expected results for representative Korean and multilingual queries.
-- Consider a query rewrite with `UNION` only if OR-MATCH remains a measurable bottleneck.
-- Define search quality samples before introducing Elasticsearch or semantic search.
+- k6로 동일 영어 검색어의 `/api/search` p95 전후 비교
+- 원문과 번역문이 다른 `OR MATCH` 사례 분석
+- 대표 한국어·다국어 질의의 현재 FULLTEXT 결과와 기대 결과 비교
+- `OR MATCH`가 반복 측정에서 병목으로 확인될 때만 `UNION` query rewrite 검토
+- Elasticsearch 또는 semantic search 도입 전에 검색 품질 표본 정의

--- a/docs/backend-improvement/search-fulltext-term-baseline.md
+++ b/docs/backend-improvement/search-fulltext-term-baseline.md
@@ -1,87 +1,82 @@
-# Search API FULLTEXT term baseline
+# 검색 API FULLTEXT 검색어별 기준선
 
-## Purpose
+## 목적
 
-This document defines a repeatable baseline for `GET /api/search` by search term type.
-It connects the #133/#134 MySQL FULLTEXT query-plan improvement to API-level measurements such as p95 response time, failure rate, and result count.
+이 문서는 검색어 유형별 `GET /api/search` 반복 측정 기준을 정의한다. #133/#134의 MySQL FULLTEXT 실행 계획 개선을 API p95 응답시간, 실패율, 결과 수와 연결한다.
 
-This work does not change code behavior, DB schema, FULLTEXT query shape, API response shape, Redis policy, or translation policy.
+이 작업은 코드 동작, DB schema, FULLTEXT query, API 응답, Redis 정책, 번역 정책을 변경하지 않는다.
 
-## Portfolio Summary Candidate
+## 핵심 결과 요약
 
 ```text
 검색 API의 MySQL FULLTEXT 쿼리를 검색어 유형별로 측정하고 실행 계획 개선 근거와 연결해, p95 응답 시간과 실패율 기준선을 수립했습니다.
 ```
 
-Shorter resume keyword version:
+압축 표현:
 
 ```text
 검색 API MySQL FULLTEXT 실행 계획 분석 및 검색어별 p95/실패율 기준선 수립
 ```
 
-## Background
+## 배경
 
-#133/#134 analyzed the Search API FULLTEXT query path.
-For English inputs where the original search text and translated text are effectively the same, the previous duplicated `OR MATCH` shape could make MySQL choose `idx_article_published_at` instead of the intended FULLTEXT index.
+#133/#134에서는 검색 API의 FULLTEXT query 경로를 분석했다. 영어 입력에서 원문과 번역문이 같으면 기존의 중복 `OR MATCH` 때문에 MySQL이 의도한 FULLTEXT index 대신 `idx_article_published_at`을 선택할 수 있었다.
 
-The current code avoids duplicated `OR MATCH` for same original/translated terms and keeps the OR query only when the original and translated terms differ.
+현재 코드는 원문과 번역문이 같을 때 중복 `OR MATCH`를 피하고, 두 값이 다를 때만 `OR` query를 유지한다.
 
-Known local DB-level match counts from #133:
+#133에서 확인한 로컬 DB 일치 수:
 
-| Keyword | Match count | Interpretation |
+| 검색어 | 일치 수 | 해석 |
 | --- | ---: | --- |
-| `war` | 404 | English same-term, high-match sample |
-| `technology` | 82 | English same-term, medium-match sample |
-| `economy` | 39 | English same-term, lower-match sample |
-| `대구` OR `daegu` | 0 | Korean input translated to English, zero current FULLTEXT match sample |
+| `war` | 404 | 영어 동일 검색어, 다수 결과 표본 |
+| `technology` | 82 | 영어 동일 검색어, 중간 결과 표본 |
+| `economy` | 39 | 영어 동일 검색어, 적은 결과 표본 |
+| `대구` OR `daegu` | 0 | 한국어를 영어로 번역했지만 현재 결과가 없는 표본 |
 
-Known API checks after #123/#126 and #133/#134:
+#123/#126과 #133/#134 이후 API 확인:
 
-| Request | Status | Notes |
+| 요청 | 상태 | 설명 |
 | --- | --- | --- |
-| `/api/search?text=war` | 200 | English, many matches |
-| `/api/search?text=economy` | 200 | English, fewer matches |
-| `/api/search?text=technology` | 200 | English, medium matches |
-| `/api/search?text=대구` | 200 | Translates to `daegu`, zero current FULLTEXT matches |
+| `/api/search?text=war` | 200 | 영어, 다수 결과 |
+| `/api/search?text=economy` | 200 | 영어, 비교적 적은 결과 |
+| `/api/search?text=technology` | 200 | 영어, 중간 규모 결과 |
+| `/api/search?text=대구` | 200 | `daegu`로 번역되지만 현재 결과는 없음 |
 
-## Measurement Tool
+## 측정 도구
 
-Use `load-tests/k6/search-fulltext-terms.js`.
+`load-tests/k6/search-fulltext-terms.js`를 사용한다.
 
-The script requests `/api/search` for a comma-separated search term set and tags each request with `searchTerm`.
-It also records the response `data.searchArticles.length` into the custom `search_result_count` metric.
+script는 쉼표로 구분한 검색어를 `/api/search`에 요청하고 각 요청에 `searchTerm` tag를 붙인다. 응답의 `data.searchArticles.length`는 custom `search_result_count` metric으로 기록한다.
 
-Default terms:
+기본 검색어:
 
 ```text
 war,korea,economy,technology,대구,AI
 ```
 
-## Search Term Set
+## 검색어 집합
 
-| Type | Term | Why |
+| 유형 | 검색어 | 선정 이유 |
 | --- | --- | --- |
-| English high-match | `war` | Exercises many-match same-term FULLTEXT behavior from #133. |
-| English common topic | `korea` | Checks common English keyword behavior after #123 fixed 500 responses. |
-| English lower-match | `economy` | Checks lower result-count path. |
-| English medium-match | `technology` | Checks medium result-count path from #133. |
-| Korean translated zero-match | `대구` | Confirms translated/original search can return 200 even with zero local FULLTEXT matches. |
-| Short/common technical term | `AI` | Checks short uppercase input handling and result count variance. |
+| 영어 다수 결과 | `war` | #133에서 확인한 다수 결과 동일 검색어 FULLTEXT 경로 |
+| 영어 일반 주제 | `korea` | #123의 500 수정 이후 일반 영어 검색 동작 확인 |
+| 영어 적은 결과 | `economy` | 결과 수가 적은 경로 확인 |
+| 영어 중간 결과 | `technology` | #133의 중간 결과 표본 |
+| 한국어 번역·결과 없음 | `대구` | 번역·원문 검색 결과가 없어도 200을 반환하는지 확인 |
+| 짧은 기술 용어 | `AI` | 짧은 대문자 입력과 결과 수 편차 확인 |
 
-Do not treat result count alone as search quality.
-This baseline records performance and stability first.
-Search relevance and multilingual quality require separate samples and manual review.
+결과 수만으로 검색 품질을 판단하지 않는다. 이 기준선은 우선 성능과 안정성을 기록한다. 검색 관련성과 다국어 품질은 별도 표본과 수동 판정이 필요하다.
 
-## Execution
+## 실행
 
-Start local dependencies and server first.
+먼저 로컬 의존성과 서버를 실행한다.
 
 ```powershell
 docker compose -f docker-compose.dev.yml up -d
 .\gradlew.bat bootRun
 ```
 
-Run a short smoke baseline:
+짧은 smoke 기준선:
 
 ```powershell
 $env:BASE_URL = "http://localhost:8080"
@@ -92,7 +87,7 @@ $env:SLEEP_SECONDS = "1"
 k6 run .\load-tests\k6\search-fulltext-terms.js
 ```
 
-Run a longer local baseline:
+긴 로컬 기준선:
 
 ```powershell
 $env:BASE_URL = "http://localhost:8080"
@@ -103,7 +98,7 @@ $env:SLEEP_SECONDS = "1"
 k6 run .\load-tests\k6\search-fulltext-terms.js
 ```
 
-Optional filters:
+선택 filter:
 
 ```powershell
 $env:COUNTRY = "kr"
@@ -111,57 +106,52 @@ $env:CATEGORY = "business"
 $env:DATE = "2026-07-01"
 ```
 
-## Result Recording Template
+## 결과 기록 양식
 
-Record p95 and failure rate from k6 output.
-Record result count from `search_result_count` per `searchTerm` and confirm `SearchArticlesService` logs for `resultCount`, `dbSearchMs`, and `totalMs` when needed.
+k6 출력에서 p95와 실패율을 기록한다. `searchTerm`별 `search_result_count`를 기록하고 필요하면 `SearchArticlesService` log의 `resultCount`, `dbSearchMs`, `totalMs`를 확인한다.
 
-| Date | Environment | Term | Type | p95 | Failure rate | Result count | Notes |
+| 날짜 | 환경 | 검색어 | 유형 | p95 | 실패율 | 결과 수 | 비고 |
 | --- | --- | --- | --- | ---: | ---: | ---: | --- |
-|  | local/dev | `war` | English high-match |  |  |  |  |
-|  | local/dev | `korea` | English common topic |  |  |  |  |
-|  | local/dev | `economy` | English lower-match |  |  |  |  |
-|  | local/dev | `technology` | English medium-match |  |  |  |  |
-|  | local/dev | `대구` | Korean translated zero-match |  |  |  |  |
-|  | local/dev | `AI` | Short/common technical term |  |  |  |  |
+|  | local/dev | `war` | 영어 다수 결과 |  |  |  |  |
+|  | local/dev | `korea` | 영어 일반 주제 |  |  |  |  |
+|  | local/dev | `economy` | 영어 적은 결과 |  |  |  |  |
+|  | local/dev | `technology` | 영어 중간 결과 |  |  |  |  |
+|  | local/dev | `대구` | 한국어 번역·결과 없음 |  |  |  |  |
+|  | local/dev | `AI` | 짧은 기술 용어 |  |  |  |  |
 
-## Initial Local Smoke Result
+## 최초 로컬 smoke 결과
 
-The first baseline was measured on 2026-07-09 with local Docker MySQL/Redis containers and a local `bootRun` server on `http://localhost:8080`.
-Each term was executed separately with `SEARCH_VUS=1`, `SEARCH_DURATION=10s`, and `SLEEP_SECONDS=1`.
+2026-07-09에 로컬 Docker MySQL/Redis와 `http://localhost:8080`의 `bootRun` 서버에서 측정했다. 각 검색어를 `SEARCH_VUS=1`, `SEARCH_DURATION=10s`, `SLEEP_SECONDS=1`로 따로 실행했다.
 
-This is a smoke baseline, not a capacity limit test.
-Use it as a same-environment comparison point for later query, cache, or search-policy changes.
+이는 capacity 한계가 아닌 smoke 기준선이다. 향후 query, cache, 검색 정책 변경을 같은 환경에서 비교할 때 사용한다.
 
-| Date | Environment | Term | Type | p95 | Failure rate | Result count | Requests | Checks | Notes |
+| 날짜 | 환경 | 검색어 | 유형 | p95 | 실패율 | 결과 수 | 요청 수 | check | 비고 |
 | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
-| 2026-07-09 | local/dev | `war` | English high-match | 76.63ms | 0.00% | 100 | 10 | 100.00% | API limit-sized result set |
-| 2026-07-09 | local/dev | `korea` | English common topic | 60.38ms | 0.00% | 40 | 10 | 100.00% | Common English keyword |
-| 2026-07-09 | local/dev | `economy` | English lower-match | 63.24ms | 0.00% | 39 | 10 | 100.00% | Lower result-count sample |
-| 2026-07-09 | local/dev | `technology` | English medium-match | 103.41ms | 0.00% | 82 | 10 | 100.00% | Slowest sample in this smoke run |
-| 2026-07-09 | local/dev | `대구` | Korean translated zero-match | 50.14ms | 0.00% | 0 | 10 | 100.00% | Valid zero-match result |
-| 2026-07-09 | local/dev | `AI` | Short/common technical term | 24.78ms | 0.00% | 0 | 10 | 100.00% | Valid zero-match result |
+| 2026-07-09 | local/dev | `war` | 영어 다수 결과 | 76.63ms | 0.00% | 100 | 10 | 100.00% | API limit 크기의 결과 |
+| 2026-07-09 | local/dev | `korea` | 영어 일반 주제 | 60.38ms | 0.00% | 40 | 10 | 100.00% | 일반 영어 검색어 |
+| 2026-07-09 | local/dev | `economy` | 영어 적은 결과 | 63.24ms | 0.00% | 39 | 10 | 100.00% | 적은 결과 표본 |
+| 2026-07-09 | local/dev | `technology` | 영어 중간 결과 | 103.41ms | 0.00% | 82 | 10 | 100.00% | 이 smoke 실행에서 가장 느린 표본 |
+| 2026-07-09 | local/dev | `대구` | 한국어 번역·결과 없음 | 50.14ms | 0.00% | 0 | 10 | 100.00% | 결과 없음도 정상 |
+| 2026-07-09 | local/dev | `AI` | 짧은 기술 용어 | 24.78ms | 0.00% | 0 | 10 | 100.00% | 결과 없음도 정상 |
 
-## Interpretation Rules
+## 해석 규칙
 
-- A 2xx response with `0` results is not a failure. It can be a valid zero-match FULLTEXT result.
-- A high result count can still be low relevance; this document is not a relevance benchmark.
-- If English same-term searches are slow, compare with #133 EXPLAIN notes and inspect whether the single-MATCH path is still used.
-- If translated/original terms differ and performance is slow, analyze the OR-MATCH path separately before considering query rewrites.
-- Elasticsearch or another search engine should be considered only after repeated evidence of missing recall, poor multilingual relevance, or p95 instability that cannot be addressed with MySQL FULLTEXT tuning.
+- 결과 0건의 2xx 응답은 실패가 아니라 정상적인 FULLTEXT 결과일 수 있다.
+- 결과가 많아도 관련성이 낮을 수 있다. 이 문서는 relevance 기준선이 아니다.
+- 영어 동일 검색어가 느리면 #133의 EXPLAIN 기록과 단일 `MATCH` 경로 사용 여부를 확인한다.
+- 원문과 번역문이 다르고 느리면 query rewrite 전에 `OR MATCH` 경로를 별도로 분석한다.
+- MySQL FULLTEXT 조정으로 해결하기 어려운 recall 누락, 다국어 관련성 저하, p95 불안정이 반복될 때만 Elasticsearch 등 다른 검색 엔진을 검토한다.
 
-## Current Scope Decision
+## 현재 범위 판단
 
-This issue establishes the measurement baseline and script.
-The current PR validates the script shape with `node --check`, `k6 inspect`, `git diff --check`, and a local k6 smoke run against `localhost:8080`.
-The smoke run recorded per-term p95, failure rate, result count, request count, and check success rate.
+이 작업은 측정 기준선과 script를 마련했다. `node --check`, `k6 inspect`, `git diff --check`, `localhost:8080` 대상 로컬 k6 smoke 실행으로 script 형태를 검증했다. 검색어별 p95, 실패율, 결과 수, 요청 수, check 성공률을 기록했다.
 
-It intentionally avoids:
+다음 변경은 의도적으로 제외했다.
 
-- changing repository queries
-- adding Elasticsearch
-- changing translation behavior
-- changing API response shape
-- adding new DB indexes
+- repository query 변경
+- Elasticsearch 추가
+- 번역 동작 변경
+- API 응답 변경
+- 신규 DB index 추가
 
-The next step is to repeat the same term set after a future query, cache, or search-policy change and compare p95/failure-rate trends by term type.
+향후 query, cache, 검색 정책 변경 후 같은 검색어 집합을 반복해 유형별 p95와 실패율 추세를 비교한다.


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #241

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- 검색 API와 Perspectives의 영어 중심 근거 문서 10개를 한국어 중심으로 재정리했습니다.
- 목적, 실행 흐름, 결과 해석, 결정 경계와 후속 조건을 한국어로 설명하되 SQL, 명령, 로그, metric 식별자는 원문 형태를 유지했습니다.
- `Portfolio Summary Candidate` 같은 외부 제출 관점 표현은 시스템 중심의 `핵심 결과 요약`으로 바꿨습니다.
- `NEXT_AGENT_BRIEF.md`, `WORK_PROGRESS.md`, `BACKLOG.md`에 #241 진행 상태와 범위를 같은 커밋으로 기록했습니다.

## 🔍 기술적 배경
- Phase 1의 상세 근거는 충분하지만 영어 중심 문서가 섞여 있어 구조 맵에서 원본 자료로 내려가며 학습하기 어려운 부분이 있었습니다.
- 일반 검색 API의 `TranslationService → SearchArticlesService` 경로와 Perspectives의 `KeywordExtractor → findPerspectives` 경로를 구분해 기술했습니다.
- 로컬 DB 표본과 fixture 결과를 운영 품질이나 전체 데이터셋 정확도로 확대 해석하지 않도록 기존 경계와 source coverage 한계를 유지했습니다.
- Phase 1 기술 상태는 `Completed` 그대로이며 production code, test, schema, workflow, 신규 측정과 신규 기술은 변경하지 않았습니다.

## 🧪 테스트/검증 (필수)
- [x] 대상 10개 문서별로 `HEAD` 원문과 숫자 token multiset이 동일함을 자동 비교했습니다.
- [x] 대상 10개 문서별 Markdown code fence 수가 원문과 동일함을 자동 비교했습니다.
- [x] 변경 문서의 상대 링크 존재 여부와 `git diff --check`를 확인했습니다.
- [x] 대상 문서에서 `Portfolio`, `Resume`, `면접`, `이력서`, `포트폴리오` 표현이 남지 않았음을 확인했습니다.
- [x] 문서 전용 변경이므로 Gradle 테스트는 생략했으며 PR Backend CI에서 전체 테스트를 확인합니다.

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop`)
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 검증했을 때 에러가 발생하지 않았는가?
- [x] production code와 외부 동작을 변경하지 않았는가?

## 📸 스크린샷 (선택)
- 해당 없음

## 💬 리뷰 요구사항(선택)
- 측정 수치, 표본 ID, SQL·명령과 해석 경계가 원문 의미를 유지하는지 확인해주세요.
- 일반 검색 API 경로와 Perspectives 경로가 혼동되지 않는지 확인해주세요.
- fixture·로컬 표본 결과가 운영 품질 근거로 과장되지 않았는지 확인해주세요.

## ➕ 추후 계획(선택)
- 남은 영어 중심 문서는 Gemini/외부 호출과 부하·DB·관측·수집 묶음으로 나눠 별도 Issue에서 검토합니다.
