### PR TITLE
🧪 [TEST/#249] News API·Google Trends 소규모 실호출 설정 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,4 +28,17 @@ JWT_SECRET=your_jwt_secret_key_must_be_at_least_32_characters
 # OAuth2 로그인 성공 후 FE 리다이렉트 URI
 OAUTH2_REDIRECT_URI=http://localhost:5173/oauth2/redirect
 
+# 수동 External Smoke에서만 공급자별 호출 범위를 작게 제한할 때 사용
+# NEWS_FETCH_ENABLED=false
+# NEWS_API_FETCH_ENABLED=true
+# NEWS_API_PAGE_SIZE=1
+# NEWS_API_MAX_REQUESTS_PER_RUN=1
+# RSS_FETCH_ENABLED=true
+# RSS_FETCH_COUNTRIES=kr
+# RSS_MAX_FEEDS_PER_RUN=1
+# RSS_MAX_ARTICLES_PER_FEED=1
+# TREND_FETCH_ENABLED=true
+# TREND_FETCH_COUNTRIES=KR
+# TREND_MAX_ITEMS_PER_COUNTRY=1
+
 # Example을 따라 직접 환경 변수 파일 만들어서 테스트 할 것.

--- a/docs/backend-improvement/BACKLOG.md
+++ b/docs/backend-improvement/BACKLOG.md
@@ -7,7 +7,14 @@ GlobalTimes 백엔드의 개선 작업을 문제 정의부터 검증 결과까�
 
 ## Current Active Work
 
-현재 진행 중인 backend improvement Issue는 없다.
+### P1. News API·Google Trends 소규모 실호출 설정
+
+- 상태: `In Progress` ([#249](https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/249))
+- 근거: News API와 Trend를 토글만 켜면 각각 최대 30회와 26개국 요청이 시작돼 소규모 실제 호출 E2E의 비용·외부 부하 경계를 강제할 수 없다.
+- 범위: 기본 동작을 유지하는 News API 요청 수·page size, Trend 국가·국가별 결과 상한 설정과 회귀 테스트로 제한한다.
+- 검증: 집중 테스트 11개와 Testcontainers 포함 전체 112개 테스트 통과, 실제 외부 호출 0회.
+- 후속: Frontend 수동 External Smoke에서 각 공급자를 최소 호출하고 대표 로그인 사용자 사이클을 검증한다.
+- 제외: Perspectives 의미적 관련성 합격 판정, 실제 Google OAuth, ranking·schema·queue·Kafka, Issue #110.
 
 ## Phase 1 Exit Roadmap
 

--- a/docs/backend-improvement/NEXT_AGENT_BRIEF.md
+++ b/docs/backend-improvement/NEXT_AGENT_BRIEF.md
@@ -5,7 +5,13 @@
 
 ## Current Active Work
 
-현재 진행 중인 backend improvement Issue는 없다.
+- #249: `In Progress`
+- 브랜치: `test/249-provider-smoke-limits`
+- 목표: 최종 수동 External Smoke에서 실제 News API와 Google Trends 호출 범위를 작게 강제할 수 있도록 News API 요청 수·page size와 Trend 국가·국가별 결과 상한을 설정화한다.
+- 하위 호환: 기본값은 기존 News API 최대 30회·page size 100, Trend 26개국·국가별 6건을 유지하며 수집기는 기본 비활성이다.
+- 검증: 설정·News API·Trend 집중 테스트 11개와 전체 112개 테스트가 통과했고, 기본 비활성 조건에서 실제 외부 호출은 0회다.
+- 후속: Frontend에서 News API·RSS·Trend 실수집과 Translation·Gemini 요약·로그인 질의·스크랩의 대표 사이클을 검증한다.
+- 경계: Perspectives 의미적 관련성과 결과 건수, 실제 Google OAuth, 자동 retry, Issue #110은 제외한다.
 
 ## Recently Completed
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -5,7 +5,18 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Current Active Work
 
-현재 진행 중인 backend improvement Issue는 없다.
+### #249 - News API·Google Trends 소규모 실호출 설정
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/249
+- 작업 브랜치: `test/249-provider-smoke-limits`
+- 상태: `In Progress`
+- 기준선: News API는 활성화 시 미국 7개 카테고리와 6개 도메인을 최대 30회 요청하고, Trend는 26개국을 조회한다. 최종 수동 External Smoke에서 실제 호출을 소규모로 제한할 설정이 없다.
+- 범위: 기존 기본 동작과 전역·공급자별 토글 하위 호환을 유지하면서 News API 요청 수·page size와 Trend 국가·국가별 결과 상한을 설정으로 분리한다.
+- 설정 문서: `docs/backend-improvement/news-trend-external-smoke-limits.md`
+- 구현 결과: News API `pageSize`·실행당 최대 요청 수와 Trend 대상 국가·국가별 최대 결과 수를 환경변수로 override할 수 있게 했고, 기본값은 기존 100건·30회 및 26개국·6건을 유지했다.
+- 검증: 설정·News API·Trend 집중 테스트 11개와 Testcontainers 포함 전체 112개 테스트가 통과했다. 기본 비활성 조건에서 실제 외부 API 호출은 0회다.
+- 후속: Frontend External Smoke에서 News API·RSS·Trend 실수집부터 실제 Translation·Gemini 요약·로그인 질의·스크랩 저장까지 대표 사용자 사이클을 검증한다.
+- 경계: Perspectives는 HTTP·번역·FULLTEXT·국가별 구성·Redis cache 기술 경로만 확인하며 실시간 기사 수·국가 수·의미적 관련성을 합격 조건으로 사용하지 않는다. Issue #110은 제외한다.
 
 ## Recently Completed
 

--- a/docs/backend-improvement/news-trend-external-smoke-limits.md
+++ b/docs/backend-improvement/news-trend-external-smoke-limits.md
@@ -1,0 +1,53 @@
+# News API·Google Trends 소규모 실호출 설정
+
+## 목적
+
+최종 수동 Full-stack External Smoke에서 News API, 언론사 RSS, Google Trends를 실제 호출하되 개발용 quota와 외부 서버에 불필요한 부하를 주지 않도록 실행 범위를 설정으로 강제한다. 수집기는 기존처럼 기본 비활성이며, 아래 값은 수동 Smoke 프로세스에만 주입한다.
+
+## 최소 호출 설정
+
+```text
+NEWS_FETCH_ENABLED=false
+
+NEWS_API_FETCH_ENABLED=true
+NEWS_API_PAGE_SIZE=1
+NEWS_API_MAX_REQUESTS_PER_RUN=1
+
+RSS_FETCH_ENABLED=true
+RSS_FETCH_COUNTRIES=kr
+RSS_MAX_FEEDS_PER_RUN=1
+RSS_MAX_ARTICLES_PER_FEED=1
+
+TREND_FETCH_ENABLED=true
+TREND_FETCH_COUNTRIES=KR
+TREND_MAX_ITEMS_PER_COUNTRY=1
+```
+
+- News API는 첫 번째 `US/general` headline 요청 1회만 실행하고 기사 후보를 최대 1건 요청한다.
+- RSS는 선택 국가의 첫 feed에서 기사 후보 1건만 처리한다. 실제 원문 확보 가능 여부는 후속 preflight가 별도로 확인한다.
+- Google Trends RSS는 KR 1개 국가만 요청하고 Redis `trend:KR`에 최대 1건을 저장한다.
+- 기본값은 기존 News API page size 100·최대 30회, Trend 26개국·국가별 6건을 유지한다.
+
+## 최종 E2E 판정 경계
+
+후속 Frontend 수동 E2E는 실제 공급자 수집과 대표 로그인 사용자 사이클을 다음 순서로 확인한다.
+
+```text
+News API·RSS MySQL 적재 / Google Trends Redis 적재
+→ 실제 Translation 검색
+→ 실제 기사 원문 crawling
+→ 실제 Gemini 요약
+→ fixture JWT 로그인
+→ 실제 Gemini SSE 질의와 MySQL 대화 저장·재조회
+→ 스크랩 저장·재조회
+```
+
+Perspectives는 외부 기사 구성에 따라 결과가 달라지므로 HTTP 200, 번역·FULLTEXT·국가별 구성, Redis cache 생성 같은 기술 경로만 자동 판정한다. 반환 기사 수, 국가 수, 동일 사건 여부와 의미적 관련성은 합격 조건이 아니며 관찰 결과로만 기록한다. 이 검증은 Backend Issue #110의 수집·검색·관련성 한계를 해결했다는 근거가 아니다.
+
+실제 Google OAuth, 자동 retry, VU 부하, News API·Trend 반복 호출, ranking·schema·queue·Kafka 변경은 포함하지 않는다.
+
+## 구현 검증
+
+- 설정 기본값·override, News API 1회 요청과 `pageSize=1`, Trend KR 1회·결과 1건, 수집기 비활성 시 외부 호출 0회를 집중 테스트 11개로 확인했다.
+- Testcontainers를 포함한 Backend 전체 테스트 112개가 통과했다.
+- 이 단계에서는 실제 외부 API를 호출하지 않는다. 실제 호출과 성공 결과는 후속 Frontend 수동 External Smoke에서 기록한다.

--- a/src/main/java/com/example/globalTimes_be/domain/trend/scheduler/TrendScheduler.java
+++ b/src/main/java/com/example/globalTimes_be/domain/trend/scheduler/TrendScheduler.java
@@ -18,6 +18,7 @@ import org.springframework.web.client.RestTemplate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -28,6 +29,12 @@ public class TrendScheduler {
 
     @Value("${news-fetch.trend-enabled:${news-fetch.enabled:false}}")
     private boolean fetchEnabled;
+
+    @Value("${news-fetch.trend-countries:KR,AU,AT,BR,CA,CO,DK,EG,FR,DE,GR,HK,IN,ID,IT,JP,MY,MX,NL,RU,SG,TW,TR,GB,US,ES}")
+    private String fetchCountries;
+
+    @Value("${news-fetch.trend-max-items-per-country:6}")
+    private int maxItemsPerCountry;
 
     @PostConstruct
     public void init() {
@@ -41,15 +48,10 @@ public class TrendScheduler {
     @Scheduled(cron = "0 0 */1 * * *")
     public void saveTrendApi(){
         if (!fetchEnabled) return;
-        //나라 코드 리스트 생성
-        List<String> countries = new ArrayList<>
-                (Arrays.asList("KR", "AU", "AT", "BR", "CA", "CO", "DK", "EG", "FR", "DE", "GR", "HK", "IN",
-                        "ID", "IT", "JP", "MY", "MX", "NL", "RU", "SG", "TW", "TR", "GB", "US", "ES"));
-
         int totalKeywords = 0;
         int successCount = 0;
 
-        for (String countryCode : countries){
+        for (String countryCode : selectedCountries()){
             List<TrendDTO> trendDTOS = createTrendDTOS(countryCode);
 
             if(trendDTOS == null || trendDTOS.isEmpty()){
@@ -100,8 +102,8 @@ public class TrendScheduler {
 
         //반복문으로 items안에 있는 데이터 가져오기
         for (Element item : items) {
-            // item을 6개 저장하거나 item이 비어있으면 종료
-            if(count > 5 ){
+            // 설정된 국가별 최대 개수만 저장한다. 0 이하면 기존처럼 전체 item을 허용한다.
+            if(maxItemsPerCountry > 0 && count >= maxItemsPerCountry){
                 break;
             }
             
@@ -163,5 +165,17 @@ public class TrendScheduler {
         }
 
         return trendDTOS;
+    }
+
+    List<String> selectedCountries() {
+        if (fetchCountries == null || fetchCountries.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(fetchCountries.split(","))
+                .map(String::trim)
+                .filter(value -> !value.isBlank())
+                .map(value -> value.toUpperCase(Locale.ROOT))
+                .distinct()
+                .toList();
     }
 }

--- a/src/main/java/com/example/globalTimes_be/externalApi/config/NewsFetchConfig.java
+++ b/src/main/java/com/example/globalTimes_be/externalApi/config/NewsFetchConfig.java
@@ -1,5 +1,6 @@
 package com.example.globalTimes_be.externalApi.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -10,6 +11,12 @@ import java.util.List;
  */
 @Component
 public class NewsFetchConfig {
+
+    @Value("${news-fetch.news-api-page-size:100}")
+    private int pageSize;
+
+    @Value("${news-fetch.news-api-max-requests-per-run:30}")
+    private int maxRequestsPerRun;
 
     /**
      * 헤드라인 수집 대상 국가 코드 목록 (News API top-headlines 기준)
@@ -55,7 +62,7 @@ public class NewsFetchConfig {
      * 한 번 요청 시 가져올 최대 기사 수 (News API 최대: 100)
      */
     public int getPageSize() {
-        return 100;
+        return pageSize;
     }
 
     /**
@@ -63,7 +70,7 @@ public class NewsFetchConfig {
      * 무료 플랜: 100 req/24h → 초기 적재(1회) + 스케줄링(2~3회) 고려해 여유 있게 설정
      */
     public int getMaxRequestsPerRun() {
-        return 30;
+        return maxRequestsPerRun;
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,8 +65,12 @@ oauth2:
 news-fetch:
   enabled: ${NEWS_FETCH_ENABLED:false}
   news-api-enabled: ${NEWS_API_FETCH_ENABLED:${NEWS_FETCH_ENABLED:false}}
+  news-api-page-size: ${NEWS_API_PAGE_SIZE:100}
+  news-api-max-requests-per-run: ${NEWS_API_MAX_REQUESTS_PER_RUN:30}
   rss-enabled: ${RSS_FETCH_ENABLED:${NEWS_FETCH_ENABLED:false}}
   trend-enabled: ${TREND_FETCH_ENABLED:${NEWS_FETCH_ENABLED:false}}
+  trend-countries: ${TREND_FETCH_COUNTRIES:KR,AU,AT,BR,CA,CO,DK,EG,FR,DE,GR,HK,IN,ID,IT,JP,MY,MX,NL,RU,SG,TW,TR,GB,US,ES}
+  trend-max-items-per-country: ${TREND_MAX_ITEMS_PER_COUNTRY:6}
   rss-countries: ${RSS_FETCH_COUNTRIES:}
   rss-max-feeds-per-run: ${RSS_MAX_FEEDS_PER_RUN:0}
   rss-max-articles-per-feed: ${RSS_MAX_ARTICLES_PER_FEED:0}

--- a/src/test/java/com/example/globalTimes_be/domain/trend/scheduler/TrendSchedulerTest.java
+++ b/src/test/java/com/example/globalTimes_be/domain/trend/scheduler/TrendSchedulerTest.java
@@ -1,0 +1,81 @@
+package com.example.globalTimes_be.domain.trend.scheduler;
+
+import com.example.globalTimes_be.domain.trend.dto.resonse.TrendDTO;
+import com.example.globalTimes_be.domain.trend.service.TrendService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+class TrendSchedulerTest {
+
+    private final RestTemplate restTemplate = mock(RestTemplate.class);
+    private final TrendService trendService = mock(TrendService.class);
+    private final TrendScheduler scheduler = new TrendScheduler(restTemplate, trendService);
+
+    @Test
+    void collectionEntryPoints_doNothingWhenTrendFetchIsDisabled() {
+        ReflectionTestUtils.setField(scheduler, "fetchEnabled", false);
+
+        scheduler.init();
+        scheduler.saveTrendApi();
+
+        org.mockito.Mockito.verifyNoInteractions(restTemplate, trendService);
+    }
+
+    @Test
+    void saveTrendApi_limitsCountriesAndItemsPerCountry() {
+        ReflectionTestUtils.setField(scheduler, "fetchEnabled", true);
+        ReflectionTestUtils.setField(scheduler, "fetchCountries", "kr");
+        ReflectionTestUtils.setField(scheduler, "maxItemsPerCountry", 1);
+        when(restTemplate.getForObject(
+                "https://trends.google.co.kr/trending/rss?geo=KR", String.class))
+                .thenReturn(trendXml());
+
+        scheduler.saveTrendApi();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<TrendDTO>> trends = ArgumentCaptor.forClass(List.class);
+        verify(trendService).replaceTrendKeywords(org.mockito.ArgumentMatchers.eq("KR"), trends.capture());
+        assertThat(trends.getValue()).hasSize(1);
+        assertThat(trends.getValue().get(0).getKeyword()).isEqualTo("First trend");
+        verify(restTemplate, times(1)).getForObject(
+                "https://trends.google.co.kr/trending/rss?geo=KR", String.class);
+        verifyNoMoreInteractions(restTemplate, trendService);
+    }
+
+    @Test
+    void selectedCountries_normalizesAndRemovesDuplicates() {
+        ReflectionTestUtils.setField(scheduler, "fetchCountries", "kr, US,kr");
+
+        assertThat(scheduler.selectedCountries()).containsExactly("KR", "US");
+    }
+
+    private String trendXml() {
+        return """
+                <rss xmlns:ht="https://trends.google.com/trending/rss"><channel>
+                  <item><title>First trend</title><ht:news_item>
+                    <ht:news_item_title>First article</ht:news_item_title>
+                    <ht:news_item_url>https://news.example/first</ht:news_item_url>
+                    <ht:news_item_source>First source</ht:news_item_source>
+                    <ht:news_item_picture>https://news.example/first.jpg</ht:news_item_picture>
+                  </ht:news_item></item>
+                  <item><title>Second trend</title><ht:news_item>
+                    <ht:news_item_title>Second article</ht:news_item_title>
+                    <ht:news_item_url>https://news.example/second</ht:news_item_url>
+                    <ht:news_item_source>Second source</ht:news_item_source>
+                    <ht:news_item_picture>https://news.example/second.jpg</ht:news_item_picture>
+                  </ht:news_item></item>
+                </channel></rss>
+                """;
+    }
+}

--- a/src/test/java/com/example/globalTimes_be/externalApi/config/NewsFetchConfigurationTest.java
+++ b/src/test/java/com/example/globalTimes_be/externalApi/config/NewsFetchConfigurationTest.java
@@ -21,6 +21,10 @@ class NewsFetchConfigurationTest {
         assertThat(environment.getProperty("news-fetch.news-api-enabled", Boolean.class)).isFalse();
         assertThat(environment.getProperty("news-fetch.rss-enabled", Boolean.class)).isFalse();
         assertThat(environment.getProperty("news-fetch.trend-enabled", Boolean.class)).isFalse();
+        assertThat(environment.getProperty("news-fetch.news-api-page-size", Integer.class)).isEqualTo(100);
+        assertThat(environment.getProperty("news-fetch.news-api-max-requests-per-run", Integer.class)).isEqualTo(30);
+        assertThat(environment.getProperty("news-fetch.trend-max-items-per-country", Integer.class)).isEqualTo(6);
+        assertThat(environment.getProperty("news-fetch.trend-countries")).startsWith("KR,AU,AT");
     }
 
     @Test
@@ -37,16 +41,24 @@ class NewsFetchConfigurationTest {
         ConfigurableEnvironment environment = applicationEnvironment(
                 "NEWS_FETCH_ENABLED=true",
                 "NEWS_API_FETCH_ENABLED=false",
+                "NEWS_API_PAGE_SIZE=1",
+                "NEWS_API_MAX_REQUESTS_PER_RUN=1",
                 "RSS_FETCH_ENABLED=true",
                 "TREND_FETCH_ENABLED=false",
+                "TREND_FETCH_COUNTRIES=kr",
+                "TREND_MAX_ITEMS_PER_COUNTRY=1",
                 "RSS_FETCH_COUNTRIES=kr",
                 "RSS_MAX_FEEDS_PER_RUN=1",
                 "RSS_MAX_ARTICLES_PER_FEED=2"
         );
 
         assertThat(environment.getProperty("news-fetch.news-api-enabled", Boolean.class)).isFalse();
+        assertThat(environment.getProperty("news-fetch.news-api-page-size", Integer.class)).isEqualTo(1);
+        assertThat(environment.getProperty("news-fetch.news-api-max-requests-per-run", Integer.class)).isEqualTo(1);
         assertThat(environment.getProperty("news-fetch.rss-enabled", Boolean.class)).isTrue();
         assertThat(environment.getProperty("news-fetch.trend-enabled", Boolean.class)).isFalse();
+        assertThat(environment.getProperty("news-fetch.trend-countries")).isEqualTo("kr");
+        assertThat(environment.getProperty("news-fetch.trend-max-items-per-country", Integer.class)).isEqualTo(1);
         assertThat(environment.getProperty("news-fetch.rss-countries")).isEqualTo("kr");
         assertThat(environment.getProperty("news-fetch.rss-max-feeds-per-run", Integer.class)).isEqualTo(1);
         assertThat(environment.getProperty("news-fetch.rss-max-articles-per-feed", Integer.class)).isEqualTo(2);

--- a/src/test/java/com/example/globalTimes_be/externalApi/service/NewsApiServiceTest.java
+++ b/src/test/java/com/example/globalTimes_be/externalApi/service/NewsApiServiceTest.java
@@ -8,8 +8,10 @@ import com.example.globalTimes_be.domain.source.repository.SourceRepository;
 import com.example.globalTimes_be.domain.source.service.SourceService;
 import com.example.globalTimes_be.externalApi.config.NewsFetchConfig;
 import com.example.globalTimes_be.externalApi.dto.NewsApiArticleDto;
+import com.example.globalTimes_be.externalApi.dto.NewsApiResponseDto;
 import com.example.globalTimes_be.externalApi.dto.NewsApiSourceDto;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 
@@ -21,9 +23,12 @@ import java.util.stream.StreamSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -112,6 +117,29 @@ class NewsApiServiceTest {
 
         verifyNoInteractions(restTemplate, articleRepository, sourceService, newsFetchConfig);
         verify(articleRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    void fetchTopHeadlines_stopsAtConfiguredRequestLimitAndUsesConfiguredPageSize() {
+        NewsApiResponseDto response = new NewsApiResponseDto();
+        response.setArticles(List.of());
+        ReflectionTestUtils.setField(service, "newsApiBaseUrl", "https://newsapi.org");
+        ReflectionTestUtils.setField(service, "apiKey", "test-key");
+        when(newsFetchConfig.getCountries()).thenReturn(List.of("us"));
+        when(newsFetchConfig.getCategories()).thenReturn(List.of("general", "business"));
+        when(newsFetchConfig.getMaxRequestsPerRun()).thenReturn(1);
+        when(newsFetchConfig.getPageSize()).thenReturn(1);
+        when(newsFetchConfig.getRequestDelayMs()).thenReturn(0L);
+        when(restTemplate.getForEntity(anyString(), eq(NewsApiResponseDto.class)))
+                .thenReturn(ResponseEntity.ok(response));
+
+        service.fetchTopHeadlines(false);
+
+        verify(restTemplate, times(1)).getForEntity(
+                argThat((String url) -> url.contains("country=us")
+                        && url.contains("category=general")
+                        && url.contains("pageSize=1")),
+                eq(NewsApiResponseDto.class));
     }
 
     private NewsApiArticleDto article(String url, String title) {


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #249

## 🧭 변경 타입
- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용
- News API `pageSize`와 실행당 최대 요청 수를 환경변수로 override할 수 있게 했습니다.
- Google Trends 대상 국가와 국가별 최대 저장 건수를 환경변수로 override할 수 있게 했습니다.
- 기본값은 기존 News API 100건·최대 30회, Trend 26개국·국가별 6건으로 유지했습니다.
- 수동 External Smoke용 1회 제한 설정과 최종 로그인 사용자 사이클, Perspectives 판정 경계를 문서화했습니다.
- 코드·테스트·진척 문서를 하나의 `[TEST/#249]` 커밋으로 묶었습니다.

## 🔍 기술적 배경
- 기존 공급자별 토글은 활성화 여부만 제어합니다. News API를 켜면 미국 7개 카테고리와 6개 도메인을 순회하고, Trend를 켜면 26개국을 조회하므로 최종 실제 호출 E2E를 1회 수준으로 강제할 수 없었습니다.
- `NEWS_API_MAX_REQUESTS_PER_RUN=1`, `NEWS_API_PAGE_SIZE=1`, `TREND_FETCH_COUNTRIES=KR`, `TREND_MAX_ITEMS_PER_COUNTRY=1`을 수동 Smoke 프로세스에만 주입하면 실제 호출 범위를 작게 고정할 수 있습니다.
- 수집기는 기존처럼 기본 비활성이며 `NEWS_FETCH_ENABLED`와 공급자별 override 하위 호환을 유지합니다.
- Perspectives는 실시간 외부 기사 구성에 의존하므로 HTTP·번역·FULLTEXT·국가별 구성·Redis cache 기술 경로만 확인하고 기사 수·국가 수·의미적 관련성은 자동 합격 조건으로 사용하지 않습니다.

## 🧪 테스트/검증 (필수)
- [x] 설정 기본값·override, News API 1회/pageSize 1, Trend KR 1회/1건, 비활성 호출 0회 집중 테스트 11개 통과
- [x] `./gradlew test` 전체 112개 통과 (`Failures 0 / Errors 0 / Skipped 0`)
- [x] `git diff --check` 통과
- [x] 실제 News API·RSS·Trend·Translation·Gemini 호출 0회. 실제 호출은 후속 Frontend 수동 External Smoke에서만 수행

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop` 대상)
- [x] 로컬 전체 테스트에서 에러가 발생하지 않았는가?
- [x] 기존 기본 수집 범위와 비활성 기본값을 유지했는가?

## 📸 스크린샷 (선택)
- 해당 없음

## 💬 리뷰 요구사항(선택)
- 기존 `NEWS_FETCH_ENABLED` 및 공급자별 토글 하위 호환 여부
- News API 요청 수/page size와 Trend 국가/건수 상한이 수동 Smoke에서 실제로 1회 수준을 강제하는지
- 기본 비활성에서 외부 호출이 발생하지 않는지
- Perspectives 의미적 관련성 판정과 Backend Issue #110이 범위에 섞이지 않았는지

## ➕ 추후 계획(선택)
- Frontend 수동 External Smoke에서 News API·RSS·Trend 실수집부터 Translation 검색, Gemini 요약·로그인 질의, 대화·스크랩 저장까지 대표 사용자 사이클을 1회 검증합니다.
