### PR TITLE
🐛 [FIX/#245] AI 질의 SSE 정상 종료 이벤트 계약 명확화

### DIFF
--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -41,6 +41,14 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## Recently Completed
 
+### P1 연동 후속. AI 질의 SSE 정상 종료 이벤트 계약
+
+- 상태: `Done` ([#245](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/245), [PR #246](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/246))
+- AS-IS: Frontend는 정상 완료를 `end` event로 구분하려 하지만 Backend는 emitter만 완료해 정상 종료와 연결 실패의 경계가 불명확했다.
+- 결과: 대화 저장 처리 뒤 `end` named event를 보내고 emitter를 완료해 후속 Frontend 재시도 UX가 정상 완료와 실패를 구분할 수 있게 했다.
+- 검증: 로그인 저장 성공·실패, 익명 Redis 저장, event builder payload와 send 실패 시 container 종료 위임을 집중 테스트 6개와 전체 103개 테스트로 고정했다. Backend CI가 통과했고 AI Reviewer는 Blocking 없음·MERGE_READY로 판정했다.
+- 범위: 기존 SSE payload·대화 저장 의미를 유지했으며 실제 Gemini, 자동 retry, WebFlux, queue·Kafka와 Issue #110은 제외했다.
+
 ### P1 문서 후속. 영어 근거 문서 한국어 재정리 및 작업·학습 여정
 
 - 상태: `Done` ([#243](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/243), [PR #244](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/244))

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -9,6 +9,11 @@
 
 ## Recently Completed
 
+- #245 / PR #246: `Done`
+- 결과: Gemini AI 질의의 로그인 DB·익명 Redis 대화 저장 처리 뒤 named SSE `end` 이벤트를 보내고 emitter를 완료하도록 Backend–Frontend 정상 종료 계약을 명시했다.
+- 검증: event builder payload와 `저장 → end → complete`, I/O·상태 오류 시 container 종료 위임을 포함한 집중 테스트 6개, 전체 103개 테스트와 Backend CI가 통과했다. AI Reviewer는 Blocking 없음·MERGE_READY로 판정했다.
+- 후속: Frontend에서 정상 `end`, REST 요약 `502/503/504`, SSE 실패 재시도와 중복 연결 방지를 연동한다. 실제 Gemini, 자동 retry, WebFlux, queue·Kafka와 Issue #110은 제외했다.
+
 - #243 / PR #244: `Done`
 - 결과: Gemini·외부 호출·부하·DB·관측·수집 문서 13개에 한국어 학습 안내를 추가하고 원본 측정 기록을 보존했다. Phase 1 작업·학습 여정에서 실제 협업 절차, 작업 연대기, 문제·개념·수행·검증·다음 선택 이유를 Issue/PR 링크와 연결했다.
 - 검증: 대상 문서 숫자 token·code fence 원문 대조, 상대 링크, `git diff --check`, Backend CI가 통과했다.

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -9,6 +9,18 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Recently Completed
 
+### #245 - AI 질의 SSE 정상 종료 이벤트 계약 명확화
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/245
+- 작업 브랜치: `fix/#245-ai-sse-end-event`
+- 상태: `Done` ([PR #246](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/246))
+- 기준선: Frontend `EventSource`는 `end` named event를 정상 완료 신호로 기다리지만, Backend `AiSseService`는 마지막 누적 답변과 대화 저장 후 emitter만 완료해 정상 종료도 `onerror` 연결 종료 경로로 전달될 수 있었다.
+- 변경: 로그인 DB 또는 익명 Redis 대화 저장 처리가 끝난 뒤 `event: end`, `data: completed`를 보내고 emitter를 완료하도록 Backend–Frontend 계약을 명시했다.
+- 저장 경계: 로그인 이력 저장은 기존처럼 best-effort이며 실패해도 이미 생성한 답변의 종료 이벤트를 보낸다. 익명 Redis append 경로도 유지한다.
+- 검증: mock emitter에서 로그인 저장 성공·실패와 익명 저장 경로의 `저장 → end 전송 → complete` 순서, 실제 event builder payload, I/O·상태 오류 시 container 종료 위임을 포함한 집중 테스트 6개와 전체 103개 테스트, Backend CI가 통과했다. AI Reviewer는 Blocking 없음·MERGE_READY로 판정했다.
+- 후속 Frontend: 정상 `end` 처리, REST 요약 `502/503/504` 재시도, SSE 연결 실패 질문 재시도와 중복 연결 방지를 별도 Frontend Issue로 진행한다.
+- overengineering 판단: 새로운 SSE 라이브러리·자동 retry·WebFlux·오류 event 프로토콜·queue·Kafka를 추가하지 않고 정상 종료 named event 하나만 고정한다. 실제 Gemini와 Issue #110은 제외한다.
+
 ### #243 - 백엔드 개선 영어 근거 문서 한국어 재정리 마무리
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/243

--- a/src/main/java/com/example/globalTimes_be/domain/ai/service/AiSseService.java
+++ b/src/main/java/com/example/globalTimes_be/domain/ai/service/AiSseService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +35,8 @@ public class AiSseService {
     private int contextWindowSize;
 
     private static final String GEMINI_MODEL = "gemini-2.5-flash";
+    static final String COMPLETION_EVENT_NAME = "end";
+    static final String COMPLETION_EVENT_DATA = "completed";
 
     private final ChatHistoryService chatHistoryService;
     private final AnonymousChatSessionService anonymousChatSessionService;
@@ -197,6 +200,24 @@ public class AiSseService {
                     anonymousSessionId, articleId, question, answer, contextWindowSize);
         }
 
+        if (sendCompletionEvent(emitter)) {
+            completeEmitter(emitter);
+        }
+    }
+
+    private boolean sendCompletionEvent(SseEmitter emitter) {
+        try {
+            emitter.send(SseEmitter.event()
+                    .name(COMPLETION_EVENT_NAME)
+                    .data(COMPLETION_EVENT_DATA));
+            return true;
+        } catch (IOException | IllegalStateException e) {
+            log.warn("[Gemini SSE] completion event 전송 실패: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private void completeEmitter(SseEmitter emitter) {
         try {
             emitter.complete();
         } catch (Exception e) {

--- a/src/test/java/com/example/globalTimes_be/domain/ai/service/AiSseServiceCompletionTest.java
+++ b/src/test/java/com/example/globalTimes_be/domain/ai/service/AiSseServiceCompletionTest.java
@@ -13,14 +13,19 @@ import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import reactor.core.publisher.Mono;
 
+import java.io.IOException;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -48,16 +53,22 @@ class AiSseServiceCompletionTest {
     }
 
     @Test
-    void completesLoginStreamAfterHistorySave() {
+    void completesLoginStreamAfterHistorySave() throws IOException {
         aiSseService.completeStreaming(emitter, "question", 1L, 2L, null, "answer");
 
-        verify(chatHistoryService).save(1L, 2L, "question", "answer");
-        verify(emitter).complete();
+        var completionEvent = forClass(SseEmitter.SseEventBuilder.class);
+        var ordered = inOrder(chatHistoryService, emitter);
+        ordered.verify(chatHistoryService).save(1L, 2L, "question", "answer");
+        ordered.verify(emitter).send(completionEvent.capture());
+        ordered.verify(emitter).complete();
+        assertThat(completionEvent.getValue().build())
+                .extracting(ResponseBodyEmitter.DataWithMediaType::getData)
+                .containsExactly("event:end\ndata:", "completed", "\n\n");
         verify(emitter, never()).completeWithError(org.mockito.ArgumentMatchers.any());
     }
 
     @Test
-    void historySaveFailureIsLoggedAndDoesNotFailCompletedAnswer(CapturedOutput output) {
+    void historySaveFailureIsLoggedAndDoesNotFailCompletedAnswer(CapturedOutput output) throws IOException {
         doThrow(new DataIntegrityViolationException("commit failed"))
                 .when(chatHistoryService)
                 .save(1L, 2L, "question", "answer");
@@ -66,7 +77,9 @@ class AiSseServiceCompletionTest {
                 aiSseService.completeStreaming(emitter, "question", 1L, 2L, null, "answer")
         ).doesNotThrowAnyException();
 
-        verify(emitter).complete();
+        var ordered = inOrder(emitter);
+        ordered.verify(emitter).send(any(SseEmitter.SseEventBuilder.class));
+        ordered.verify(emitter).complete();
         verify(emitter, never()).completeWithError(org.mockito.ArgumentMatchers.any());
         assertThat(output)
                 .contains("채팅 이력 저장 실패")
@@ -76,7 +89,7 @@ class AiSseServiceCompletionTest {
     }
 
     @Test
-    void anonymousCompletionKeepsExistingRedisAppendPath() {
+    void anonymousCompletionKeepsExistingRedisAppendPath() throws IOException {
         aiSseService.completeStreaming(
                 emitter,
                 "question",
@@ -86,12 +99,40 @@ class AiSseServiceCompletionTest {
                 "answer"
         );
 
-        verify(anonymousChatSessionService)
+        var ordered = inOrder(anonymousChatSessionService, emitter);
+        ordered.verify(anonymousChatSessionService)
                 .appendTurn("anonymous-session", 2L, "question", "answer", 10);
+        ordered.verify(emitter).send(any(SseEmitter.SseEventBuilder.class));
+        ordered.verify(emitter).complete();
         verify(chatHistoryService, never())
                 .save(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
                         org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
-        verify(emitter).complete();
+    }
+
+    @Test
+    void completionEventIoFailureDoesNotEscapeOrCompleteEmitterAgain() throws IOException {
+        doThrow(new IOException("client disconnected"))
+                .when(emitter)
+                .send(any(SseEmitter.SseEventBuilder.class));
+
+        assertThatCode(() ->
+                aiSseService.completeStreaming(emitter, "question", 1L, 2L, null, "answer")
+        ).doesNotThrowAnyException();
+
+        verify(emitter, never()).complete();
+    }
+
+    @Test
+    void completionEventStateFailureDoesNotEscapeOrCompleteEmitterAgain() throws IOException {
+        doThrow(new IllegalStateException("already completed"))
+                .when(emitter)
+                .send(any(SseEmitter.SseEventBuilder.class));
+
+        assertThatCode(() ->
+                aiSseService.completeStreaming(emitter, "question", 1L, 2L, null, "answer")
+        ).doesNotThrowAnyException();
+
+        verify(emitter, never()).complete();
     }
 
     @Test


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #245

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [x] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- Gemini AI 질의의 마지막 누적 답변과 로그인 DB·익명 Redis 대화 저장 처리 뒤 named SSE `end` 이벤트를 전송합니다.
- 정상 경로의 `저장 → event: end/data: completed → emitter.complete()` 순서를 명시했습니다.
- completion event 전송이 I/O 또는 emitter 상태 오류로 실패하면 중복 `complete()`를 호출하지 않고 Servlet container 종료 처리에 맡깁니다.
- `NEXT_AGENT_BRIEF.md`, `WORK_PROGRESS.md`, `BACKLOG.md`에 Backend–Frontend 연동 목적, 검증 결과와 후속 FE 범위를 함께 기록했습니다.

## 🔍 기술적 배경
- Frontend `EventSource`는 `end` named event를 정상 완료 신호로 기다리지만 기존 Backend는 emitter만 완료했습니다. 그 결과 정상 종료도 브라우저의 연결 종료 오류 경로로 전달될 수 있었습니다.
- Phase 1에서 구축한 Gemini SSE, 로그인 채팅 transaction 실패 격리, 익명 Redis 저장을 변경하지 않고 종료 신호만 명시해 Frontend가 정상 완료와 재시도 대상을 구분할 수 있도록 했습니다.
- Spring `SseEmitter.send()`의 I/O 실패는 Servlet container가 async dispatch로 정리하므로 실패 뒤 `complete()`를 재호출하지 않습니다.

## 🧪 테스트/검증 (필수)
- [x] `AiSseServiceCompletionTest` 집중 테스트 6개: 로그인 저장 성공·실패, 익명 Redis 저장, event builder payload, I/O·상태 오류 종료 위임
- [x] `.\gradlew.bat test`: 전체 103개 성공, failures 0, errors 0, skipped 0
- [x] `git diff --check` 통과
- [x] 실제 Gemini·Translation API 호출 0회

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop` 대상)
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 기존 답변 chunk와 로그인·익명 대화 저장 의미를 유지했는가?

## 📸 스크린샷 (선택)
- Backend 이벤트 계약과 자동 테스트 변경이므로 해당 없음

## 💬 리뷰 요구사항(선택)
- 정상 저장과 best-effort 저장 실패 뒤 모두 `end` 이벤트가 전송되는지 확인해주세요.
- event 전송 실패 시 `complete()`를 다시 호출하지 않는 경계가 Spring `SseEmitter` lifecycle과 맞는지 확인해주세요.
- 후속 Frontend 정상 종료·실패·재시도 UX 연동에 충분한 최소 계약인지 확인해주세요.

## ➕ 추후 계획(선택)
- Frontend 별도 Issue에서 `end` 정상 완료 처리, REST 요약 `502/503/504` 재시도, SSE 실패 질문 재시도와 중복 연결 방지를 연동합니다.
- 실제 Gemini, 자동 retry, WebFlux, 별도 오류 event 프로토콜, queue·Kafka와 Issue #110은 이번 범위에서 제외합니다.
