### PR TITLE
[TEST/#247] 실제 호출 E2E 수집 범위 제어

### DIFF
--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -5,7 +5,10 @@
 
 ## Current Active Work
 
-현재 진행 중인 backend improvement Issue는 없다.
+- #247 `[TEST] 실제 호출 E2E를 위한 수집기별 실행 범위 제어`: 구현과 전체 108개 테스트 검증 완료, PR/Reviewer 확인 전 상태다.
+- 기존 `NEWS_FETCH_ENABLED` 하위 호환을 유지하면서 News API/RSS/Trend 토글과 RSS 국가·feed·기사 후보 상한을 분리했다.
+- 후속 Frontend Playwright External Smoke는 실제 적재·번역·크롤링·Gemini 요약·익명/로그인 질의를 소수 호출로 검증한다.
+- Perspectives는 기술 경로만 Smoke 검증하며, 실시간 RSS coverage와 의미적 관련성은 자동 합격 조건이 아니다. Issue #110은 계속 제외한다.
 
 ## Recently Completed
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -5,7 +5,16 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Current Active Work
 
-현재 진행 중인 backend improvement Issue는 없다.
+### #247 - 실제 호출 E2E를 위한 수집기별 실행 범위 제어
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/247
+- 작업 브랜치: `test/247-external-e2e-fetch-controls`
+- 상태: `In Progress`
+- 목적: 단일 `NEWS_FETCH_ENABLED`가 News API, RSS, Trend를 함께 실행하는 구조를 공급자별로 제어하고, 후속 실제 호출 Smoke E2E에서 RSS 국가·feed·기사 수를 제한한다.
+- 구현: 기존 전역 플래그를 기본값으로 유지하면서 공급자별 활성화 설정과 RSS 국가·feed·feed별 기사 후보 상한을 추가했다.
+- 검증: 설정 기본값·전역 플래그 하위 호환·공급자별 override·RSS 필터/상한 집중 테스트와 전체 108개 테스트가 통과했다.
+- 검증 경계: 실제 적재·검색·번역·크롤링·Gemini 요약·질의·저장 연결을 검증하되, 실시간 RSS의 국가별 동일 사건 coverage가 비결정적이므로 Perspectives 관련성 품질과 결과 건수는 자동 합격 조건으로 사용하지 않는다.
+- 범위 제외: 실제 Google OAuth, 전체 News API·26개국 Trend 호출, 대규모 부하, 새 검색 기술 및 Issue #110.
 
 ## Recently Completed
 

--- a/docs/backend-improvement/real-external-api-smoke-e2e.md
+++ b/docs/backend-improvement/real-external-api-smoke-e2e.md
@@ -1,0 +1,39 @@
+# 실제 외부 API Smoke E2E 실행 경계
+
+## 목적
+
+기존 Full Stack E2E는 Frontend, Backend, MySQL, Redis의 연결을 결정적으로 검증하기 위해 외부 Gemini와 번역 응답을 대체한다. 별도의 수동 External Smoke는 실제 RSS 기사 적재부터 검색, 번역, 원문 크롤링, Gemini 요약과 질의, 사용자별 저장까지 도메인 경로가 이어지는지 소수 호출로 확인한다.
+
+## 수집 제어
+
+기존 `NEWS_FETCH_ENABLED`는 세 공급자의 기본값으로 유지한다. 실제 Smoke에서는 다음처럼 공급자와 RSS 범위를 별도로 제한한다.
+
+```text
+NEWS_FETCH_ENABLED=false
+NEWS_API_FETCH_ENABLED=false
+RSS_FETCH_ENABLED=true
+TREND_FETCH_ENABLED=false
+RSS_FETCH_COUNTRIES=kr
+RSS_MAX_FEEDS_PER_RUN=1
+RSS_MAX_ARTICLES_PER_FEED=1
+```
+
+상한이 `0`이면 기존 전체 목록을 사용한다. 실제 호출용 환경에서는 국가, feed 수, feed별 기사 후보 수를 모두 명시한다.
+
+## 후속 Playwright 시나리오
+
+1. 격리된 MySQL과 Redis를 실행한다.
+2. 비영어 RSS 한 곳에서 소수 기사를 실제 수집하고 MySQL 적재를 확인한다.
+3. 수집된 기사에서 검색어를 선택해 실제 번역과 FULLTEXT 검색 경로를 확인한다.
+4. 기사 상세에서 원문을 크롤링하고 Gemini 요약을 한 번 생성해 저장한다.
+5. 익명 질의를 한 번 실행해 Redis 저장과 재조회를 확인한다.
+6. fixture JWT 로그인 질의를 한 번 실행해 MySQL 저장과 재조회를 확인한다.
+7. 서버와 일회성 컨테이너를 종료한다.
+
+목표 상한은 Translation 1회, Gemini 요약 1회, 익명 질의 1회, 로그인 질의 1회다. 실제 Google OAuth 로그인은 자동화하지 않는다.
+
+## 검증 한계
+
+실시간 RSS에는 특정 사건의 국가별 기사가 동시에 존재한다는 보장이 없다. 따라서 Perspectives는 기준 기사 조회, 키워드 추출, 필요 시 번역, FULLTEXT 조회, 국가별 응답 구성과 Redis 캐시라는 기술 경로만 Smoke 검증한다. 결과 기사 수, 국가 수, 의미적 관련성은 자동 합격 조건으로 사용하지 않는다.
+
+실제 Gemini 문구와 기사 제목도 실행 시점마다 달라질 수 있다. 정확한 문자열 대신 HTTP/SSE 완료, 비어 있지 않은 응답, 저장 및 재조회 여부를 검증한다. 이 검증은 장기 troubleshooting Issue #110의 검색·수집·관련성 한계를 해결했다는 근거로 사용하지 않는다.

--- a/src/main/java/com/example/globalTimes_be/domain/trend/scheduler/TrendScheduler.java
+++ b/src/main/java/com/example/globalTimes_be/domain/trend/scheduler/TrendScheduler.java
@@ -26,13 +26,13 @@ public class TrendScheduler {
     private final RestTemplate restTemplate;  // timeout 설정된 빈 주입
     private final TrendService trendService;
 
-    @Value("${news-fetch.enabled:false}")
+    @Value("${news-fetch.trend-enabled:${news-fetch.enabled:false}}")
     private boolean fetchEnabled;
 
     @PostConstruct
     public void init() {
         if (!fetchEnabled) {
-            log.info("[트렌드 초기화] news-fetch.enabled=false → 트렌드 수집 건너뜀");
+            log.info("[트렌드 초기화] Trend 수집 비활성화 → 건너뜀");
             return;
         }
         saveTrendApi();

--- a/src/main/java/com/example/globalTimes_be/externalApi/service/NewsApiService.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/service/NewsApiService.java
@@ -42,9 +42,8 @@ public class NewsApiService {
     @Value("${spring.newsapi.base-url:https://newsapi.org}")
     private String newsApiBaseUrl;
 
-    // false = 로컬 개발 중 스케줄러/초기 적재 비활성화 (API 할당량 절약)
-    // 수집 테스트 시 application.yml 에서 news-fetch.enabled: true 로 변경
-    @Value("${news-fetch.enabled:false}")
+    // 기존 통합 플래그를 기본값으로 사용하며 공급자별 플래그로 독립 제어한다.
+    @Value("${news-fetch.news-api-enabled:${news-fetch.enabled:false}}")
     private boolean fetchEnabled;
 
     private int totalNewArticles = 0;
@@ -62,7 +61,7 @@ public class NewsApiService {
     @PostConstruct
     public void init() {
         if (!fetchEnabled) {
-            log.info("[초기화] news-fetch.enabled=false → 초기 적재 건너뜀 (API 할당량 절약)");
+            log.info("[초기화] News API 수집 비활성화 → 초기 적재 건너뜀");
             return;
         }
         try {

--- a/src/main/java/com/example/globalTimes_be/externalApi/service/RssNewsService.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/service/RssNewsService.java
@@ -22,6 +22,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -37,8 +38,17 @@ public class RssNewsService {
     private final SourceService sourceService;
     private final RssFeedConfig rssFeedConfig;
 
-    @Value("${news-fetch.enabled:false}")
+    @Value("${news-fetch.rss-enabled:${news-fetch.enabled:false}}")
     private boolean fetchEnabled;
+
+    @Value("${news-fetch.rss-countries:}")
+    private String fetchCountries;
+
+    @Value("${news-fetch.rss-max-feeds-per-run:0}")
+    private int maxFeedsPerRun;
+
+    @Value("${news-fetch.rss-max-articles-per-feed:0}")
+    private int maxArticlesPerFeed;
 
     // RSS pubDate 파싱 포맷 목록 (언론사마다 포맷이 다름)
     // zzz = GMT/UTC 같은 이름형 타임존, Z = +0900/+0000 같은 숫자형 오프셋
@@ -54,7 +64,7 @@ public class RssNewsService {
     @PostConstruct
     public void init() {
         if (!fetchEnabled) {
-            log.info("[RSS 초기화] news-fetch.enabled=false → RSS 수집 건너뜀");
+            log.info("[RSS 초기화] RSS 수집 비활성화 → 건너뜀");
             return;
         }
         fetchAllFeeds("[RSS 초기 적재]");
@@ -69,7 +79,7 @@ public class RssNewsService {
 
     private void fetchAllFeeds(String logPrefix) {
         int totalSaved = 0;
-        for (RssFeedConfig.FeedSource feed : rssFeedConfig.getFeeds()) {
+        for (RssFeedConfig.FeedSource feed : selectedFeeds()) {
             totalSaved += fetchFeed(feed);
         }
         log.info("{} 전체 저장된 신규 기사: {}개", logPrefix, totalSaved);
@@ -91,7 +101,7 @@ public class RssNewsService {
             }
 
             Document doc = Jsoup.parse(xml, "", org.jsoup.parser.Parser.xmlParser());
-            Elements items = doc.select("item");
+            Elements items = limitArticles(doc.select("item"));
 
             if (items.isEmpty()) {
                 log.info("[수집 통계] {} | 응답 없음", feed.sourceName());
@@ -104,6 +114,32 @@ public class RssNewsService {
             log.error("[RSS 수집 오류] {} 처리 중 오류 발생", feed.sourceName(), e);
             return 0;
         }
+    }
+
+    List<RssFeedConfig.FeedSource> selectedFeeds() {
+        String configuredCountries = fetchCountries == null ? "" : fetchCountries;
+        Set<String> countries = Arrays.stream(configuredCountries.split(","))
+                .map(String::trim)
+                .filter(value -> !value.isBlank())
+                .map(value -> value.toLowerCase(Locale.ROOT))
+                .collect(Collectors.toSet());
+
+        var feeds = rssFeedConfig.getFeeds().stream()
+                .filter(feed -> countries.isEmpty()
+                        || countries.contains(feed.country().toLowerCase(Locale.ROOT)));
+        if (maxFeedsPerRun > 0) {
+            feeds = feeds.limit(maxFeedsPerRun);
+        }
+        return feeds.toList();
+    }
+
+    Elements limitArticles(Elements items) {
+        if (maxArticlesPerFeed <= 0 || items.size() <= maxArticlesPerFeed) {
+            return items;
+        }
+        Elements limited = new Elements();
+        items.stream().limit(maxArticlesPerFeed).forEach(limited::add);
+        return limited;
     }
 
     int processItems(RssFeedConfig.FeedSource feed, Elements items) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,10 +60,16 @@ oauth2:
   redirect-uri: ${OAUTH2_REDIRECT_URI:http://localhost:5173/oauth2/redirect}
 
 # 뉴스 수집 활성화 여부
-# false(기본): 로컬 개발 중 API 할당량 절약 목적으로 @PostConstruct/스케줄러 비활성화
-# true: 수집 테스트 시에만 변경 (주의: 무료 플랜 100 req/24h 제한)
+# enabled는 기존 통합 스위치이며 공급자별 설정이 없을 때 기본값으로 사용한다.
+# 실제 호출 Smoke에서는 공급자별 스위치와 RSS 상한을 함께 지정한다.
 news-fetch:
-  enabled: false
+  enabled: ${NEWS_FETCH_ENABLED:false}
+  news-api-enabled: ${NEWS_API_FETCH_ENABLED:${NEWS_FETCH_ENABLED:false}}
+  rss-enabled: ${RSS_FETCH_ENABLED:${NEWS_FETCH_ENABLED:false}}
+  trend-enabled: ${TREND_FETCH_ENABLED:${NEWS_FETCH_ENABLED:false}}
+  rss-countries: ${RSS_FETCH_COUNTRIES:}
+  rss-max-feeds-per-run: ${RSS_MAX_FEEDS_PER_RUN:0}
+  rss-max-articles-per-feed: ${RSS_MAX_ARTICLES_PER_FEED:0}
 
 # 국가별 시각 비교 API: Redis 캐시 (0이면 미사용, 동일 articleId 반복 요청 시 FULLTEXT 부하 감소)
 perspectives:

--- a/src/test/java/com/example/globalTimes_be/externalApi/config/NewsFetchConfigurationTest.java
+++ b/src/test/java/com/example/globalTimes_be/externalApi/config/NewsFetchConfigurationTest.java
@@ -1,0 +1,67 @@
+package com.example.globalTimes_be.externalApi.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NewsFetchConfigurationTest {
+
+    @Test
+    void allCollectorsAreDisabledByDefault() throws IOException {
+        ConfigurableEnvironment environment = applicationEnvironment();
+
+        assertThat(environment.getProperty("news-fetch.news-api-enabled", Boolean.class)).isFalse();
+        assertThat(environment.getProperty("news-fetch.rss-enabled", Boolean.class)).isFalse();
+        assertThat(environment.getProperty("news-fetch.trend-enabled", Boolean.class)).isFalse();
+    }
+
+    @Test
+    void legacyGlobalFlagStillEnablesAllCollectors() throws IOException {
+        ConfigurableEnvironment environment = applicationEnvironment("NEWS_FETCH_ENABLED=true");
+
+        assertThat(environment.getProperty("news-fetch.news-api-enabled", Boolean.class)).isTrue();
+        assertThat(environment.getProperty("news-fetch.rss-enabled", Boolean.class)).isTrue();
+        assertThat(environment.getProperty("news-fetch.trend-enabled", Boolean.class)).isTrue();
+    }
+
+    @Test
+    void providerFlagsAndRssLimitsOverrideTheLegacyFlag() throws IOException {
+        ConfigurableEnvironment environment = applicationEnvironment(
+                "NEWS_FETCH_ENABLED=true",
+                "NEWS_API_FETCH_ENABLED=false",
+                "RSS_FETCH_ENABLED=true",
+                "TREND_FETCH_ENABLED=false",
+                "RSS_FETCH_COUNTRIES=kr",
+                "RSS_MAX_FEEDS_PER_RUN=1",
+                "RSS_MAX_ARTICLES_PER_FEED=2"
+        );
+
+        assertThat(environment.getProperty("news-fetch.news-api-enabled", Boolean.class)).isFalse();
+        assertThat(environment.getProperty("news-fetch.rss-enabled", Boolean.class)).isTrue();
+        assertThat(environment.getProperty("news-fetch.trend-enabled", Boolean.class)).isFalse();
+        assertThat(environment.getProperty("news-fetch.rss-countries")).isEqualTo("kr");
+        assertThat(environment.getProperty("news-fetch.rss-max-feeds-per-run", Integer.class)).isEqualTo(1);
+        assertThat(environment.getProperty("news-fetch.rss-max-articles-per-feed", Integer.class)).isEqualTo(2);
+    }
+
+    private ConfigurableEnvironment applicationEnvironment(String... properties) throws IOException {
+        MockEnvironment environment = new MockEnvironment();
+        for (String property : properties) {
+            int separator = property.indexOf('=');
+            environment.setProperty(property.substring(0, separator), property.substring(separator + 1));
+        }
+
+        List<PropertySource<?>> sources = new YamlPropertySourceLoader().load(
+                "application", new ClassPathResource("application.yml"));
+        sources.forEach(environment.getPropertySources()::addLast);
+        return environment;
+    }
+}

--- a/src/test/java/com/example/globalTimes_be/externalApi/service/RssNewsServiceTest.java
+++ b/src/test/java/com/example/globalTimes_be/externalApi/service/RssNewsServiceTest.java
@@ -103,6 +103,36 @@ class RssNewsServiceTest {
         verifyNoInteractions(articleRepository, sourceService, rssFeedConfig);
     }
 
+    @Test
+    void selectedFeeds_filtersCountriesAndAppliesRunLimit() {
+        RssFeedConfig.FeedSource englishFeed = new RssFeedConfig.FeedSource(
+                "https://feed.example/en", "gb", "en", "English RSS", "general");
+        RssFeedConfig.FeedSource koreanFeed = new RssFeedConfig.FeedSource(
+                "https://feed.example/ko", "kr", "ko", "Korean RSS", "general");
+        RssFeedConfig.FeedSource secondKoreanFeed = new RssFeedConfig.FeedSource(
+                "https://feed.example/ko-2", "kr", "ko", "Korean RSS", "business");
+        when(rssFeedConfig.getFeeds()).thenReturn(List.of(englishFeed, koreanFeed, secondKoreanFeed));
+        ReflectionTestUtils.setField(service, "fetchCountries", " KR ");
+        ReflectionTestUtils.setField(service, "maxFeedsPerRun", 1);
+
+        assertThat(service.selectedFeeds()).containsExactly(koreanFeed);
+    }
+
+    @Test
+    void limitArticles_capsCandidatesForExternalSmokeRun() {
+        Elements items = items(
+                item("https://news.example/1", "one"),
+                item("https://news.example/2", "two"),
+                item("https://news.example/3", "three")
+        );
+        ReflectionTestUtils.setField(service, "maxArticlesPerFeed", 2);
+
+        Elements limited = service.limitArticles(items);
+
+        assertThat(limited).hasSize(2);
+        assertThat(limited.eachText()).allMatch(text -> !text.contains("three"));
+    }
+
     private Elements items(String... items) {
         return Jsoup.parse("<rss><channel>" + String.join("", items) + "</channel></rss>", "", Parser.xmlParser())
                 .select("item");


### PR DESCRIPTION
## 관련 이슈
- closed #247

## 변경 타입
- [ ] 기능 추가 (FEAT)
- [ ] 버그 수정 (FIX)
- [ ] 리팩토링 (REFACTOR)
- [x] 테스트/설정 개선 (TEST/CHORE)

## 작업 내용
- 기존 `NEWS_FETCH_ENABLED`를 하위 호환 기본값으로 유지하면서 News API, RSS, Trend 수집 활성화를 독립적으로 제어합니다.
- 실제 외부 호출 Smoke에서 RSS 국가, 실행당 feed 수, feed별 기사 후보 수를 제한할 수 있습니다.
- 기본 비활성화, 기존 전역 플래그 활성화, 공급자별 override와 RSS 필터/상한을 테스트합니다.
- 후속 Playwright 실제 호출 흐름과 호출량·검증 한계를 문서화하고 `WORK_PROGRESS.md`, `NEXT_AGENT_BRIEF.md`를 갱신합니다.

## 기술적 배경
- 기존 전역 플래그를 켜면 News API 최대 30회, 전체 언론사 RSS, 26개국 Trend 초기 수집이 함께 실행되어 소수 호출 E2E를 구성할 수 없었습니다.
- 공급자별 플래그는 기존 전역 값으로 fallback하므로 기존 실행 계약은 유지됩니다.
- RSS 상한이 `0`이면 제한하지 않으며, External Smoke에서는 국가·feed·기사 후보 상한을 모두 명시합니다.

## 테스트/검증
- [x] `NewsFetchConfigurationTest`: 기본 비활성화, 전역 플래그 하위 호환, 공급자별 override와 상한 설정
- [x] `RssNewsServiceTest`: RSS 국가 필터, feed 상한, 기사 후보 상한
- [x] 전체 Gradle 테스트: 108개 통과, 실패 0, 건너뜀 0
- [x] `git diff --check`
- [x] 실제 외부 API 호출 0회

## 검증 경계
- 후속 External Smoke는 실제 `RSS 적재 -> 검색/번역 -> 상세/크롤링 -> Gemini 요약 -> 익명·로그인 질의 저장` 연결을 검증합니다.
- Perspectives는 키워드 추출, 필요 시 번역, FULLTEXT 조회, 국가별 응답 구성과 Redis 캐시라는 기술 경로만 Smoke 검증합니다.
- 실시간 RSS에 동일 사건의 국가별 기사가 존재한다는 보장이 없으므로 결과 기사 수, 국가 수, 의미적 관련성은 자동 합격 조건으로 사용하지 않습니다.
- 이 작업은 장기 troubleshooting Issue #110의 수집 coverage·관련성 한계를 해결했다고 주장하지 않습니다.

## 체크리스트
- [x] 대상 브랜치는 `develop`입니다.
- [x] 코드와 문서 변경을 하나의 커밋으로 구성했습니다.
- [x] 기존 전역 플래그와 기본 비활성화 동작을 보존했습니다.

## 후속 계획
- Frontend 저장소에서 수동 실행 전용 Playwright External Smoke를 별도 Issue/PR로 추가합니다.
- 목표 상한은 Translation 1회, Gemini 요약 1회, 익명 질의 1회, 로그인 질의 1회입니다.
