### PR TITLE
📝 [DOCS/#251] Backend README 데이터 구조와 후속 판단 기준 보완

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@
 고정된 기사 표본에서 관련 기사가 DB에 존재하지만 표현 차이로 반복 누락되는 경우에만
 embedding·Vector DB와 현재 FULLTEXT 결과를 비교한다.
 
-수집 처리는 현재 1,000건 기준으로 다음 스케줄 실행 전에 완료된다.
+Testcontainers의 고정 fixture 1,000건 측정에서는 다음 스케줄 주기보다 짧게 완료됐다.
+이 결과는 실제 외부 공급자나 운영 환경의 처리량을 의미하지 않는다.
 따라서 Kafka나 별도 Queue는 도입하지 않았으며,
 수집 backlog·재처리·독립 consumer 요구가 생기는 시점에 비교한다.
 
@@ -283,7 +284,7 @@ embedding·Vector DB와 현재 FULLTEXT 결과를 비교한다.
 
 ```mermaid
 erDiagram
-    SOURCE ||--o{ ARTICLE : provides
+    SOURCE o|--o{ ARTICLE : provides
     USERS ||--o{ CHAT_HISTORY : owns
     ARTICLE ||--o{ CHAT_HISTORY : contains
     USERS ||--o{ SCRAP : owns

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@
 > 본 서비스의 핵심 의의는 _"동일한 사건을 각국의 시선으로 비교"_ 하는 것이었으나,  
 > 각 RSS 피드는 **갱신 주기·기사 선택 기준이 언론사마다 상이**하여  
 > 동일 이슈에 대한 국가별 기사를 정확히 매핑하는 것이 구조적으로 어렵다는 한계가 존재.  
-> 국가·카테고리별 데이터셋을 최대한 폭넓게 수집하여 제공하도록 수정정.
+> 국가·카테고리별 데이터셋을 최대한 폭넓게 수집하여 제공하도록 수정.
 
 
 ### 3️⃣ News API 연동
@@ -156,13 +156,21 @@
 
 
 
-**➕ 향후 개선 가능**
+**➕ 다음 개선을 검토하는 기준**
 
-- **Elasticsearch** 도입 시 의미적 유사도 기반 검색으로 커버리지 확대
-- **벡터 DB 기반 유사 기사 탐색**: 기사 본문을 임베딩 벡터로 변환 후 코사인 유사도로 매칭  
-  → `pgvector`(PostgreSQL 확장), `Weaviate`, `Pinecone` 등 벡터 DB 활용 가능
-- **MSA 분리 고려**: 기사 수집·저장 / AI 처리 / 검색을 독립 마이크로서비스로 분리하면  
-  각 서비스별 언어·프레임워크 최적화 가능 (예: 검색 서비스는 Python + LangChain / FastAPI 조합)
+현재 Perspectives는 번역한 제목에서 키워드를 추출하고 MySQL FULLTEXT로 관련 기사를 찾는다.
+새로운 검색 기술을 바로 추가하기보다 현재 방식으로 찾지 못하는 원인을 먼저 구분한다.
+
+- 실제 관련 기사가 DB에 없는 경우: RSS·News API 수집 범위 문제
+- 관련 기사가 있지만 검색되지 않는 경우: 번역·키워드·FULLTEXT 검색 문제
+- 검색은 되지만 상위 결과가 부정확한 경우: 정렬과 ranking 문제
+
+고정된 기사 표본에서 관련 기사가 DB에 존재하지만 표현 차이로 반복 누락되는 경우에만
+embedding·Vector DB와 현재 FULLTEXT 결과를 비교한다.
+
+수집 처리는 현재 1,000건 기준으로 다음 스케줄 실행 전에 완료된다.
+따라서 Kafka나 별도 Queue는 도입하지 않았으며,
+수집 backlog·재처리·독립 consumer 요구가 생기는 시점에 비교한다.
 
 ---
 
@@ -188,6 +196,18 @@
 - AI 모델 OpenAI GPT → **Google Gemini** 로 마이그레이션
 - **로그인 유저**: 이전 대화 내역을 슬라이딩 윈도우(최근 10턴) 방식으로 누적 전달 → 맥락 기반 대화
 - **비로그인 유저**: 익명 session ID 기준으로 Redis에 최근 대화와 기사 목록을 저장해 제한된 맥락 대화 제공
+
+#### 로그인·비로그인 대화 저장
+
+| 구분 | 로그인 사용자 | 비로그인 사용자 |
+| --- | --- | --- |
+| 저장소 | MySQL `chat_history` | Redis List·Sorted Set |
+| 식별 기준 | JWT `userId` | 익명 session ID |
+| 대화 구분 | `user_id + article_id` | `sessionId + articleId` |
+| 저장 범위 | 전체 대화 영속 저장 | 최근 10턴 |
+| 보존 기간 | 별도 만료 없음 | 마지막 활동부터 7일 |
+| Gemini Context | 최근 10턴 | 최근 10턴 |
+| 주요 목적 | 기기 간 조회·관계 정합성 | 가입 없는 임시 대화 |
 
 ### 7️⃣ Google OAuth2 + JWT 로그인 
 
@@ -259,6 +279,17 @@
 
 <img width="876" height="577" alt="Image" src="https://github.com/user-attachments/assets/592241b7-2c04-486f-8239-d817e6ecbbf9" />
 
+### MySQL ERD
+
+```mermaid
+erDiagram
+    SOURCE ||--o{ ARTICLE : provides
+    USERS ||--o{ CHAT_HISTORY : owns
+    ARTICLE ||--o{ CHAT_HISTORY : contains
+    USERS ||--o{ SCRAP : owns
+    ARTICLE ||--o{ SCRAP : targets
+```
+
 ---
 
 ## 🚀 로컬 실행 가이드
@@ -307,6 +338,17 @@ docker compose -f docker-compose.dev.yml down   # 종료
 
 - Swagger UI: `http://localhost:8080/swagger-ui/index.html`
 - OAuth2 로그인 테스트: `http://localhost:8080/oauth2/authorization/google`
+
+### 3) 전체 테스트 실행
+
+```powershell
+.\gradlew.bat test
+```
+
+- MySQL·Redis 통합 테스트: Testcontainers
+- PR·push 회귀 검증: GitHub Actions Backend CI
+- 테스트 종료 후 임시 컨테이너 자동 정리
+- CI 통과와 실제 EC2 배포 성공은 별도 범위
 
 ---
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -5,7 +5,13 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Current Active Work
 
-현재 진행 중인 backend improvement Issue는 없다.
+### #251 - Backend README 데이터 구조와 후속 판단 기준 보완
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/251
+- 작업 브랜치: `docs/251-readme-data-model`
+- 상태: `In Progress`
+- 범위: 기존 README 구조와 이미지를 유지하면서 Perspectives 후속 판단 기준, MySQL 관계 ERD, 로그인·비로그인 채팅 저장 비교와 전체 테스트 실행 안내를 보완한다.
+- 경계: production code·schema·test·workflow를 변경하지 않고 실제 외부 API를 호출하지 않으며 Issue #110을 다루지 않는다.
 
 ## Recently Completed
 

--- a/docs/backend-improvement/WORK_PROGRESS.md
+++ b/docs/backend-improvement/WORK_PROGRESS.md
@@ -5,15 +5,19 @@ Codex 대화 context가 사라지거나 새 세션에서 이어서 작업해야 
 
 ## Current Active Work
 
+- 현재 진행 중인 backend improvement Issue는 없다.
+
+## Recently Completed
+
 ### #251 - Backend README 데이터 구조와 후속 판단 기준 보완
 
 - Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/issues/251
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_BeSide/pull/252
 - 작업 브랜치: `docs/251-readme-data-model`
-- 상태: `In Progress`
+- 상태: `Done`
 - 범위: 기존 README 구조와 이미지를 유지하면서 Perspectives 후속 판단 기준, MySQL 관계 ERD, 로그인·비로그인 채팅 저장 비교와 전체 테스트 실행 안내를 보완한다.
 - 경계: production code·schema·test·workflow를 변경하지 않고 실제 외부 API를 호출하지 않으며 Issue #110을 다루지 않는다.
-
-## Recently Completed
+- 검증: README 상대 링크와 `git diff --check`, Backend CI 전체 테스트가 통과했다. Reviewer의 Source nullable cardinality Blocking과 fixture 측정 경계를 반영했고 재검토에서 Blocking 없음·MERGE_READY로 판정됐다.
 
 ### #249 - News API·Google Trends 소규모 실호출 설정
 


### PR DESCRIPTION
## 🚀 관련 이슈

- closed #251

## 🧭 변경 타입

- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용

- Perspectives의 Elasticsearch·Vector DB·MSA 단순 나열을 collection·retrieval·ranking 원인과 후속 기술 비교 조건으로 교체했습니다.
- 기존 시스템 아키텍처 이미지 아래에 Source·Article·User·ChatHistory·Scrap 관계만 보여주는 Mermaid ERD를 추가했습니다.
- 로그인 MySQL과 비로그인 Redis List·Sorted Set 채팅 저장 차이를 핵심 비교표로 추가했습니다.
- 로컬 전체 Gradle test와 Testcontainers·Backend CI·실제 배포의 경계를 실행 가이드에 추가했습니다.
- 기존 README의 `수정정` 오탈자를 정리하고 전체 구성과 스크린샷은 유지했습니다.

## 🔍 기술적 배경

- README의 ERD는 V1 migration과 현재 JPA의 5개 FK 관계만 표현하며 컬럼이나 구현되지 않은 테이블을 추가하지 않습니다.
- 익명 채팅은 session·article key의 Redis List에 최근 10턴을 보존하고 7일 TTL을 갱신하며, Sorted Set으로 최근 기사 순서를 관리합니다.
- 로그인 채팅은 MySQL에 전체 이력을 영속 저장하고 Gemini Context를 구성할 때만 최근 10턴을 조회합니다.
- Vector DB와 Kafka는 현재 계획이 아니라 Phase 2 진입 신호가 확인될 때 비교할 후보입니다.

## 🧪 테스트/검증 (필수)

- [x] README 상대 Markdown 링크 6개 존재 확인
- [x] Mermaid 관계를 V1 migration과 JPA 연관관계에 대조
- [x] 채팅 표의 저장소·10턴·7일 TTL을 실제 Service·RedisUtil 설정에 대조
- [x] `git diff --check` 통과
- [x] production code·schema·test·workflow·외부 API 호출 없음
- [ ] Backend CI 전체 테스트

## ✔️ 체크 리스트

- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 외부 동작/응답 변경 없음

## 📸 스크린샷 (선택)

- 기존 README 스크린샷 유지

## 💬 리뷰 요구사항(선택)

- Mermaid 관계와 로그인·비로그인 채팅 저장 비교가 현재 구현과 일치하는지 확인
- Phase 2 후보가 현재 구현 완료로 읽히지 않는지 확인
- Backend Issue #110 범위가 섞이지 않았는지 확인

## ➕ 추후 계획(선택)

- 후속 구현은 Backend Phase 2 진입 신호가 확인된 경우에만 별도 Issue와 ADR로 검토
